### PR TITLE
refactor(measures/_shared): add walk-directories primitive

### DIFF
--- a/packages/measures/src/_shared/walk-directories.test.ts
+++ b/packages/measures/src/_shared/walk-directories.test.ts
@@ -1,0 +1,81 @@
+import {mkdtemp, mkdir, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join, relative} from 'node:path'
+import {afterEach, describe, expect, it} from 'vitest'
+import {walkDirectories} from './walk-directories'
+
+const tmpRoots: string[] = []
+
+describe('walkDirectories', () => {
+    afterEach(async () => {
+        await Promise.all(tmpRoots.splice(0).map(root => rm(root, {recursive: true, force: true})))
+    })
+
+    it('returns a deterministic tree of directories and entries', async () => {
+        const root = await createTmpRoot()
+        await mkdir(join(root, 'z-dir'))
+        await mkdir(join(root, 'a-dir', 'nested'), {recursive: true})
+        await writeFile(join(root, 'b.ts'), '')
+        await writeFile(join(root, 'a-dir', 'nested', 'c.tsx'), '')
+
+        const walked = await walkDirectories(root)
+
+        expect(summarizeWalk(root, walked)).toEqual([
+            {
+                directory: '.',
+                entries: ['directory:a-dir', 'file:b.ts', 'directory:z-dir'],
+            },
+            {
+                directory: 'a-dir',
+                entries: ['directory:a-dir/nested'],
+            },
+            {
+                directory: 'a-dir/nested',
+                entries: ['file:a-dir/nested/c.tsx'],
+            },
+            {
+                directory: 'z-dir',
+                entries: [],
+            },
+        ])
+    })
+
+    it('filters entries before reporting or descending into them', async () => {
+        const root = await createTmpRoot()
+        await mkdir(join(root, 'keep'))
+        await mkdir(join(root, 'skip'))
+        await writeFile(join(root, 'keep', 'included.ts'), '')
+        await writeFile(join(root, 'skip', 'excluded.ts'), '')
+
+        const walked = await walkDirectories(root, {
+            includeEntry: entry => entry.name !== 'skip',
+        })
+
+        expect(summarizeWalk(root, walked)).toEqual([
+            {
+                directory: '.',
+                entries: ['directory:keep'],
+            },
+            {
+                directory: 'keep',
+                entries: ['file:keep/included.ts'],
+            },
+        ])
+    })
+})
+
+async function createTmpRoot(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'walk-directories-'))
+    tmpRoots.push(root)
+    return root
+}
+
+function summarizeWalk(
+    root: string,
+    walked: Awaited<ReturnType<typeof walkDirectories>>,
+): Array<{directory: string; entries: string[]}> {
+    return walked.map(directory => ({
+        directory: relative(root, directory.absolutePath) || '.',
+        entries: directory.entries.map(entry => `${entry.kind}:${relative(root, entry.absolutePath)}`),
+    }))
+}

--- a/packages/measures/src/_shared/walk-directories.ts
+++ b/packages/measures/src/_shared/walk-directories.ts
@@ -1,0 +1,46 @@
+import {readdir} from 'node:fs/promises'
+import {join} from 'node:path'
+
+export type WalkDirectoryEntryKind = 'directory' | 'file' | 'other'
+
+export type WalkDirectoryEntry = {
+    readonly name: string
+    readonly absolutePath: string
+    readonly kind: WalkDirectoryEntryKind
+}
+
+export type WalkedDirectory = {
+    readonly absolutePath: string
+    readonly entries: readonly WalkDirectoryEntry[]
+}
+
+export type WalkDirectoriesOptions = {
+    readonly includeEntry?: (entry: WalkDirectoryEntry) => boolean
+}
+
+export async function walkDirectories(
+    root: string,
+    options: WalkDirectoriesOptions = {},
+): Promise<readonly WalkedDirectory[]> {
+    const entries = (await readdir(root, {withFileTypes: true}))
+        .map(entry => ({
+            name: entry.name,
+            absolutePath: join(root, entry.name),
+            kind: walkDirectoryEntryKind(entry),
+        }))
+        .filter(options.includeEntry ?? (() => true))
+        .sort((a, b) => a.name.localeCompare(b.name))
+
+    const nested = await Promise.all(entries.map(entry => {
+        if (entry.kind !== 'directory') return Promise.resolve([])
+        return walkDirectories(entry.absolutePath, options)
+    }))
+
+    return [{absolutePath: root, entries}, ...nested.flat()]
+}
+
+function walkDirectoryEntryKind(entry: {isDirectory(): boolean; isFile(): boolean}): WalkDirectoryEntryKind {
+    if (entry.isDirectory()) return 'directory'
+    if (entry.isFile()) return 'file'
+    return 'other'
+}


### PR DESCRIPTION
## Summary
- Adds `walkDirectories` — a pure, deterministic, recursive directory walker — under `packages/measures/src/_shared/`
- Includes a hermetic test (tmpfs roots, deterministic sort, filter via `includeEntry`)
- Salvaged from `wt-walk-directories` (`3dbf2dd1`), whose other changes collided with dev-manu's `_shared/` reshuffle (`fd9f53d1`); only the primitive + test were lifted

## Follow-up (not in this PR)
- Wire `discovery/function-discovery.ts` `listProductionSources` to use `walkDirectories` (still has the inline walker dev-manu shipped pre-reshuffle)

## Test plan
- [x] Deterministic tree-ordering test
- [x] `includeEntry` filter test (skips dir before descending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)