### PR TITLE
Test generated measures workflow trigger

### DIFF
--- a/packages/measures/scratch/generated-workflow-smoke.txt
+++ b/packages/measures/scratch/generated-workflow-smoke.txt
@@ -1,0 +1,4 @@
+Generated measures workflow smoke trigger.
+
+This file exists only to make a pull request touch packages/measures/**.
+


### PR DESCRIPTION
This PR intentionally touches packages/measures/** with a tiny scratch marker so the generated measures workflow runs on a real pull_request event after PR #107 merged.\n\nExpected validation:\n- Generated Measures Budget Gate workflow starts because of the packages/measures/** path filter.\n- Generated workflow reaches and passes budget-gate.\n\nNo product behavior changes.