### PR TITLE
Native arm64 Linux AppImage in release pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Keep the build context tiny — the Dockerfile only needs the docker/
+# directory. Everything else lives inside the AppImage that we download
+# during the build.
+
+*
+!docker/
+!docker/**

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,7 @@
 # Copy to `.env` and fill in. docker-compose reads this automatically.
 
-# Required for Claude Code if you skip the OAuth login flow inside the
-# container's browser. OAuth also works: run `claude` in a terminal inside
-# the container and complete the flow in the Firefox window that opens.
+# Required for Claude Code. No browser is preinstalled in the container,
+# so the OAuth flow is awkward — set the API key and you're done.
 ANTHROPIC_API_KEY=
 
 # Optional: other agent CLIs you might install via install-agents.sh

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy to `.env` and fill in. docker-compose reads this automatically.
+
+# Required for Claude Code if you skip the OAuth login flow inside the
+# container's browser. OAuth also works: run `claude` in a terminal inside
+# the container and complete the flow in the Firefox window that opens.
+ANTHROPIC_API_KEY=
+
+# Optional: other agent CLIs you might install via install-agents.sh
+# OPENAI_API_KEY=
+# GEMINI_API_KEY=
+
+# Optional: disable analytics (matches webapp/.env switch).
+# VITE_DISABLE_ANALYTICS=true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,78 @@
+name: Docker image
+
+on:
+  release:
+    types: [published]
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'docker/**'
+      - 'docker-compose.yml'
+      - '.dockerignore'
+      - '.github/workflows/docker.yml'
+  workflow_dispatch:
+    inputs:
+      voicetree_version:
+        description: 'VoiceTree release tag to bake into the image (e.g. v2.9.16 or "latest")'
+        required: false
+        default: 'latest'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/voicetree
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Resolve VoiceTree version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ inputs.voicetree_version || 'latest' }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          TAG="${{ steps.ver.outputs.tag }}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # vX.Y.Z release: publish both :X.Y.Z and :latest
+            CLEAN="${TAG#v}"
+            echo "tags=${IMAGE}:${CLEAN},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            # PR builds: build only, no push
+            echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=${IMAGE}:manual-${TAG}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (and push on release / manual)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            VOICETREE_VERSION=${{ steps.ver.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,15 +64,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build (and push on release / manual)
+      - name: Build (load locally, push on release / manual)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
           platforms: linux/amd64
+          # PRs: load only (no registry push). Release/manual: push.
+          load: ${{ github.event_name == 'pull_request' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
             VOICETREE_VERSION=${{ steps.ver.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Smoke test
+        if: github.event_name != 'release'
+        env:
+          IMAGE: ${{ env.IMAGE }}:pr-${{ github.event.pull_request.number || 'manual' }}
+          BOOT_TIMEOUT: 120
+        run: |
+          # On workflow_dispatch the tag is :manual-<input>; pick whichever
+          # tag is loaded.
+          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+              IMAGE=$(echo "${{ steps.tags.outputs.tags }}" | cut -d, -f1)
+              export IMAGE
+          fi
+          echo "Smoke-testing image: $IMAGE"
+          bash docker/test/smoke.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,10 +343,20 @@ jobs:
           npx electron-builder --win --publish=always
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-  build-linux-x64:
+  build-linux:
     needs: [check-version]
     if: ${{ needs.check-version.outputs.should_build == 'true' && (github.event_name == 'push' || inputs.build_linux) }}
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # x64 is the critical path — if it fails the release fails.
+          - { arch: x64,   runs-on: ubuntu-latest,    soft_fail: false }
+          # arm64 is new; allowed to fail until proven stable. Flip
+          # soft_fail to false once a few releases ship cleanly.
+          - { arch: arm64, runs-on: ubuntu-24.04-arm, soft_fail: true  }
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.soft_fail }}
 
     steps:
       - uses: actions/checkout@v4
@@ -404,10 +414,24 @@ jobs:
           VITE_POSTHOG_HOST: ${{ secrets.VITE_POSTHOG_HOST }}
         run: |
           npx electron-vite build
-          npx electron-builder --linux --publish=always
+          npx electron-builder --linux --${{ matrix.arch }} --publish=always
+
+      # Backward-compat alias: keep `voicetree.AppImage` (no arch suffix)
+      # pointing at the x64 build so existing consumers (the docker.yml
+      # workflow on main, hand-downloaders, anyone with a bookmarked URL)
+      # don't 404. Remove once all consumers are on the arch-suffixed names.
+      - name: Publish legacy AppImage alias (x64 only)
+        if: matrix.arch == 'x64'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          VERSION="${{ needs.check-version.outputs.version }}"
+          cp out/electron/voicetree-x64.AppImage out/electron/voicetree.AppImage
+          gh release upload "v${VERSION}" out/electron/voicetree.AppImage \
+            --clobber --repo voicetreelab/voicetree
 
   publish-release:
-    needs: [check-version, build-mac, build-windows, build-linux-x64, merge-mac-manifests]
+    needs: [check-version, build-mac, build-windows, build-linux, merge-mac-manifests]
     if: ${{ needs.check-version.outputs.should_build == 'true' }}
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,7 @@ webapp/workers/share-worker/.wrangler/**
 !webapp/example_folder_fixtures/example_real_large/voicetree-24-2/**/*.md
 !packages/graph-model/tests/**/*.md
 !packages/graph-state/**/*.md
