### PR TITLE
Add exit button to feedback dialog and platform-specific keyboard shortcuts

### DIFF
--- a/webapp/src/pure/agentTabs/index.ts
+++ b/webapp/src/pure/agentTabs/index.ts
@@ -3,6 +3,8 @@
  * No side effects, no DOM, no state
  */
 
+import { formatShortcut } from '@/pure/utils/keyboardShortcutDisplay';
+
 // =============================================================================
 // Constants
 // =============================================================================
@@ -34,7 +36,7 @@ export function getShortcutHintForTab(
     const rightDistance: number = (tabIndex - activeIndex + totalTabs) % totalTabs;
 
     // If distances are equal, prefer right (])
-    return leftDistance <= rightDistance ? '⌘[' : '⌘]';
+    return leftDistance <= rightDistance ? formatShortcut('[') : formatShortcut(']');
 }
 
 // =============================================================================

--- a/webapp/src/pure/utils/keyboardShortcutDisplay.ts
+++ b/webapp/src/pure/utils/keyboardShortcutDisplay.ts
@@ -1,0 +1,78 @@
+/**
+ * Utility functions for displaying keyboard shortcuts with platform-specific symbols
+ */
+
+/**
+ * Detects if the current platform is macOS
+ */
+export function isMacPlatform(): boolean {
+    if (typeof navigator !== 'undefined' && typeof navigator.platform === 'string') {
+        return navigator.platform.toLowerCase().includes('mac');
+    }
+    if (typeof process !== 'undefined' && process.platform) {
+        return process.platform === 'darwin';
+    }
+    return false;
+}
+
+/**
+ * Returns the appropriate modifier key symbol for the current platform
+ * @returns '⌘' for Mac, 'Ctrl' for Windows/Linux
+ */
+export function getModifierSymbol(): string {
+    return isMacPlatform() ? '⌘' : 'Ctrl';
+}
+
+/**
+ * Formats a keyboard shortcut for display with special key handling
+ * @param key - The key (e.g., 'N', 'Enter', 'Backspace', '1', '[', ']')
+ * @param modifier - Whether to include the modifier key (default: true)
+ * @returns Formatted shortcut string (e.g., '⌘N' on Mac, 'Ctrl+N' on Windows)
+ */
+export function formatShortcut(key: string, modifier: boolean = true): string {
+    const isMac = isMacPlatform();
+    const modifierSymbol = getModifierSymbol();
+    const separator = isMac ? '' : '+';
+
+    // Convert special key names to platform-specific symbols
+    let displayKey: string;
+    switch (key.toLowerCase()) {
+        case 'backspace':
+            displayKey = isMac ? '⌫' : 'Backspace';
+            break;
+        case 'enter':
+        case 'return':
+            displayKey = isMac ? '⏎' : 'Enter';
+            break;
+        case 'option':
+        case 'alt':
+            displayKey = isMac ? '⌥' : 'Alt';
+            break;
+        default:
+            displayKey = key;
+    }
+
+    if (!modifier) {
+        return displayKey;
+    }
+
+    return `${modifierSymbol}${separator}${displayKey}`;
+}
+
+/**
+ * Gets platform-specific symbols for special keys
+ */
+export function getSpecialKeySymbol(key: 'backspace' | 'enter' | 'option'): string {
+    const isMac = isMacPlatform();
+
+    switch (key) {
+        case 'backspace':
+            return isMac ? '⌫' : 'Backspace';
+        case 'enter':
+            return isMac ? '⏎' : 'Enter';
+        case 'option':
+            return isMac ? '⌥' : 'Alt';
+        default:
+            return key;
+    }
+}

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/VerticalMenuService.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/VerticalMenuService.ts
@@ -8,6 +8,7 @@ import type {TerminalData} from "@/shell/edge/UI-edge/floating-windows/terminals
 import {showTaskInputPopup, type SelectedNodeInfo, type TaskInputResult} from "@/shell/edge/UI-edge/graph/taskInputPopup";
 import type {NodeIdAndFilePath} from "@/pure/graph";
 import '@/shell/electron.d.ts';
