### PR TITLE
BF-348: daemon storm + stale-owner regression tests

### DIFF
--- a/packages/systems/graph-db-client/src/__tests__/fixtures/ensure-graphd-child.mjs
+++ b/packages/systems/graph-db-client/src/__tests__/fixtures/ensure-graphd-child.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Child-process helper for the BF-348 cross-process storm regression test.
+ *
+ * Invoked as:
+ *   node --import tsx <this> --vault <path> --bin "<command line>"
+ *     [--timeoutMs <n>] [--caller <CallerKind>]
+ *
+ * Calls `ensureGraphDaemonForVault` once and writes a single JSON line to
+ * stdout describing the outcome:
+ *
+ *   { "ok": true, "port": N, "pid": P, "ownerNonce": "...", "launched": true|false }
+ *   { "ok": false, "errorName": "...", "errorMessage": "..." }
+ *
+ * Exits 0 on success, 1 on any thrown error. The test harness reads the
+ * JSON line back to verify all child processes converged on the same owner.
+ *
+ * Note: the `.mjs` extension is a misnomer — this file uses TS-only syntax
+ * because the harness re-uses it through `node --import tsx`. Kept under
+ * fixtures/ alongside fake-vt-graphd.mjs so vitest does not treat it as a
+ * test file.
+ */
+
+import { ensureGraphDaemonForVault } from '@vt/graph-db-client'
+
+function arg(flag) {
+  const i = process.argv.indexOf(flag)
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : undefined
+}
+
+const vault = arg('--vault')
+const bin = arg('--bin')
+const timeoutMs = Number(arg('--timeoutMs') ?? '10000')
+const caller = arg('--caller') ?? 'electron'
+
+if (!vault || !bin) {
+  process.stderr.write('ensure-graphd-child: --vault and --bin required\n')
+  process.exit(2)
+}
+
+try {
+  const result = await ensureGraphDaemonForVault(vault, caller, {
+    bin,
+    timeoutMs,
+  })
+  process.stdout.write(
+    JSON.stringify({
+      ok: true,
+      port: result.port,
+      pid: result.pid,
+      ownerNonce: result.ownerNonce,
+      launched: result.launched,
+    }) + '\n',
+  )
+  process.exit(0)
+} catch (err) {
+  process.stdout.write(
+    JSON.stringify({
+      ok: false,
+      errorName: err?.name ?? 'Error',
+      errorMessage: err?.message ?? String(err),
+    }) + '\n',
+  )
+  process.exit(1)
+}