+!docker/**/*.md
 
 # MCP config
 **/.mcp.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  voicetree:
+    image: ghcr.io/voicetreelab/voicetree:latest
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    container_name: voicetree
+    ports:
+      - "6080:6080"
+    volumes:
+      - vault:/home/vt/vault
+      - claude-config:/home/vt/.config/claude
+    env_file:
+      - .env
+    shm_size: "1gb"
+    restart: unless-stopped
+
+volumes:
+  vault:
+  claude-config:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,12 +23,16 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # System dependencies: virtual X stack, Electron runtime libs, VNC, Node (for
 # agent CLIs that ship as npm packages), git, curl. libasound2t64 is the
 # renamed-in-24.04 successor to libasound2.
+# No browser is installed in the base image; on Ubuntu 24.04 Firefox is
+# distributed as a snap which doesn't work inside a plain container.
+# Set ANTHROPIC_API_KEY in .env to skip Claude Code's OAuth-browser flow,
+# or apt-install a browser yourself inside a running container.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl wget git tini sudo \
+        squashfs-tools \
         xvfb x11vnc openbox xterm \
         novnc websockify \
         fonts-liberation fonts-noto-core \
-        firefox-esr \
         nodejs npm \
         # Electron runtime deps
         libnss3 libnspr4 libdbus-1-3 \
@@ -47,14 +51,25 @@ RUN npm install -g @anthropic-ai/claude-code
 
 # Non-root user. uid 1000 lines up with the default host user on most Linux
 # distros, which makes bind-mounting feel natural if a user opts in.
-RUN useradd --create-home --shell /bin/bash --uid 1000 vt \
+# Ubuntu 24.04 ships a placeholder `ubuntu` user at uid 1000, so we remove
+# it first to free the uid.
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && useradd --create-home --shell /bin/bash --uid 1000 vt \
     && mkdir -p /home/vt/vault /home/vt/.config/claude "$XDG_RUNTIME_DIR" \
     && chown -R vt:vt /home/vt "$XDG_RUNTIME_DIR" \
     && chmod 700 "$XDG_RUNTIME_DIR"
 
-# Fetch and extract the AppImage at build time, so the image is self-contained
-# and tagged with a known VoiceTree version. --appimage-extract avoids needing
-# FUSE in the running container.
+# Fetch and extract the AppImage at build time.
+#
+# We unpack the embedded SquashFS directly with unsquashfs rather than running
+# ./voicetree.AppImage --appimage-extract, because the AppImage's prepended
+# ELF runtime wrapper does not survive non-native execution (e.g. Rosetta or
+# binfmt-misc emulation) — "exec format error". The SquashFS payload itself
+# is architecture-neutral filesystem data; unsquashfs reads it directly.
+#
+# Offset of the squashfs payload = end of the ELF section header table:
+#     e_shoff + e_shentsize * e_shnum
+# all read straight from the 64-bit ELF header (LE on x86-64).
 WORKDIR /opt
 RUN set -eux; \
     if [ "$VOICETREE_VERSION" = "latest" ]; then \