+import { formatShortcut } from '@/pure/utils/keyboardShortcutDisplay';
 
 export interface Position {
     x: number;
@@ -99,7 +100,7 @@ export class VerticalMenuService {
 
         if (this.deps) {
             menuItems.push({
-                html: '<span style="display: flex; justify-content: space-between; align-items: center; gap: 16px; white-space: nowrap;">Add Node Here <span style="font-size: 10px; color: #888; opacity: 0.7;">⌘N</span></span>',
+                html: `<span style="display: flex; justify-content: space-between; align-items: center; gap: 16px; white-space: nowrap;">Add Node Here <span style="font-size: 10px; color: #888; opacity: 0.7;">${formatShortcut('N')}</span></span>`,
                 action: async () => {
                     //console.log('[VerticalMenuService] Creating node at position:', position);
                     await this.deps!.handleAddNodeAtPosition(position);
@@ -113,7 +114,7 @@ export class VerticalMenuService {
 
         const deleteText: string = noNodesSelected ? 'Delete (0 nodes selected)' : `Delete Selected (${selectedCount})`;
         menuItems.push({
-            html: `<span style="display: flex; justify-content: space-between; align-items: center; gap: 16px; white-space: nowrap;">${deleteText} <span style="font-size: 10px; color: #888; opacity: 0.7;">⌘⌫</span></span>`,
+            html: `<span style="display: flex; justify-content: space-between; align-items: center; gap: 16px; white-space: nowrap;">${deleteText} <span style="font-size: 10px; color: #888; opacity: 0.7;">${formatShortcut('Backspace')}</span></span>`,
             disabled: noNodesSelected,
             action: deleteSelectedNodesAction(this.cy!),
         });

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/getNodeMenuItems.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/getNodeMenuItems.ts
@@ -7,6 +7,7 @@ import type { Core } from 'cytoscape';
 import { Plus, Play, Trash2, AlertTriangle, Clipboard, ChevronDown, Edit2, GitBranch, FolderOpen } from 'lucide';
 import type { GraphNode } from "@/pure/graph";
 import { createNewChildNodeFromUI, deleteNodesFromUI } from "@/shell/edge/UI-edge/graph/handleUIActions";
+import { formatShortcut } from '@/pure/utils/keyboardShortcutDisplay';
 import {
     spawnTerminalWithNewContextNode,
     spawnTerminalWithCommandEditor,
@@ -64,7 +65,7 @@ export function getNodeMenuItems(input: NodeMenuItemsInput): HorizontalMenuItem[
 
     // LEFT SIDE: Delete, Copy, Add (3 buttons)
     menuItems.push({
-        icon: Trash2, label: 'Delete', hotkey: '⌘⌫',
+        icon: Trash2, label: 'Delete', hotkey: formatShortcut('Backspace'),
         action: () => deleteNodesFromUI([nodeId], cy),
     });
     menuItems.push({
@@ -72,7 +73,7 @@ export function getNodeMenuItems(input: NodeMenuItemsInput): HorizontalMenuItem[
         action: () => { void navigator.clipboard.writeText(getFilePathForNode(nodeId)); },
     });
     menuItems.push({
-        icon: Plus, label: 'Add Child', hotkey: '⌘N',
+        icon: Plus, label: 'Add Child', hotkey: formatShortcut('N'),
         action: () => { void createNewChildNodeFromUI(nodeId, cy); },
     });
 
@@ -81,7 +82,7 @@ export function getNodeMenuItems(input: NodeMenuItemsInput): HorizontalMenuItem[
         icon: Play,
         label: 'Run',
         color: '#22c55e', // green
-        hotkey: '⌘⏎',
+        hotkey: formatShortcut('Enter'),
         action: async () => {
             await spawnTerminalWithNewContextNode(nodeId, cy);
         },

--- a/webapp/src/shell/UI/views/RecentNodeTabsBar.ts
+++ b/webapp/src/shell/UI/views/RecentNodeTabsBar.ts
@@ -18,6 +18,7 @@ import type { UpsertNodeDelta } from '@/pure/graph'
 import { getNodeTitle } from '@/pure/graph/markdown-parsing'
 import { getPinnedEditors } from '@/shell/edge/UI-edge/state/EditorStore'
 import { Pin, createElement } from 'lucide'
+import { formatShortcut } from '@/pure/utils/keyboardShortcutDisplay'
 
 const TAB_WIDTH: number = 90
 
@@ -146,7 +147,7 @@ function createTab(
     // Create shortcut hint element (shown on hover)
     const shortcutHint: HTMLSpanElement = document.createElement('span')
     shortcutHint.className = 'recent-tab-shortcut-hint'
-    shortcutHint.innerHTML = `⌘${shortcutNumber}`
+    shortcutHint.innerHTML = formatShortcut(shortcutNumber.toString())
 
     wrapper.appendChild(tab)
     wrapper.appendChild(shortcutHint)


### PR DESCRIPTION
## Summary
- Added a "Skip" button to the feedback dialog so users can exit without submitting, and allowed ESC to close the dialog (previously prevented)
- Created a `keyboardShortcutDisplay.ts` utility that detects the platform and displays appropriate modifier keys (⌘ on Mac, Ctrl+ on Windows/Linux)
- Updated all UI components that display keyboard shortcuts: RecentNodeTabsBar, HorizontalMenuItems, VerticalMenuService, and agentTabs

## Test plan
- [ ] Verify feedback dialog shows "Skip" button alongside "Submit"
- [ ] Verify ESC key closes the feedback dialog
- [ ] Verify keyboard shortcuts display `Ctrl+` prefix on Windows/Linux
- [ ] Verify keyboard shortcuts display `⌘` prefix on Mac
- [ ] Check all shortcut locations: node hover menu, right-click menu, recent tabs bar, tab navigation hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)