### PR TITLE
fix: preserve headless agent registry records on exit for wait_for_ag…

### DIFF
--- a/webapp/src/shell/edge/main/mcp-server/__tests__/headless-tool-guards.test.ts
+++ b/webapp/src/shell/edge/main/mcp-server/__tests__/headless-tool-guards.test.ts
@@ -102,7 +102,8 @@ function createTerminalRecord(
     return {
         terminalId,
         terminalData,
-        status: 'running'
+        status: 'running',
+        exitCode: null
     }
 }
 

--- a/webapp/src/shell/edge/main/mcp-server/agent-completion-monitor.ts
+++ b/webapp/src/shell/edge/main/mcp-server/agent-completion-monitor.ts
@@ -38,17 +38,34 @@ export function startMonitor(
         )
         const graph: Graph = getGraph()
 
-        const allDone: boolean = targetRecords.every(
+        // Detect terminals that vanished from registry (should not happen after Fix 1,
+        // but defend against it). Treat missing terminals as complete.
+        const foundIds: Set<string> = new Set(targetRecords.map((r: TerminalRecord) => r.terminalId))
+        const missingIds: string[] = terminalIds.filter((id: string) => !foundIds.has(id))
+
+        const allFoundDone: boolean = targetRecords.every(
             (r: TerminalRecord) => isAgentComplete(r, graph, now, currentRecords)
         )
 
-        if (allDone) {
+        if (allFoundDone) {
             const results: AgentResult[] = targetRecords.map((r: TerminalRecord) => ({
                 terminalId: r.terminalId,
                 agentName: r.terminalData.agentName,
                 status: getAgentStatus(r),
+                exitCode: r.exitCode,
                 nodes: getNewNodesForAgent(graph, r.terminalData.agentName)
             }))
+
+            // Add entries for any terminals that vanished from registry
+            for (const missingId of missingIds) {
+                results.push({
+                    terminalId: missingId,
+                    agentName: undefined,
+                    status: 'exited',
+                    exitCode: null,
+                    nodes: []
+                })
+            }
 
             const message: string = buildCompletionMessage(results)
             void sendTextToTerminal(callerTerminalId, message)

--- a/webapp/src/shell/edge/main/mcp-server/buildCompletionMessage.test.ts
+++ b/webapp/src/shell/edge/main/mcp-server/buildCompletionMessage.test.ts
@@ -13,6 +13,7 @@ describe('buildCompletionMessage', () => {
                 terminalId: 't1',
                 agentName: 'Alice',
                 status: 'exited',
+                exitCode: 0,
                 nodes: [
                     {nodeId: 'n1', title: 'Design doc'},
                     {nodeId: 'n2', title: 'Implementation'},
@@ -22,12 +23,13 @@ describe('buildCompletionMessage', () => {
                 terminalId: 't2',
                 agentName: 'Bob',
                 status: 'idle',
+                exitCode: null,
                 nodes: [{nodeId: 'n3', title: 'Progress update'}],
             },
         ]
         const msg: string = buildCompletionMessage(agents)
         expect(msg).toContain('[WaitForAgents] All agents completed.')
-        expect(msg).toContain('- Alice [exited]: Design doc, Implementation')
+        expect(msg).toContain('- Alice [exited:0]: Design doc, Implementation')
         expect(msg).toContain('- Bob [idle]: Progress update')
     })
 
@@ -37,6 +39,7 @@ describe('buildCompletionMessage', () => {
                 terminalId: 'term-42',
                 agentName: undefined,
                 status: 'exited',
+                exitCode: null,
                 nodes: [],
             },
         ]
@@ -50,11 +53,26 @@ describe('buildCompletionMessage', () => {
                 terminalId: 't1',
                 agentName: 'Carol',
                 status: 'exited',
+                exitCode: 0,
                 nodes: [],
             },
         ]
         const msg: string = buildCompletionMessage(agents)
-        expect(msg).toContain('- Carol [exited]: (no nodes created)')
+        expect(msg).toContain('- Carol [exited:0]: (no nodes created)')
+    })
+
+    it('shows exit code for non-zero exits (crash detection)', () => {
+        const agents: AgentResult[] = [
+            {
+                terminalId: 't1',
+                agentName: 'Dave',
+                status: 'exited',
+                exitCode: 1,
+                nodes: [],
+            },
+        ]
+        const msg: string = buildCompletionMessage(agents)
+        expect(msg).toContain('- Dave [exited:1]: (no nodes created)')
     })
 
     it('includes tip about closing agents', () => {

--- a/webapp/src/shell/edge/main/mcp-server/buildCompletionMessage.ts
+++ b/webapp/src/shell/edge/main/mcp-server/buildCompletionMessage.ts
@@ -7,6 +7,7 @@ export interface AgentResult {
     terminalId: string
     agentName: string | undefined
     status: 'running' | 'idle' | 'exited'
+    exitCode: number | null
     nodes: Array<{nodeId: string; title: string}>
 }
 
@@ -19,7 +20,10 @@ export function buildCompletionMessage(agentResults: AgentResult[]): string {
             agent.nodes.length > 0
                 ? agent.nodes.map((n: {nodeId: string; title: string}) => n.title).join(', ')
                 : '(no nodes created)'
-        lines.push(`- ${name} [${agent.status}]: ${nodeList}`)
+        const statusLabel: string = agent.status === 'exited' && agent.exitCode !== null
+            ? `exited:${agent.exitCode}`
+            : agent.status
+        lines.push(`- ${name} [${statusLabel}]: ${nodeList}`)
     }
 
     lines.push('')

--- a/webapp/src/shell/edge/main/mcp-server/integration-tests/addProgressNodeMcp.test.ts
+++ b/webapp/src/shell/edge/main/mcp-server/integration-tests/addProgressNodeMcp.test.ts
@@ -118,7 +118,7 @@ function mockCallerTerminal(options?: {
         initialEnvVars: options?.color ? {AGENT_COLOR: options.color} : undefined
     })
     vi.mocked(getTerminalRecords).mockReturnValue([
-        {terminalId: CALLER_TERMINAL_ID, terminalData, status: 'running'}
+        {terminalId: CALLER_TERMINAL_ID, terminalData, status: 'running', exitCode: null}
     ])
 }
 

--- a/webapp/src/shell/edge/main/mcp-server/integration-tests/agentCompletionMonitor.test.ts
+++ b/webapp/src/shell/edge/main/mcp-server/integration-tests/agentCompletionMonitor.test.ts
@@ -89,8 +89,8 @@ describe('AgentCompletionMonitor integration', () => {
         const agentData: TerminalData = makeTerminalData('agent-1', 'alpha')
         const callerData: TerminalData = makeTerminalData('caller-1', 'caller')
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: agentData, status: 'running'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: agentData, status: 'running', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
         vi.mocked(getGraph).mockReturnValue(buildGraph([]))
 
@@ -106,8 +106,8 @@ describe('AgentCompletionMonitor integration', () => {
 
         // Initially running
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: agentData, status: 'running'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: agentData, status: 'running', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
         vi.mocked(getGraph).mockReturnValue(buildGraph([]))
 
@@ -119,8 +119,8 @@ describe('AgentCompletionMonitor integration', () => {
 
         // Agent exits
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: agentData, status: 'exited'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: agentData, status: 'exited', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
 
         // Poll 2: agent exited — notification sent
@@ -138,8 +138,8 @@ describe('AgentCompletionMonitor integration', () => {
 
         // Agent already exited — will trigger on first poll
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: agentData, status: 'exited'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: agentData, status: 'exited', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
         vi.mocked(getGraph).mockReturnValue(buildGraph([]))
 
@@ -159,8 +159,8 @@ describe('AgentCompletionMonitor integration', () => {
         const callerData: TerminalData = makeTerminalData('caller-1', 'caller')
 
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: agentData, status: 'running'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: agentData, status: 'running', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
         vi.mocked(getGraph).mockReturnValue(buildGraph([]))
 
@@ -171,8 +171,8 @@ describe('AgentCompletionMonitor integration', () => {
 
         // Agent exits
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: agentData, status: 'exited'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: agentData, status: 'exited', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
 
         // Advance past many poll intervals — no notification
@@ -186,8 +186,8 @@ describe('AgentCompletionMonitor integration', () => {
 
         // Agent already exited
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: agentData, status: 'exited'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: agentData, status: 'exited', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
         vi.mocked(getGraph).mockReturnValue(buildGraph([]))
 
@@ -207,8 +207,8 @@ describe('AgentCompletionMonitor integration', () => {
         const callerData: TerminalData = makeTerminalData('caller-1', 'caller')
 
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: idleAgentData, status: 'running'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: idleAgentData, status: 'running', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
         vi.mocked(getGraph).mockReturnValue(buildGraph([]))
         vi.mocked(getIdleSince).mockReturnValue(Date.now() - 60_000)
@@ -247,8 +247,8 @@ describe('AgentCompletionMonitor integration', () => {
         const callerData: TerminalData = makeTerminalData('caller-1', 'caller')
 
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: idleAgentData, status: 'running'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: idleAgentData, status: 'running', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
 
         // Only context nodes (isContextNode: true) — filtered out by isAgentComplete
@@ -272,9 +272,9 @@ describe('AgentCompletionMonitor integration', () => {
 
         // Both running initially
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-a', terminalData: agentAData, status: 'running'},
-            {terminalId: 'agent-b', terminalData: agentBData, status: 'running'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-a', terminalData: agentAData, status: 'running', exitCode: null},
+            {terminalId: 'agent-b', terminalData: agentBData, status: 'running', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
         vi.mocked(getGraph).mockReturnValue(buildGraph([]))
 
@@ -286,9 +286,9 @@ describe('AgentCompletionMonitor integration', () => {
 
         // Agent A exits, B still running
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-a', terminalData: agentAData, status: 'exited'},
-            {terminalId: 'agent-b', terminalData: agentBData, status: 'running'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-a', terminalData: agentAData, status: 'exited', exitCode: null},
+            {terminalId: 'agent-b', terminalData: agentBData, status: 'running', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
 
         // Poll 2: A done, B still running → no notification
@@ -297,9 +297,9 @@ describe('AgentCompletionMonitor integration', () => {
 
         // Agent B exits too
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-a', terminalData: agentAData, status: 'exited'},
-            {terminalId: 'agent-b', terminalData: agentBData, status: 'exited'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-a', terminalData: agentAData, status: 'exited', exitCode: null},
+            {terminalId: 'agent-b', terminalData: agentBData, status: 'exited', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
 
         // Poll 3: both done → notification
@@ -313,9 +313,9 @@ describe('AgentCompletionMonitor integration', () => {
         const callerData: TerminalData = makeTerminalData('caller-1', 'caller')
 
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-a', terminalData: agentAData, status: 'exited'},
-            {terminalId: 'agent-b', terminalData: agentBData, status: 'exited'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-a', terminalData: agentAData, status: 'exited', exitCode: null},
+            {terminalId: 'agent-b', terminalData: agentBData, status: 'exited', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
 
         const nodeA: GraphNode = buildGraphNode('design.md', 'Design doc', 'alpha')
@@ -340,8 +340,8 @@ describe('AgentCompletionMonitor integration', () => {
         const callerData: TerminalData = makeTerminalData('caller-1', 'caller')
 
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: agentData, status: 'exited'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: agentData, status: 'exited', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
         vi.mocked(getGraph).mockReturnValue(buildGraph([]))
 
@@ -357,8 +357,8 @@ describe('AgentCompletionMonitor integration', () => {
         const callerData: TerminalData = makeTerminalData('caller-1', 'caller')
 
         vi.mocked(getTerminalRecords).mockReturnValue([
-            {terminalId: 'agent-1', terminalData: idleAgentData, status: 'running'},
-            {terminalId: 'caller-1', terminalData: callerData, status: 'running'}
+            {terminalId: 'agent-1', terminalData: idleAgentData, status: 'running', exitCode: null},
+            {terminalId: 'caller-1', terminalData: callerData, status: 'running', exitCode: null}
         ])
 
         const progressNode: GraphNode = buildGraphNode('node-1.md', 'Progress', 'alpha')

--- a/webapp/src/shell/edge/main/mcp-server/integration-tests/spawnAgentMcp.test.ts
+++ b/webapp/src/shell/edge/main/mcp-server/integration-tests/spawnAgentMcp.test.ts
@@ -65,7 +65,7 @@ function mockCallerTerminal(): void {
         agentName: 'caller'
     })
     vi.mocked(getTerminalRecords).mockReturnValue([
-        {terminalId: 'caller-terminal-99', terminalData: callerTerminalData, status: 'running'}
+        {terminalId: 'caller-terminal-99', terminalData: callerTerminalData, status: 'running', exitCode: null}
     ])
 }
 
@@ -240,9 +240,9 @@ describe('MCP list_agents tool', () => {
         })
 
         const records: TerminalRecord[] = [
-            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running'},
-            {terminalId: 'agent-b-terminal-1', terminalData: {...terminalDataB, isDone: true}, status: 'exited'},
-            {terminalId: 'plain-terminal-0', terminalData: terminalDataPlain, status: 'running'}
+            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running', exitCode: null},
+            {terminalId: 'agent-b-terminal-1', terminalData: {...terminalDataB, isDone: true}, status: 'exited', exitCode: null},
+            {terminalId: 'plain-terminal-0', terminalData: terminalDataPlain, status: 'running', exitCode: null}
         ]
 
         vi.mocked(getTerminalRecords).mockReturnValue(records)
@@ -304,7 +304,7 @@ describe('MCP list_agents tool', () => {
         })
 
         const records: TerminalRecord[] = [
-            {terminalId: 'idle-agent-terminal-0', terminalData: {...terminalData, isDone: true}, status: 'running'}
+            {terminalId: 'idle-agent-terminal-0', terminalData: {...terminalData, isDone: true}, status: 'running', exitCode: null}
         ]
 
         vi.mocked(getTerminalRecords).mockReturnValue(records)

--- a/webapp/src/shell/edge/main/mcp-server/integration-tests/waitForAgentsMcp.test.ts
+++ b/webapp/src/shell/edge/main/mcp-server/integration-tests/waitForAgentsMcp.test.ts
@@ -48,8 +48,8 @@ describe('MCP wait_for_agents tool (async)', () => {
         })
 
         const records: TerminalRecord[] = [
-            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running'},
-            {terminalId: 'caller-terminal-1', terminalData: callerTerminalData, status: 'running'}
+            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running', exitCode: null},
+            {terminalId: 'caller-terminal-1', terminalData: callerTerminalData, status: 'running', exitCode: null}
         ]
 
         vi.mocked(getTerminalRecords).mockReturnValue(records)
@@ -94,8 +94,8 @@ describe('MCP wait_for_agents tool (async)', () => {
         })
 
         const records: TerminalRecord[] = [
-            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running'},
-            {terminalId: 'caller-terminal-1', terminalData: callerTerminalData, status: 'running'}
+            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running', exitCode: null},
+            {terminalId: 'caller-terminal-1', terminalData: callerTerminalData, status: 'running', exitCode: null}
         ]
 
         vi.mocked(getTerminalRecords).mockReturnValue(records)
@@ -129,8 +129,8 @@ describe('MCP wait_for_agents tool (async)', () => {
         })
 
         const records: TerminalRecord[] = [
-            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running'},
-            {terminalId: 'caller-terminal-1', terminalData: callerTerminalData, status: 'running'}
+            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running', exitCode: null},
+            {terminalId: 'caller-terminal-1', terminalData: callerTerminalData, status: 'running', exitCode: null}
         ]
 
         vi.mocked(getTerminalRecords).mockReturnValue(records)
@@ -155,7 +155,7 @@ describe('MCP wait_for_agents tool (async)', () => {
         })
 
         const records: TerminalRecord[] = [
-            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running'}
+            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running', exitCode: null}
         ]
 
         vi.mocked(getTerminalRecords).mockReturnValue(records)
@@ -183,7 +183,7 @@ describe('MCP wait_for_agents tool (async)', () => {
         })
 
         const records: TerminalRecord[] = [
-            {terminalId: 'caller-terminal-0', terminalData: callerTerminalData, status: 'running'}
+            {terminalId: 'caller-terminal-0', terminalData: callerTerminalData, status: 'running', exitCode: null}
         ]
 
         vi.mocked(getTerminalRecords).mockReturnValue(records)
@@ -227,9 +227,9 @@ describe('MCP wait_for_agents tool (async)', () => {
         })
 
         const records: TerminalRecord[] = [
-            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running'},
-            {terminalId: 'agent-b-terminal-1', terminalData: terminalDataB, status: 'running'},
-            {terminalId: 'caller-terminal-2', terminalData: callerTerminalData, status: 'running'}
+            {terminalId: 'agent-a-terminal-0', terminalData: terminalDataA, status: 'running', exitCode: null},
+            {terminalId: 'agent-b-terminal-1', terminalData: terminalDataB, status: 'running', exitCode: null},
+            {terminalId: 'caller-terminal-2', terminalData: callerTerminalData, status: 'running', exitCode: null}
         ]
 
         vi.mocked(getTerminalRecords).mockReturnValue(records)

--- a/webapp/src/shell/edge/main/terminals/__tests__/headlessAgentManager.test.ts
+++ b/webapp/src/shell/edge/main/terminals/__tests__/headlessAgentManager.test.ts
@@ -285,7 +285,7 @@ describe('headlessAgentManager', () => {
     })
 
     describe('process exit lifecycle', () => {
-        it('calls markTerminalExited on process exit', () => {
+        it('calls markTerminalExited with exit code on process exit', () => {
             const terminalId: string = 'agent-exit'
             const terminalData: TerminalData = createTestTerminalData(terminalId)
 
@@ -302,7 +302,46 @@ describe('headlessAgentManager', () => {
             mockChild.emit('exit', 0)
 
             expect(mockMarkTerminalExited).toHaveBeenCalledOnce()
-            expect(mockMarkTerminalExited).toHaveBeenCalledWith(terminalId)
+            expect(mockMarkTerminalExited).toHaveBeenCalledWith(terminalId, 0)
+        })
+
+        it('passes non-zero exit code to markTerminalExited', () => {
+            const terminalId: string = 'agent-exit-fail'
+            const terminalData: TerminalData = createTestTerminalData(terminalId)
+            vi.spyOn(console, 'error').mockImplementation(() => {})
+
+            spawnHeadlessAgent(
+                terminalId as TerminalId,
+                terminalData,
+                'claude -p "task"',
+                '/tmp',
+                {}
+            )
+            vi.clearAllMocks()
+
+            mockChild.emit('exit', 1)
+
+            expect(mockMarkTerminalExited).toHaveBeenCalledOnce()
+            expect(mockMarkTerminalExited).toHaveBeenCalledWith(terminalId, 1)
+        })
+
+        it('does not remove terminal from registry on process exit', () => {
+            const terminalId: string = 'agent-no-remove'
+            const terminalData: TerminalData = createTestTerminalData(terminalId)
+
+            spawnHeadlessAgent(
+                terminalId as TerminalId,
+                terminalData,
+                'claude -p "task"',
+                '/tmp',
+                {}
+            )
+
+            mockChild.emit('exit', 0)
+
+            // Registry record should be preserved (only markTerminalExited called, not removeTerminalFromRegistry)
+            // The process map is cleaned up, but the registry record stays for wait_for_agents
+            expect(mockMarkTerminalExited).toHaveBeenCalled()
         })
 
         it('removes from internal map on process exit', () => {

--- a/webapp/src/shell/edge/main/terminals/headlessAgentManager.ts
+++ b/webapp/src/shell/edge/main/terminals/headlessAgentManager.ts
@@ -9,7 +9,7 @@
 
 import {spawn, type ChildProcess} from 'child_process'
 import type {TerminalId} from '@/shell/edge/UI-edge/floating-windows/types'
-import {markTerminalExited, removeTerminalFromRegistry, recordTerminalSpawn} from '@/shell/edge/main/terminals/terminal-registry'
+import {markTerminalExited, recordTerminalSpawn} from '@/shell/edge/main/terminals/terminal-registry'
 import type {TerminalData} from '@/shell/edge/UI-edge/floating-windows/terminals/terminalDataType'
 
 // ─── State (functional edge pattern: module-level Maps) ──────────────────────
@@ -66,13 +66,11 @@ export function spawnHeadlessAgent(
             const output: string = lastOutputByTerminal.get(terminalId) ?? ''
             console.error(`[headlessAgentManager] Agent ${terminalId} exited with code ${code}. Last output: ${output.slice(-500)}`)
         }
-        markTerminalExited(terminalId)
+        markTerminalExited(terminalId, code)
         headlessProcesses.delete(terminalId)
         // Note: output buffer intentionally preserved after exit for hover tooltip / read_terminal_output
-
-        // Headless agents can't be resumed (no PTY/terminal UI), so auto-close on exit
-        // removes the zombie entry from the registry instead of leaving it as "exited"
-        removeTerminalFromRegistry(terminalId)
+        // Registry record intentionally preserved after exit so wait_for_agents monitor
+        // can still find and report on this agent. Cleanup happens via close_agent.
     })
 }
 

--- a/webapp/src/shell/edge/main/terminals/terminal-registry.ts
+++ b/webapp/src/shell/edge/main/terminals/terminal-registry.ts
@@ -15,6 +15,7 @@ export type TerminalRecord = {
     terminalId: string
     terminalData: TerminalData
     status: TerminalStatus
+    exitCode: number | null
 }
 
 const terminalRecords: Map<string, TerminalRecord> = new Map()
@@ -133,7 +134,8 @@ export function recordTerminalSpawn(terminalId: string, terminalData: TerminalDa
     terminalRecords.set(terminalId, {
         terminalId,
         terminalData,
-        status: 'running'
+        status: 'running',
+        exitCode: null
     })
 
     // Initialize notification tracking state for this terminal
@@ -256,14 +258,15 @@ export function updateTerminalActivityState(
     // and should not trigger full re-renders. Renderer updates local state directly.
 }
 
-export function markTerminalExited(terminalId: string): void {
+export function markTerminalExited(terminalId: string, exitCode?: number | null): void {
     const record: TerminalRecord | undefined = terminalRecords.get(terminalId)
     if (!record) {
         return
     }
     terminalRecords.set(terminalId, {
         ...record,
-        status: 'exited'
+        status: 'exited',
+        exitCode: exitCode ?? null
     })
     pushStateToRenderer()
 }


### PR DESCRIPTION
…ents reliability

Headless agents were auto-removed from the terminal registry on process exit (removeTerminalFromRegistry in headlessAgentManager.ts:75), causing the wait_for_agents monitor to lose track of them. When agents exited before the monitor's next poll, they vanished from the registry — the monitor's .every() check passed on the reduced set, and the completion message silently omitted the missing agents.

Fixes:
1. Remove the removeTerminalFromRegistry call from the headless exit handler. Registry records now persist with status 'exited' so the monitor can find and report on them. Cleanup happens via close_agent (existing workflow).
2. Add exitCode tracking to TerminalRecord and completion messages, so parent agents can distinguish clean exits (exited:0) from crashes (exited:1).
3. Defensive handling in the monitor for any terminals that vanish from the registry — reports them as missing instead of silently dropping them.