@@ -63,9 +78,12 @@ RUN set -eux; \
         URL="https://github.com/voicetreelab/voicetree/releases/download/${VOICETREE_VERSION}/voicetree.AppImage"; \
     fi; \
     curl -fL --retry 3 -o voicetree.AppImage "$URL"; \
-    chmod +x voicetree.AppImage; \
-    ./voicetree.AppImage --appimage-extract >/dev/null; \
-    mv squashfs-root voicetree; \
+    e_shoff=$(od -An -j40 -N8 -tu8 voicetree.AppImage | tr -d ' '); \
+    e_shentsize=$(od -An -j58 -N2 -tu2 voicetree.AppImage | tr -d ' '); \
+    e_shnum=$(od -An -j60 -N2 -tu2 voicetree.AppImage | tr -d ' '); \
+    offset=$((e_shoff + e_shentsize * e_shnum)); \
+    echo "squashfs offset: $offset"; \
+    unsquashfs -no-progress -o "$offset" -d voicetree voicetree.AppImage; \
     rm voicetree.AppImage; \
     chown -R vt:vt /opt/voicetree
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,81 @@
+# syntax=docker/dockerfile:1.7
+#
+# Sandboxed VoiceTree runtime.
+#
+# Runs the released voicetree.AppImage inside a virtual desktop (Xvfb +
+# openbox), reachable from the host via a browser at http://localhost:6080
+# (noVNC). Intended use: contain agent activity (Claude Code etc.) so it
+# cannot touch the host filesystem.
+#
+# Architecture: linux/amd64 only. The published AppImage is x86_64.
+
+FROM ubuntu:24.04
+
+ARG VOICETREE_VERSION=latest
+ARG NOVNC_VERSION=1.5.0
+ARG WEBSOCKIFY_VERSION=0.12.0
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    DISPLAY=:99 \
+    XDG_RUNTIME_DIR=/tmp/runtime-vt \
+    VOICETREE_VAULT=/home/vt/vault
+
+# System dependencies: virtual X stack, Electron runtime libs, VNC, Node (for
+# agent CLIs that ship as npm packages), git, curl. libasound2t64 is the
+# renamed-in-24.04 successor to libasound2.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl wget git tini sudo \
+        xvfb x11vnc openbox xterm \
+        novnc websockify \
+        fonts-liberation fonts-noto-core \
+        firefox-esr \
+        nodejs npm \
+        # Electron runtime deps
+        libnss3 libnspr4 libdbus-1-3 \
+        libatk1.0-0t64 libatk-bridge2.0-0t64 \
+        libcups2t64 libdrm2 libgbm1 libxkbcommon0 \
+        libxcomposite1 libxdamage1 libxext6 libxfixes3 libxrandr2 \
+        libxshmfence1 libxss1 libxtst6 \
+        libgtk-3-0t64 libpango-1.0-0 libcairo2 \
+        libasound2t64 libnotify4 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Agent CLIs preinstalled. Claude Code is the priority; others (codex,
+# opencode, gemini) can be added via docker/install-agents.sh inside the
+# container.
+RUN npm install -g @anthropic-ai/claude-code
+
+# Non-root user. uid 1000 lines up with the default host user on most Linux
+# distros, which makes bind-mounting feel natural if a user opts in.
+RUN useradd --create-home --shell /bin/bash --uid 1000 vt \
+    && mkdir -p /home/vt/vault /home/vt/.config/claude "$XDG_RUNTIME_DIR" \
+    && chown -R vt:vt /home/vt "$XDG_RUNTIME_DIR" \
+    && chmod 700 "$XDG_RUNTIME_DIR"
+
+# Fetch and extract the AppImage at build time, so the image is self-contained
+# and tagged with a known VoiceTree version. --appimage-extract avoids needing
+# FUSE in the running container.
+WORKDIR /opt
+RUN set -eux; \
+    if [ "$VOICETREE_VERSION" = "latest" ]; then \
+        URL="https://github.com/voicetreelab/voicetree/releases/latest/download/voicetree.AppImage"; \
+    else \
+        URL="https://github.com/voicetreelab/voicetree/releases/download/${VOICETREE_VERSION}/voicetree.AppImage"; \
+    fi; \
+    curl -fL --retry 3 -o voicetree.AppImage "$URL"; \
+    chmod +x voicetree.AppImage; \
+    ./voicetree.AppImage --appimage-extract >/dev/null; \
+    mv squashfs-root voicetree; \
+    rm voicetree.AppImage; \
+    chown -R vt:vt /opt/voicetree
+
+COPY --chown=vt:vt docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --chown=vt:vt docker/install-agents.sh /usr/local/bin/install-agents.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/install-agents.sh
+
+USER vt
+WORKDIR /home/vt
+VOLUME ["/home/vt/vault", "/home/vt/.config/claude"]
+EXPOSE 6080
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,91 @@
+# Sandboxed VoiceTree (Docker)
+
+Runs the released VoiceTree AppImage inside a container with a virtual
+desktop, accessible from your browser. Use this when you want Claude Code
+(or other terminal agents) to work without any ability to touch your host
+filesystem.
+
+> **Architecture:** `linux/amd64` only — the published AppImage is x86_64.
+> Apple Silicon Macs run this image under emulation (Rosetta via Docker
+> Desktop / OrbStack / Colima). It works, but slower than native. A native
+> arm64 image (from source) is on the roadmap.
+
+## Quick start
+
+```bash
+cp .env.example .env        # fill in ANTHROPIC_API_KEY (or leave blank + OAuth in-container)
+docker compose up -d
+open http://localhost:6080/vnc.html?autoconnect=1&resize=remote
+```
+
+Or without compose:
+
+```bash
+docker run -d --rm --name voicetree \
+    -p 6080:6080 \
+    -v voicetree-vault:/home/vt/vault \
+    -v voicetree-claude:/home/vt/.config/claude \
+    --shm-size=1g \
+    -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+    ghcr.io/voicetreelab/voicetree:latest
+```
+
+Then open `http://localhost:6080/vnc.html?autoconnect=1&resize=remote`.
+
+## What you get
+
+- **VoiceTree desktop app** running on a virtual display, served over noVNC.
+- **Claude Code** preinstalled. Run `claude` in any terminal VoiceTree spawns.
+- **Persistent named volumes**:
+  - `voicetree-vault` → `/home/vt/vault` (your markdown graph; survives container recreates)
+  - `voicetree-claude` → `/home/vt/.config/claude` (auth tokens; log in once)
+- **No browser** is preinstalled. Set `ANTHROPIC_API_KEY` to skip Claude Code's OAuth flow, or `apt-get install` a browser yourself inside a running container if you really need it.
+
+## Isolation guarantees
+
+The container only sees:
+- its own filesystem (ephemeral except for the two named volumes above)
+- outbound network
+- inbound: `localhost:6080` from the host
+
+It does **not** see your home directory, your projects, your SSH keys, or
+anything else on the host. An agent doing `rm -rf /` inside the container
+only destroys the container. Recreate it with `docker compose up -d`.
+
+## Add more agents
+
+```bash
+docker exec -it voicetree bash -lc install-agents.sh
+```
+
+Installs `codex`, `opencode`, and `gemini` alongside Claude Code. Skipped by
+default to keep the base image small.
+
+## Build locally
+
+```bash
+docker build --platform=linux/amd64 -f docker/Dockerfile -t voicetree:dev .
+# or pin a version:
+docker build --platform=linux/amd64 -f docker/Dockerfile \
+    --build-arg VOICETREE_VERSION=v2.9.16 -t voicetree:2.9.16 .
+```
+
+`--platform=linux/amd64` is required on Apple Silicon hosts — Docker
+Desktop defaults to your native architecture (arm64) and the published
+AppImage is x86_64-only. The build runs under Rosetta; it's slower but
+produces the correct image.
+
+## Performance knobs
+
+- `SCREEN_GEOMETRY` env var: default `1600x1000x24`. Bump if your monitor is
+  bigger.
+- `--shm-size=1g`: Chromium/Electron writes a lot to `/dev/shm`. Smaller
+  values cause renderer crashes.
+
+## Known limits (MVP)
+
+- amd64 only.
+- Voice mode (microphone input) is not wired through; container has no
+  audio device by default.
+- GPU acceleration is off — Electron falls back to software rendering inside
+  Xvfb. Fine for the graph; visible on heavy animations.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start a virtual desktop, expose it via noVNC at :6080, then run VoiceTree
+# inside it. Signals propagate through tini (PID 1) -> this script -> child
+# processes; we forward SIGTERM explicitly to give VoiceTree a chance to
+# shutdown cleanly.
+
+VNC_PORT=${VNC_PORT:-5900}
+NOVNC_PORT=${NOVNC_PORT:-6080}
+SCREEN_GEOMETRY=${SCREEN_GEOMETRY:-1600x1000x24}
+VOICETREE_BIN=/opt/voicetree/voicetree
+
+pids=()
+cleanup() {
+    for pid in "${pids[@]}"; do
+        kill -TERM "$pid" 2>/dev/null || true
+    done
+    wait
+}
+trap cleanup EXIT TERM INT
+
+# Virtual X server.
+Xvfb "$DISPLAY" -screen 0 "$SCREEN_GEOMETRY" -nolisten tcp -ac &
+pids+=($!)
+
+# Wait for Xvfb to accept connections (max ~5s).
+for _ in $(seq 1 50); do
+    if xdpyinfo -display "$DISPLAY" >/dev/null 2>&1; then break; fi
+    sleep 0.1
+done
+
+openbox --config-file /etc/xdg/openbox/rc.xml &
+pids+=($!)
+
+# VNC server attached to the virtual display.
+x11vnc -display "$DISPLAY" -nopw -forever -shared -rfbport "$VNC_PORT" -quiet &
+pids+=($!)
+
+# Browser-accessible VNC. websockify ships novnc's vnc.html as the web root,
+# so visiting http://localhost:${NOVNC_PORT}/vnc.html?autoconnect=1 works.
+websockify --web=/usr/share/novnc "$NOVNC_PORT" "localhost:$VNC_PORT" &
+pids+=($!)
+
+echo "[entrypoint] desktop ready at http://localhost:${NOVNC_PORT}/vnc.html?autoconnect=1&resize=remote"
+echo "[entrypoint] vault: $VOICETREE_VAULT"
+
+# Electron in a container requires --no-sandbox unless we set up user
+# namespaces; the outer container already provides the sandbox boundary that
+# matters here.
+exec "$VOICETREE_BIN" --no-sandbox "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,7 +9,15 @@ set -euo pipefail
 VNC_PORT=${VNC_PORT:-5900}
 NOVNC_PORT=${NOVNC_PORT:-6080}
 SCREEN_GEOMETRY=${SCREEN_GEOMETRY:-1600x1000x24}
-VOICETREE_BIN=/opt/voicetree/voicetree
+APPDIR=/opt/voicetree
+VOICETREE_BIN=$APPDIR/voicetree-webapp
+
+# Replicates what the AppImage's AppRun script does, without its broken
+# AppDir auto-detection (which mis-parses --no-sandbox as a filename).
+export APPDIR
+export LD_LIBRARY_PATH="$APPDIR/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export XDG_DATA_DIRS="$APPDIR/usr/share/:${XDG_DATA_DIRS:-/usr/share:/usr/local/share}"
+export GSETTINGS_SCHEMA_DIR="$APPDIR/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}"
 
 pids=()
 cleanup() {

--- a/docker/install-agents.sh
+++ b/docker/install-agents.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Optional installer for additional terminal-based agents. Run inside a
+# running container (`docker exec -it voicetree bash -lc install-agents.sh`)
+# to add codex / opencode / gemini alongside the preinstalled Claude Code.
+set -euo pipefail
+
+sudo npm install -g \
+    @openai/codex \
+    opencode-ai \
+    @google/gemini-cli
+
+echo "Installed: codex, opencode, gemini"

--- a/docker/test/README.md
+++ b/docker/test/README.md
@@ -1,0 +1,41 @@
+# Docker smoke tests
+
+`smoke.sh` exercises a built VoiceTree image to confirm it actually boots.
+
+## Run locally
+
+```bash
+docker build --platform=linux/amd64 -f docker/Dockerfile -t voicetree:smoke .
+IMAGE=voicetree:smoke bash docker/test/smoke.sh
+```
+
+`--platform=linux/amd64` is required on Apple Silicon (the AppImage is
+x86_64). The build runs under Rosetta emulation — slower but correct.
+
+What it checks:
+
+1. Container stays running for ≥5 seconds (catches immediate Electron crashes
+   from missing libs).
+2. All four background daemons are up: `Xvfb`, `openbox`, `x11vnc`,
+   `websockify`.
+3. `http://localhost:16080/vnc.html` returns 200 and the body mentions
+   noVNC.
+4. The VoiceTree main process (`/opt/voicetree/voicetree`) is alive.
+5. `claude --version` succeeds inside the container.
+
+Failure dumps the last 80 lines of container logs.
+
+## Useful overrides
+
+| Env var          | Default            | Purpose                                   |
+|------------------|--------------------|-------------------------------------------|
+| `IMAGE`          | `voicetree:smoke`  | image tag under test                      |
+| `HOST_PORT`      | `16080`            | host port to map; bump if 16080 is taken  |
+| `BOOT_TIMEOUT`   | `90`               | seconds to wait for daemons / processes   |
+| `KEEP_CONTAINER` | unset              | set to `1` to leave the container running for manual inspection |
+
+## CI
+
+This script is invoked from `.github/workflows/docker.yml` on every PR to
+`dev` that touches docker paths. PRs build the image (no push) and run
+this smoke against it.

--- a/docker/test/smoke.sh
+++ b/docker/test/smoke.sh
@@ -96,15 +96,15 @@ rm -f /tmp/vncpage.$$
 log "4. VoiceTree process running inside container"
 deadline=$((SECONDS + BOOT_TIMEOUT))
 while [ $SECONDS -lt $deadline ]; do
-    if docker exec "$NAME" pgrep -f /opt/voicetree/voicetree >/dev/null 2>&1; then
+    if docker exec "$NAME" pgrep -f /opt/voicetree/voicetree-webapp >/dev/null 2>&1; then
         break
     fi
     sleep 2
 done
-if docker exec "$NAME" pgrep -f /opt/voicetree/voicetree >/dev/null 2>&1; then
-    ok "voicetree process is running"
+if docker exec "$NAME" pgrep -f /opt/voicetree/voicetree-webapp >/dev/null 2>&1; then
+    ok "voicetree-webapp process is running"
 else
-    ng "no voicetree process found after ${BOOT_TIMEOUT}s"
+    ng "no voicetree-webapp process found after ${BOOT_TIMEOUT}s"
 fi
 
 # --- Test 5: claude-code CLI is available --------------------------------

--- a/docker/test/smoke.sh
+++ b/docker/test/smoke.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Smoke tests for the VoiceTree container image. Assumes the image is
+# already built and present in the local docker daemon.
+#
+# Usage:
+#   docker build -f docker/Dockerfile -t voicetree:smoke .
+#   IMAGE=voicetree:smoke bash docker/test/smoke.sh
+#
+# Override with env vars:
+#   IMAGE          tag of the image to test (default: voicetree:smoke)
+#   HOST_PORT      port on the host to map to container's 6080 (default: 16080)
+#   BOOT_TIMEOUT   seconds to wait for processes/HTTP to come up (default: 90)
+
+set -uo pipefail
+
+IMAGE=${IMAGE:-voicetree:smoke}
+NAME=vt-smoke-$$
+HOST_PORT=${HOST_PORT:-16080}
+BOOT_TIMEOUT=${BOOT_TIMEOUT:-90}
+
+PASS=0; FAIL=0
+log()  { printf '\n--- %s ---\n' "$1"; }
+ok()   { printf '  PASS  %s\n' "$1"; PASS=$((PASS+1)); }
+ng()   { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+cleanup() {
+    if [ "${KEEP_CONTAINER:-0}" = "1" ]; then
+        echo "Leaving container $NAME running (KEEP_CONTAINER=1)"
+        return
+    fi
+    echo
+    echo "--- container logs (last 80 lines) ---"
+    docker logs "$NAME" 2>&1 | tail -80 || true
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "ERROR: image '$IMAGE' not found locally. Build it first:"
+    echo "  docker build -f docker/Dockerfile -t $IMAGE ."
+    exit 2
+fi
+
+log "Starting container ($IMAGE -> :$HOST_PORT)"
+docker run -d --name "$NAME" -p "${HOST_PORT}:6080" --shm-size=1g "$IMAGE" >/dev/null
+
+# --- Test 1: container is running ----------------------------------------
+log "1. Container is running after boot"
+sleep 5
+if [ "$(docker inspect -f '{{.State.Running}}' "$NAME" 2>/dev/null)" = "true" ]; then
+    ok "container is up"
+else
+    ng "container exited during startup"
+    exit 1   # Nothing else can succeed if the container isn't running
+fi
+
+# --- Test 2: all background daemons running ------------------------------
+log "2. Background daemons running (Xvfb / openbox / x11vnc / websockify)"
+needed=(Xvfb openbox x11vnc websockify)
+missing=()
+deadline=$((SECONDS + BOOT_TIMEOUT))
+while [ $SECONDS -lt $deadline ]; do
+    missing=()
+    for p in "${needed[@]}"; do
+        docker exec "$NAME" pgrep -f "$p" >/dev/null 2>&1 || missing+=("$p")
+    done
+    [ ${#missing[@]} -eq 0 ] && break
+    sleep 2
+done
+if [ ${#missing[@]} -eq 0 ]; then
+    ok "Xvfb, openbox, x11vnc, websockify all present"
+else
+    ng "missing after ${BOOT_TIMEOUT}s: ${missing[*]}"
+fi
+
+# --- Test 3: noVNC HTTP responds -----------------------------------------
+log "3. noVNC serves vnc.html on :$HOST_PORT"
+status=000
+deadline=$((SECONDS + 30))
+while [ $SECONDS -lt $deadline ]; do
+    status=$(curl -fsS -o /tmp/vncpage.$$ -w '%{http_code}' \
+        "http://localhost:${HOST_PORT}/vnc.html" 2>/dev/null || echo 000)
+    [ "$status" = "200" ] && break
+    sleep 1
+done
+if [ "$status" = "200" ] && grep -qi "noVNC" /tmp/vncpage.$$; then
+    ok "noVNC page reachable (HTTP 200, body mentions noVNC)"
+else
+    ng "noVNC unreachable (last status=$status)"
+fi
+rm -f /tmp/vncpage.$$
+
+# --- Test 4: VoiceTree process is alive ----------------------------------
+# Electron forks several helper processes; matching on the main binary path
+# is the reliable signal.
+log "4. VoiceTree process running inside container"
+deadline=$((SECONDS + BOOT_TIMEOUT))
+while [ $SECONDS -lt $deadline ]; do
+    if docker exec "$NAME" pgrep -f /opt/voicetree/voicetree >/dev/null 2>&1; then
+        break
+    fi
+    sleep 2
+done
+if docker exec "$NAME" pgrep -f /opt/voicetree/voicetree >/dev/null 2>&1; then
+    ok "voicetree process is running"
+else
+    ng "no voicetree process found after ${BOOT_TIMEOUT}s"
+fi
+
+# --- Test 5: claude-code CLI is available --------------------------------
+log "5. Claude Code CLI is installed and reports a version"
+if docker exec "$NAME" bash -lc 'command -v claude >/dev/null && claude --version' >/dev/null 2>&1; then
+    ok "claude CLI present and runnable"
+else
+    ng "claude CLI not on PATH (or --version failed)"
+fi
+
+# --- summary -------------------------------------------------------------
+echo
+echo "=========================================="
+printf "  %d passed, %d failed\n" "$PASS" "$FAIL"
+echo "=========================================="
+[ $FAIL -eq 0 ]

--- a/install.sh
+++ b/install.sh
@@ -24,12 +24,13 @@ esac
 # Check architecture
 ARCH="$(uname -m)"
 case "$ARCH" in
-    x86_64) ;;
-    *) error "Unsupported architecture: $ARCH. Linux AppImage is only available for x86_64." ;;
+    x86_64)  APPIMAGE="voicetree-x64.AppImage" ;;
+    aarch64) APPIMAGE="voicetree-arm64.AppImage" ;;
+    *) error "Unsupported architecture: $ARCH. Linux AppImage is available for x86_64 and aarch64." ;;
 esac
 
 # Download AppImage
-URL="https://github.com/$REPO/releases/latest/download/voicetree.AppImage"
+URL="https://github.com/$REPO/releases/latest/download/$APPIMAGE"
 
 info "Downloading Voicetree..."
 TMPDIR=$(mktemp -d)

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,18 @@ curl -fsSL https://raw.githubusercontent.com/voicetreelab/voicetree/main/install
 Windows:
 https://github.com/voicetreelab/voicetree/releases/latest/download/voicetree.exe
 
+Docker (sandboxed — keeps agents off your host filesystem)
+```bash
+docker run -d --rm -p 6080:6080 \
+    -v voicetree-vault:/home/vt/vault \
+    -v voicetree-claude:/home/vt/.config/claude \
+    --shm-size=1g \
+    -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+    ghcr.io/voicetreelab/voicetree:latest
+# then open http://localhost:6080/vnc.html?autoconnect=1&resize=remote
+```
+See [`docker/README.md`](docker/README.md) for details. amd64 only for now.
+
 ---
 
 ## How It Works

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -43,6 +43,7 @@
     "electron-trackpad-detect": "file:native-modules/electron-trackpad-detect",
     "lightningcss-darwin-arm64": "^1.30.1",
     "lightningcss-darwin-x64": "^1.30.1",
+    "lightningcss-linux-arm64-gnu": "^1.30.1",
     "lightningcss-linux-x64-gnu": "^1.30.1",
     "lightningcss-win32-x64-msvc": "^1.30.1"
   },
@@ -229,7 +230,7 @@
     "linux": {
       "target": "AppImage",
       "icon": "build/icons",
-      "artifactName": "voicetree.${ext}"
+      "artifactName": "voicetree-${arch}.${ext}"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a native Linux arm64 build to the release matrix on `ubuntu-24.04-arm`, alongside the existing x86_64 build. Output is renamed `voicetree-x64.AppImage` / `voicetree-arm64.AppImage`. For backward compat the x64 AppImage is also re-uploaded under the legacy `voicetree.AppImage` name so existing consumers (`docker/Dockerfile` on `main`, `install.sh` in the wild, bookmarked URLs) keep working.

This is the **first half** of native Apple Silicon support. Once this lands and a release ships with the new arm64 AppImage, a follow-up PR will make the Docker image multi-arch so M-series Macs run a native arm64 container instead of emulated x86_64 under Rosetta. (That follow-up is parked locally on `dev-lochlan-phase2-backup`.)

## Safety / rollout notes

- arm64 Linux release build is marked `continue-on-error: true` for now — if `ubuntu-24.04-arm` or PyInstaller surfaces an issue on the first run, the x86_64 artifacts still ship and `publish-release` still finalizes. Flip it to `false` once a few releases are clean.
- Old `voicetree.AppImage` URL keeps working via the alias upload step. No external downloader is broken.

## Test plan

- [ ] PR CI passes (codebase health gate failure is pre-existing in `dev` from `saveNodePositions.test.ts`, unrelated to this PR)
- [ ] After merge + version bump, release pipeline succeeds on `ubuntu-latest` (x64 critical path)
- [ ] After merge + version bump, release pipeline succeeds on `ubuntu-24.04-arm` (arm64; allowed to fail without blocking release)
- [ ] Release assets contain `voicetree-x64.AppImage`, `voicetree-arm64.AppImage`, and `voicetree.AppImage` (legacy alias)
- [ ] `install.sh` on a Linux arm64 host (or `aarch64`) picks up `voicetree-arm64.AppImage` and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)