--- a/packages/systems/graph-db-client/src/__tests__/harness/ownerStormHarness.ts
+++ b/packages/systems/graph-db-client/src/__tests__/harness/ownerStormHarness.ts
@@ -1,0 +1,252 @@
+/**
+ * Shared black-box harness for BF-348 storm / stale / unsafe-owner regression
+ * tests. Built around three observable boundaries the protocol must respect:
+ *
+ *  - the on-disk owner record under `<vault>/.voicetree/graphd.owner.json`,
+ *  - the actual vt-graphd processes visible via `ps` matching `--vault X`,
+ *  - the recorded pid's liveness as seen by `kill(pid, 0)`.
+ *
+ * All helpers are POSIX (darwin/linux). No mocking of `ensureGraphDaemonForVault`
+ * internals — every assertion in callers must resolve to one of the boundaries
+ * above (CLAUDE.md black-box rule).
+ */
+
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  CONTRACT_VERSION,
+  isOwnerRecord,
+  type CommandFingerprint,
+  type OwnerRecord,
+} from '@vt/graph-db-protocol'
+
+export const FIXTURE_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'fixtures',
+)
+
+export const FAKE_BIN = join(FIXTURE_DIR, 'fake-vt-graphd.mjs')
+export const FAKE_BIN_COMMAND = `${process.execPath} ${FAKE_BIN}`
+export const OWNER_FILE = 'graphd.owner.json'
+
+export type Harness = {
+  vault: string
+  /** Externally-spawned children we created (innocent victims, helpers). */
+  spawned: ChildProcess[]
+  /**
+   * Daemon pids we did NOT spawn directly (e.g. produced by ensure() itself).
+   * We track them so afterEach can SIGKILL leftovers if the test failed.
+   */
+  externalDaemonPids: number[]
+}
+
+export async function createHarness(prefix = 'vt-graphd-bf348-'): Promise<Harness> {
+  const vault = await mkdtemp(join(tmpdir(), prefix))
+  await mkdir(join(vault, '.voicetree'), { recursive: true })
+  return { vault, spawned: [], externalDaemonPids: [] }
+}
+
+export async function destroyHarness(harness: Harness): Promise<void> {
+  for (const child of harness.spawned) {
+    if (child.pid) tryKill(child.pid, 'SIGKILL')
+  }
+  for (const pid of harness.externalDaemonPids) {
+    tryKill(pid, 'SIGKILL')
+  }
+  await rm(harness.vault, { recursive: true, force: true })
+}
+
+export function trackSpawn(harness: Harness, child: ChildProcess): ChildProcess {
+  harness.spawned.push(child)
+  return child
+}
+
+export function trackDaemonPid(harness: Harness, pid: number): void {
+  harness.externalDaemonPids.push(pid)
+}
+
+function tryKill(pid: number, signal: NodeJS.Signals | 0 = 'SIGKILL'): void {
+  try {
+    process.kill(pid, signal)
+  } catch {
+    // already gone
+  }
+}
+
+export async function readPersistedOwner(vault: string): Promise<OwnerRecord> {
+  const raw = await readFile(join(vault, '.voicetree', OWNER_FILE), 'utf8')
+  const parsed: unknown = JSON.parse(raw)
+  if (!isOwnerRecord(parsed)) {
+    throw new Error('owner record on disk did not satisfy OwnerRecord schema')
+  }
+  return parsed
+}
+
+export async function readPersistedOwnerOrNull(
+  vault: string,
+): Promise<OwnerRecord | null> {
+  try {
+    return await readPersistedOwner(vault)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw err
+  }
+}
+
+/**
+ * Atomically write a synthetic owner record. Used by tests to set up
+ * adversarial preconditions (stale dead pid, alive non-vt-graphd pid, etc.)
+ * — never to validate behavior. Validation happens by reading back through
+ * {@link readPersistedOwner} after the protocol has run.
+ */
+export async function writeOwnerRecord(
+  vault: string,
+  partial: Partial<OwnerRecord> & { pid: number; ownerNonce: string },
+): Promise<OwnerRecord> {
+  const canonicalVaultPath = resolve(vault)
+  const now = Date.now()
+  const record: OwnerRecord = {
+    schemaVersion: 1,
+    canonicalVaultPath,
+    pid: partial.pid,
+    ppid: partial.ppid ?? 0,
+    port: partial.port ?? null,
+    ownerNonce: partial.ownerNonce,
+    startedAtMs: partial.startedAtMs ?? now,
+    heartbeatAtMs: partial.heartbeatAtMs ?? now,
+    callerKind: partial.callerKind ?? 'test',
+    contractVersion: partial.contractVersion ?? CONTRACT_VERSION,
+    commandFingerprint: partial.commandFingerprint ?? {
+      executable: '/usr/bin/some-other-thing',
+      args: ['--unrelated'],
+    },
+  }
+  await writeFile(
+    join(vault, '.voicetree', OWNER_FILE),
+    `${JSON.stringify(record, null, 2)}\n`,
+    'utf8',
+  )
+  return record
+}
+
+/**
+ * A long-running Node child that ignores SIGTERM the same way a hung
+ * daemon would — used as the "innocent victim" pid in unsafe-owner tests.
+ *
+ * IMPORTANT: this child's command-line (`node -e 'setInterval(...)'`) does
+ * NOT match a vt-graphd command fingerprint. That's the point — the unsafe
+ * branch is supposed to refuse to kill it.
+ */
+export function spawnInnocentLongRunner(harness: Harness): ChildProcess {
+  const child = spawn(
+    process.execPath,
+    ['-e', 'setInterval(() => {}, 1e9)'],
+    { detached: true, stdio: 'ignore' },
+  )
+  child.unref()
+  return trackSpawn(harness, child)
+}
+
+export async function deadPid(): Promise<number> {
+  // Spawn-and-exit yields a pid we know to be reaped.
+  const child = spawn(process.execPath, ['-e', 'process.exit(0)'])
+  await new Promise<void>((res) => child.once('exit', () => res()))
+  if (!child.pid) throw new Error('unable to obtain reaped pid')
+  return child.pid
+}
+
+/**
+ * Count live vt-graphd-shaped processes whose `--vault` argument resolves
+ * to `vault`. Matches both the production `vt-graphd.mjs` / `.ts` entries
+ * AND the test fixture `fake-vt-graphd.mjs` — the protocol invariant we're
+ * locking in is "exactly one daemon child" regardless of which binary the
+ * harness happens to be exercising.
+ *
+ * The match is intentionally fingerprint-shaped (executable + --vault path),
+ * not pid-set-based: callers can return their result pid 100 times from a
+ * single-flight cache, but the kernel only knows the one real process.
+ */
+export function countDaemonProcessesForVault(vault: string): number {
+  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+    throw new Error(
+      `countDaemonProcessesForVault is POSIX-only, got ${process.platform}`,
+    )
+  }
+  const canonical = resolve(vault)
+  const result = spawnSync('ps', ['-A', '-o', 'pid=,command='], {
+    encoding: 'utf8',
+    timeout: 5000,
+  })
+  if (result.status !== 0 || !result.stdout) {
+    throw new Error(
+      `ps failed: status=${result.status} stderr=${result.stderr ?? ''}`,
+    )
+  }
+  let count = 0
+  for (const line of result.stdout.split('\n')) {
+    if (matchesDaemonLine(line, canonical)) count++
+  }
+  return count
+}
+
+/**
+ * Same as {@link countDaemonProcessesForVault} but returns the matching
+ * pids so callers can SIGKILL them if a test failed in the middle.
+ */
+export function listDaemonPidsForVault(vault: string): number[] {
+  if (process.platform !== 'darwin' && process.platform !== 'linux') return []
+  const canonical = resolve(vault)
+  const result = spawnSync('ps', ['-A', '-o', 'pid=,command='], {
+    encoding: 'utf8',
+    timeout: 5000,
+  })
+  if (result.status !== 0 || !result.stdout) return []
+  const pids: number[] = []
+  for (const line of result.stdout.split('\n')) {
+    if (!matchesDaemonLine(line, canonical)) continue
+    const pidStr = line.trim().split(/\s+/, 1)[0]
+    const pid = Number(pidStr)
+    if (Number.isInteger(pid) && pid > 0) pids.push(pid)
+  }
+  return pids
+}
+
+function matchesDaemonLine(line: string, canonicalVault: string): boolean {
+  if (!line) return false
+  // Match production vt-graphd.<ext> and the test fake-vt-graphd.<ext>
+  // entries; both must point at our canonical vault.
+  const re = /(vt-graphd|fake-vt-graphd)\.\w+\b.*--vault\s+(\S+)/
+  const match = re.exec(line)
+  if (!match) return false
+  return resolve(match[2]) === canonicalVault
+}
+
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ESRCH') return false
+    if (code === 'EPERM') return true
+    return false
+  }
+}
+
+/**
+ * Synthesize a command fingerprint that matches `node <FAKE_BIN> --vault X`,
+ * for tests that need the protocol to *successfully* identify a recorded
+ * owner as vt-graphd-shaped (e.g. stale-heartbeat-with-matching-fingerprint).
+ */
+export function fakeDaemonFingerprintFor(vault: string): CommandFingerprint {
+  return {
+    executable: process.execPath,
+    args: [FAKE_BIN, '--vault', resolve(vault)],
+  }
+}

