### PR TITLE
chore: ignore nested .worktrees/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,7 @@ webapp/workers/share-worker/.wrangler/**
 
 # Worktrees
 .worktrees/**/*
+**/.worktrees/
 
 # Misc
 **/transcript_history.txt


### PR DESCRIPTION
## Summary
- Adds `**/.worktrees/` to root `.gitignore` so sibling-worktree metadata (e.g. `voicetree-7-5/.worktrees/`) stops appearing as untracked in `git status`.
- The existing `.worktrees/**/*` rule is anchored to the repo root and doesn't match nested locations.

## Test plan
- [x] `git check-ignore -v voicetree-7-5/.worktrees/` resolves to the new rule.
- [x] `git status` no longer shows the nested worktree dir as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)