--- a/packages/systems/graph-db-client/src/__tests__/stale-owner-reclaim.test.ts
+++ b/packages/systems/graph-db-client/src/__tests__/stale-owner-reclaim.test.ts
@@ -1,0 +1,126 @@
+/**
+ * BF-348 regression: stale dead-owner reclaim + multi-caller convergence.
+ *
+ * Scenario from the design (D4 stale reclaim + Migration step 7):
+ *
+ *   <vault>/.voicetree/graphd.owner.json points at a pid that is verifiably
+ *   dead (process previously exited, kill(pid, 0) → ESRCH). Many callers
+ *   race in. The protocol MUST:
+ *
+ *     1. Detect the staleness (dead pid) and remove the stale record.
+ *     2. Spawn at most ONE replacement vt-graphd child.
+ *     3. Converge ALL callers (the reclaimer plus 99 latecomers) onto that
+ *        one new healthy owner.
+ *
+ * This is the regression test for the "stale port, vault_not_open cascade"
+ * mode of the May 22 incident: many callers each thought they were the
+ * first to notice a dead daemon and would otherwise stampede the spawn
+ * path. Observability is via the actual `ps` process count and the on-disk
+ * owner record — never by inspecting protocol internals.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { ensureGraphDaemonForVault } from '../index.ts'
+import {
+  FAKE_BIN_COMMAND,
+  countDaemonProcessesForVault,
+  createHarness,
+  deadPid,
+  destroyHarness,
+  fakeDaemonFingerprintFor,
+  listDaemonPidsForVault,
+  readPersistedOwner,
+  trackDaemonPid,
+  writeOwnerRecord,
+  type Harness,
+} from './harness/ownerStormHarness.ts'
+
+let harness: Harness
+
+beforeEach(async () => {
+  harness = await createHarness('vt-graphd-bf348-stale-')
+})
+
+afterEach(async () => {
+  for (const pid of listDaemonPidsForVault(harness.vault)) {
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch {
+      // already gone
+    }
+  }
+  await destroyHarness(harness)
+})
+
+describe('BF-348 regression: stale dead-owner reclaim under storm', () => {
+  test(
+    'stale dead-pid owner + 100 concurrent callers → exactly one new daemon, all callers converge',
+    async () => {
+      const stalePid = await deadPid()
+      const staleNonce = 'stale-dead-pid-nonce-bf348'
+
+      await writeOwnerRecord(harness.vault, {
+        pid: stalePid,
+        port: null,
+        ownerNonce: staleNonce,
+        heartbeatAtMs: Date.now(),
+        // Matching fingerprint isn't required when pid is dead: the
+        // decision is 'stale-reclaim' on the dead-pid branch regardless,
+        // and we want the test to mirror what a real crashed daemon would
+        // leave behind — a record whose recorded fingerprint matches what
+        // vt-graphd would have written for itself.
+        commandFingerprint: fakeDaemonFingerprintFor(harness.vault),
+      })
+
+      const callCount = 100
+      const results = await Promise.all(
+        Array.from({ length: callCount }, () =>
+          ensureGraphDaemonForVault(harness.vault, 'electron', {
+            bin: FAKE_BIN_COMMAND,
+            timeoutMs: 10_000,
+          }),
+        ),
+      )
+
+      // (1) The stale nonce is gone — the on-disk record now reflects the
+      // freshly reclaimed owner.
+      const owner = await readPersistedOwner(harness.vault)
+      trackDaemonPid(harness, owner.pid)
+      expect(owner.ownerNonce).not.toBe(staleNonce)
+      expect(owner.pid).not.toBe(stalePid)
+      expect(owner.port).not.toBeNull()
+
+      // (2) Exactly ONE vt-graphd child visible to ps. The dead pid was
+      // never alive, so the count is the new daemon and nothing else.
+      const liveDaemonCount = countDaemonProcessesForVault(harness.vault)
+      expect(liveDaemonCount).toBe(1)
+
+      // (3) All 100 callers converge on the same new owner. The
+      // reclaimer's launched=true; all others either reused or finalised
+      // the in-flight spawn (launched=false). The CRITICAL invariant: every
+      // caller agrees on port/pid/nonce.
+      const ports = new Set(results.map((r) => r.port))
+      const pids = new Set(results.map((r) => r.pid))
+      const nonces = new Set(results.map((r) => r.ownerNonce))
+      expect(ports.size).toBe(1)
+      expect(pids.size).toBe(1)
+      expect(nonces.size).toBe(1)
+      expect([...pids][0]).toBe(owner.pid)
+      expect([...ports][0]).toBe(owner.port)
+      expect([...nonces][0]).toBe(owner.ownerNonce)
+
+      // (4) Sample-probe /health: the daemon reports the matching
+      // identity. (Health verification gates the protocol-side reuse
+      // decision, so this is what every caller is implicitly trusting.)
+      const sampleHealth = await Promise.all(
+        results.slice(0, 5).map((r) => r.client.health()),
+      )
+      for (const body of sampleHealth) {
+        expect(body.owner?.ownerNonce).toBe(owner.ownerNonce)
+        expect(body.owner?.port).toBe(owner.port)
+      }
+    },
+    30_000,
+  )
+})

--- a/packages/systems/graph-db-client/src/__tests__/storm-regression.test.ts
+++ b/packages/systems/graph-db-client/src/__tests__/storm-regression.test.ts
@@ -1,0 +1,247 @@
+/**
+ * BF-348 regression: May 22 fork-storm.
+ *
+ * On 2026-05-22 a single Electron process forked ~100 vaultless vt-graphd
+ * children when its in-module daemon guard collapsed under reload pressure.
+ * The single-owner protocol (BF-342→346) introduced two layered defenses:
+ *
+ *  1. An in-process single-flight (`inflightByVault`) that coalesces N
+ *     concurrent callers in the SAME Node process into one work loop.
+ *  2. A cross-process spawn lock (`graphd.spawn.lock`) that serialises the
+ *     spawn step across separate Node processes once `decideOwnerAction`
+ *     returns `claim`.
+ *
+ * The tests below assert observable invariants for BOTH layers:
+ *
+ *  - Test A: 100 concurrent `ensureGraphDaemonForVault` calls from one
+ *    process → exactly ONE vt-graphd child visible to `ps`.
+ *  - Test B: N concurrent `ensureGraphDaemonForVault` calls each in a
+ *    separate Node child → exactly ONE vt-graphd child visible to `ps`,
+ *    even though no caller shares in-process single-flight state.
+ *
+ * The "exactly ONE child" assertion is by command-fingerprint via `ps`,
+ * NOT by inspecting the result-set pid (a single-flight cache could
+ * deduplicate that without actually preventing spawns).
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { ensureGraphDaemonForVault } from '../index.ts'
+import {
+  FAKE_BIN,
+  FAKE_BIN_COMMAND,
+  countDaemonProcessesForVault,
+  createHarness,
+  destroyHarness,
+  listDaemonPidsForVault,
+  readPersistedOwner,
+  trackDaemonPid,
+  type Harness,
+} from './harness/ownerStormHarness.ts'
+
+const requireFromHere = createRequire(import.meta.url)
+const TSX_LOADER = requireFromHere.resolve('tsx')
+const ENSURE_CHILD = requireFromHere.resolve(
+  './fixtures/ensure-graphd-child.mjs',
+)
+
+let harness: Harness
+
+beforeEach(async () => {
+  harness = await createHarness('vt-graphd-bf348-storm-')
+})
+
+afterEach(async () => {
+  // Belt-and-braces: any vt-graphd we missed gets SIGKILLed via
+  // listDaemonPidsForVault before the temp vault is removed.
+  for (const pid of listDaemonPidsForVault(harness.vault)) {
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch {
+      // already gone
+    }
+  }
+  await destroyHarness(harness)
+})
+
+describe('BF-348 regression: May 22 fork-storm', () => {
+  test(
+    'in-process: 100 concurrent ensureGraphDaemonForVault calls produce exactly one vt-graphd child (May 22 fork-storm regression)',
+    async () => {
+      const callCount = 100
+
+      const results = await Promise.all(
+        Array.from({ length: callCount }, () =>
+          ensureGraphDaemonForVault(harness.vault, 'electron', {
+            bin: FAKE_BIN_COMMAND,
+            timeoutMs: 10_000,
+          }),
+        ),
+      )
+
+      // (1) Exactly ONE healthy owner record on disk — atomic IO read,
+      // not a function-call observation.
+      const owner = await readPersistedOwner(harness.vault)
+      trackDaemonPid(harness, owner.pid)
+      expect(owner.port).not.toBeNull()
+      expect(owner.canonicalVaultPath).toBe(resolve(harness.vault))
+
+      // (2) Exactly ONE listening port whose /health reports the matching
+      // ownerNonce. We probe the daemon directly via the returned client.
+      const health = await results[0].client.health()
+      expect(health.owner).not.toBeNull()
+      expect(health.owner?.ownerNonce).toBe(owner.ownerNonce)
+      expect(health.owner?.port).toBe(owner.port)
+
+      // (3) Exactly ONE vt-graphd child process visible to ps for this
+      // vault path. This is the direct fork-storm assertion: a single-flight
+      // cache could return identical pid/port to all 100 callers WITHOUT
+      // actually preventing spawns, so we count by command fingerprint.
+      const liveDaemonCount = countDaemonProcessesForVault(harness.vault)
+      expect(liveDaemonCount).toBe(1)
+
+      // (4) The 100 returned GraphDbClients all bind to that one port.
+      const ports = new Set(results.map((r) => r.port))
+      const pids = new Set(results.map((r) => r.pid))
+      const nonces = new Set(results.map((r) => r.ownerNonce))
+      expect(ports.size).toBe(1)
+      expect(pids.size).toBe(1)
+      expect(nonces.size).toBe(1)
+      expect([...ports][0]).toBe(owner.port)
+      expect([...pids][0]).toBe(owner.pid)
+
+      // (5) Every client truly hits the same daemon — probe a sample
+      // through the actual HTTP surface, not just the cached result.
+      const sampleHealth = await Promise.all(
+        results.slice(0, 10).map((r) => r.client.health()),
+      )
+      for (const body of sampleHealth) {
+        expect(body.vault).toBe(resolve(harness.vault))
+        expect(body.owner?.ownerNonce).toBe(owner.ownerNonce)
+        expect(body.owner?.port).toBe(owner.port)
+      }
+    },
+    30_000,
+  )
+
+  test(
+    'cross-process: N separate Node processes racing on the same vault produce exactly one vt-graphd child',
+    async () => {
+      // The in-process single-flight does not span Node processes; this
+      // test exercises the filesystem spawn lock + claim arbitration.
+      // 6 is chosen so the test finishes well under timeout but still
+      // races more than the OS-page-cache flush window for the lock file.
+      const processCount = 6
+      const childTimeoutMs = 12_000
+
+      const children = Array.from({ length: processCount }, () =>
+        spawnEnsureChild(harness.vault, childTimeoutMs),
+      )
+      const outcomes = await Promise.all(children.map(collectChildOutcome))
+
+      // Every child must have succeeded — none should have surfaced an
+      // OwnerWaitTimeoutError, UnsafeOwnerError, etc.
+      for (const outcome of outcomes) {
+        expect(outcome.ok).toBe(true)
+      }
+      const oks = outcomes.filter((o) => o.ok === true)
+      expect(oks).toHaveLength(processCount)
+
+      // (1) All N child processes returned the same port / pid / nonce.
+      const ports = new Set(oks.map((o) => o.port))
+      const pids = new Set(oks.map((o) => o.pid))
+      const nonces = new Set(oks.map((o) => o.ownerNonce))
+      expect(ports.size).toBe(1)
+      expect(pids.size).toBe(1)
+      expect(nonces.size).toBe(1)
+
+      // (2) Exactly ONE owner record on disk.
+      const owner = await readPersistedOwner(harness.vault)
+      trackDaemonPid(harness, owner.pid)
+      expect(owner.pid).toBe([...pids][0])
+      expect(owner.port).toBe([...ports][0])
+      expect(owner.ownerNonce).toBe([...nonces][0])
+
+      // (3) Exactly ONE vt-graphd child visible to ps for this vault.
+      const liveDaemonCount = countDaemonProcessesForVault(harness.vault)
+      expect(liveDaemonCount).toBe(1)
+
+      // (4) The cross-process invariant: at most ONE child reported
+      // `launched=true` (the winner of the spawn lock). The rest reused
+      // or waited.
+      const launchedCount = oks.filter((o) => o.launched).length
+      expect(launchedCount).toBeLessThanOrEqual(1)
+    },
+    45_000,
+  )
+})
+
+type ChildSuccess = {
+  readonly ok: true
+  readonly port: number
+  readonly pid: number
+  readonly ownerNonce: string
+  readonly launched: boolean
+}
+
+type ChildFailure = {
+  readonly ok: false
+  readonly errorName: string
+  readonly errorMessage: string
+}
+
+type ChildOutcome = ChildSuccess | ChildFailure
+
+function spawnEnsureChild(vault: string, timeoutMs: number): ChildProcess {
+  return spawn(
+    process.execPath,
+    [
+      '--import',
+      TSX_LOADER,
+      ENSURE_CHILD,
+      '--vault',
+      vault,
+      '--bin',
+      FAKE_BIN_COMMAND,
+      '--timeoutMs',
+      String(timeoutMs),
+      '--caller',
+      'electron',
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  )
+}
+
+async function collectChildOutcome(child: ChildProcess): Promise<ChildOutcome> {
+  const stdoutChunks: Buffer[] = []
+  const stderrChunks: Buffer[] = []
+  child.stdout?.on('data', (chunk: Buffer) => stdoutChunks.push(chunk))
+  child.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+
+  const exitCode = await new Promise<number | null>((res) => {
+    child.once('exit', (code) => res(code))
+  })
+
+  const stdout = Buffer.concat(stdoutChunks).toString('utf8').trim()
+  const stderr = Buffer.concat(stderrChunks).toString('utf8').trim()
+  const lastLine = stdout.split('\n').filter((l) => l.length > 0).at(-1)
+  if (!lastLine) {
+    return {
+      ok: false,
+      errorName: 'NoOutput',
+      errorMessage: `child exited ${exitCode}, stderr=${stderr}`,
+    }
+  }
+  try {
+    return JSON.parse(lastLine) as ChildOutcome
+  } catch {
+    return {
+      ok: false,
+      errorName: 'BadJson',
+      errorMessage: `unparseable line: ${lastLine} (stderr=${stderr})`,
+    }
+  }
+}

--- a/packages/systems/graph-db-client/src/__tests__/unsafe-owner-refusal.test.ts
+++ b/packages/systems/graph-db-client/src/__tests__/unsafe-owner-refusal.test.ts
@@ -1,0 +1,197 @@
+/**
+ * BF-348 regression: unsafe-owner refusal and lock-without-port no-fanout.
+ *
+ * Two adversarial preconditions, both about a recorded owner that ISN'T
+ * the healthy vt-graphd it claims to be:
+ *
+ *   (A) An alive pid whose command-line is NOT a vt-graphd invocation
+ *       (an "innocent victim" pid — could be any unrelated long-running
+ *       Node process). Heartbeat is stale.
+ *
+ *       The protocol MUST refuse to reclaim (UnsafeOwnerError /
+ *       fingerprint-mismatch) and MUST NOT SIGTERM/SIGKILL that pid.
+ *
+ *   (B) An alive pid AND port=null AND heartbeat fresh.
+ *
+ *       The protocol MUST wait with bounded backoff and surface
+ *       OwnerWaitTimeoutError. Many concurrent callers MUST NOT each
+ *       spawn a vt-graphd child — `ps` must see zero new daemons for the
+ *       vault while every caller is waiting.
+ *
+ * Both scenarios were latent risks behind the May 22 incident's "many
+ * vt-graphd children, vault_not_open cascade" failure mode.
+ */
+
+import { resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { ensureGraphDaemonForVault, OwnerWaitTimeoutError, UnsafeOwnerError } from '../index.ts'
+import {
+  FAKE_BIN_COMMAND,
+  countDaemonProcessesForVault,
+  createHarness,
+  destroyHarness,
+  isProcessAlive,
+  listDaemonPidsForVault,
+  readPersistedOwner,
+  spawnInnocentLongRunner,
+  type Harness,
+  writeOwnerRecord,
+} from './harness/ownerStormHarness.ts'
+
+let harness: Harness
+
+beforeEach(async () => {
+  harness = await createHarness('vt-graphd-bf348-unsafe-')
+})
+
+afterEach(async () => {
+  // Belt-and-braces cleanup: any vt-graphd we somehow spawned for this
+  // vault gets SIGKILLed before the temp directory is removed. (These
+  // tests are precisely about NOT spawning, so this should be a no-op
+  // when tests pass.)
+  for (const pid of listDaemonPidsForVault(harness.vault)) {
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch {
+      // already gone
+    }
+  }
+  await destroyHarness(harness)
+})
+
+describe('BF-348 regression: unsafe-owner pid refusal', () => {
+  test(
+    'alive innocent pid + non-matching command fingerprint + stale heartbeat → UnsafeOwnerError, pid NOT killed, NO daemon spawned',
+    async () => {
+      const innocent = spawnInnocentLongRunner(harness)
+      const innocentPid = innocent.pid
+      expect(innocentPid).toBeDefined()
+      if (!innocentPid) throw new Error('innocent child failed to spawn')
+
+      // A pid that's alive but whose command-line is `node -e setInterval(...)` —
+      // does NOT match the vt-graphd command fingerprint we record below.
+      // Combined with a stale heartbeat that's far older than the default
+      // 15s staleHeartbeatMs, the protocol routes to unsafe-owner with
+      // reason 'fingerprint-mismatch'.
+      const staleHeartbeat = Date.now() - 60_000
+      const recordedNonce = 'unsafe-fingerprint-nonce'
+      await writeOwnerRecord(harness.vault, {
+        pid: innocentPid,
+        port: null,
+        ownerNonce: recordedNonce,
+        heartbeatAtMs: staleHeartbeat,
+        startedAtMs: staleHeartbeat,
+        // Recorded fingerprint that simulates what a real vt-graphd would
+        // have written for itself — the LIVE command-line is `node -e ...`
+        // and won't match, which is precisely what triggers fingerprint-
+        // mismatch.
+        commandFingerprint: {
+          executable: process.execPath,
+          args: ['/opt/voicetree/vt-graphd.mjs', '--vault', resolve(harness.vault)],
+        },
+      })
+
+      // Snapshot: zero vt-graphd processes for this vault before the call.
+      expect(countDaemonProcessesForVault(harness.vault)).toBe(0)
+
+      await expect(
+        ensureGraphDaemonForVault(harness.vault, 'electron', {
+          bin: FAKE_BIN_COMMAND,
+          timeoutMs: 2_000,
+        }),
+      ).rejects.toBeInstanceOf(UnsafeOwnerError)
+
+      // (1) The innocent pid is STILL ALIVE — the protocol did not
+      // SIGTERM/SIGKILL it. This is the load-bearing assertion: a real
+      // user process should never be killed because of a stale owner
+      // record.
+      expect(isProcessAlive(innocentPid)).toBe(true)
+
+      // (2) NO new vt-graphd child was spawned. Unsafe-owner means
+      // "refuse, do not respawn".
+      expect(countDaemonProcessesForVault(harness.vault)).toBe(0)
+
+      // (3) The owner record on disk is untouched — reclaim was refused
+      // safely; the operator's stale record is preserved for diagnosis.
+      const owner = await readPersistedOwner(harness.vault)
+      expect(owner.pid).toBe(innocentPid)
+      expect(owner.ownerNonce).toBe(recordedNonce)
+    },
+    10_000,
+  )
+})
+
+describe('BF-348 regression: lock-without-port does not fan out', () => {
+  test(
+    'alive in-flight owner (port=null, fresh heartbeat) with 50 concurrent callers → all wait + OwnerWaitTimeoutError, ZERO daemons spawned, in-flight pid untouched',
+    async () => {
+      // The "lock-without-port" condition: an owner claim exists, the
+      // recorded pid is alive, but no port has been bound yet (port=null).
+      // With a fresh heartbeat the protocol decision is `wait` — even
+      // when the live command-line does not look like vt-graphd, because
+      // fingerprint is only consulted on the stale-heartbeat branch.
+      const inflight = spawnInnocentLongRunner(harness)
+      const inflightPid = inflight.pid
+      if (!inflightPid) throw new Error('inflight child failed to spawn')
+
+      await writeOwnerRecord(harness.vault, {
+        pid: inflightPid,
+        port: null,
+        ownerNonce: 'in-flight-nonce',
+        heartbeatAtMs: Date.now(),
+        startedAtMs: Date.now(),
+        // Non-vt-graphd fingerprint is FINE here: a fresh heartbeat
+        // routes to `wait` before the fingerprint branch is even reached.
+        commandFingerprint: {
+          executable: process.execPath,
+          args: ['-e', 'setInterval(() => {}, 1e9)'],
+        },
+      })
+
+      const callerCount = 50
+      const start = Date.now()
+      const settled = await Promise.allSettled(
+        Array.from({ length: callerCount }, () =>
+          ensureGraphDaemonForVault(harness.vault, 'electron', {
+            bin: FAKE_BIN_COMMAND,
+            timeoutMs: 600,
+          }),
+        ),
+      )
+      const elapsed = Date.now() - start
+
+      // (1) Every single caller surfaced OwnerWaitTimeoutError. None
+      // succeeded (no daemon was ever produced), none surfaced
+      // UnsafeOwnerError (fingerprint is only checked under stale
+      // heartbeat).
+      for (const outcome of settled) {
+        expect(outcome.status).toBe('rejected')
+        if (outcome.status === 'rejected') {
+          expect(outcome.reason).toBeInstanceOf(OwnerWaitTimeoutError)
+        }
+      }
+
+      // The timeout was 600ms — wall-clock should be at least that, and
+      // bounded by a sensible upper limit so we know we actually waited
+      // rather than bypassing the wait loop.
+      expect(elapsed).toBeGreaterThanOrEqual(500)
+      expect(elapsed).toBeLessThan(5_000)
+
+      // (2) ZERO vt-graphd children visible to ps. This is the
+      // anti-fork-storm invariant: 50 callers all noticed the
+      // unhealthy owner and not ONE of them spawned a child.
+      expect(countDaemonProcessesForVault(harness.vault)).toBe(0)
+
+      // (3) The in-flight pid is still alive — wait does not kill.
+      expect(isProcessAlive(inflightPid)).toBe(true)
+
+      // (4) Owner record is intact (still the original in-flight claim).
+      const owner = await readPersistedOwner(harness.vault)
+      expect(owner.pid).toBe(inflightPid)
+      expect(owner.ownerNonce).toBe('in-flight-nonce')
+      expect(owner.port).toBeNull()
+    },
+    15_000,
+  )
+})


### PR DESCRIPTION
## Summary

Locks in the single-owner-daemon protocol invariants (BF-342..346, merged via PR #90) against the failure classes from the May 22 fork-storm incident. All assertions are observable boundaries (on-disk owner record, `ps` process count, `kill(pid, 0)` liveness, HTTP `/health` body) — no internal call observation, no mocking of ensure internals.

### New tests in `packages/systems/graph-db-client/src/__tests__/`

- `storm-regression.test.ts`
  - **In-process**: 100 concurrent `ensureGraphDaemonForVault` calls → exactly 1 vt-graphd child by `ps` command-fingerprint count. **Direct regression for the May 22 fork-storm.**
  - **Cross-process**: 6 separate Node processes racing → exactly 1 vt-graphd child via the filesystem spawn lock from BF-344.
- `stale-owner-reclaim.test.ts`
  - Stale dead-pid owner record + 100 concurrent callers → exactly 1 new daemon, all 100 callers converge.
- `unsafe-owner-refusal.test.ts`
  - Alive innocent pid + non-vt-graphd command fingerprint + stale heartbeat → `UnsafeOwnerError`, pid NOT killed, ZERO daemons spawned.
  - Lock-without-port (port=null, fresh heartbeat) with 50 concurrent callers → all wait + `OwnerWaitTimeoutError`, ZERO daemons spawned.

### Shared harness — `__tests__/harness/ownerStormHarness.ts`
Factors out the observable primitives: temp-vault setup, ps-based `countDaemonProcessesForVault` (matches both production `vt-graphd` and fixture `fake-vt-graphd` by argv), spawn-fixture lifecycle.

### Fixture — `__tests__/fixtures/ensure-graphd-child.mjs`
Real Node child process invoking `ensureGraphDaemonForVault` for the cross-process race scenarios.

## Test plan
- [ ] `npm --workspace @vt/graph-db-client run test` passes locally
- [ ] No flakes across 5 consecutive runs (the 100-concurrent and 50-wait scenarios are timing-sensitive)
- [ ] CI green

## Honesty
Dan (the agent that wrote these) didn't open the PR or write a progress node before idling — Amy (orchestrator) is pushing this PR. Worth a review pass on the harness module-mutables and the timing windows in the wait scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)