### PR TITLE
fix(measures): properly budget tier-4 mutation, fix precheck staleness

### DIFF
--- a/.github/workflows/measures-budget-gate.yml
+++ b/.github/workflows/measures-budget-gate.yml
@@ -26,7 +26,10 @@ jobs:
           LARGE_FLOOR: 1000
           PR_NUMBER: "${{ github.event.pull_request.number }}"
           REPO: "${{ github.repository }}"
+          RUN_PAGE_SIZE: 20
           STALE_DAYS: 7
+          TIER_4_JOB_NAME: tier-4-analyzers
+          WORKFLOW_FILE: measures-budget-gate.yml
         run: |
           set -euo pipefail
           ADDED=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.additions // 0')
@@ -48,21 +51,24 @@ jobs:
           fi
 
           LAST=""
-          for sha in $(gh api "repos/$REPO/commits?sha=main&per_page=100" --jq '.[].sha'); do
-            LAST=$(gh api "repos/$REPO/commits/$sha/check-runs" \
-                   --jq '.check_runs[] | select(.name=="Main CI / Full" and .conclusion=="success") | .completed_at' \
-                   | head -n1)
-            [ -n "$LAST" ] && break
+          for run_id in $(gh api "repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?status=success&per_page=$RUN_PAGE_SIZE" --jq '.workflow_runs[].id'); do
+            done_at=$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" \
+                      --jq ".jobs[] | select(.name==\"$TIER_4_JOB_NAME\" and .conclusion==\"success\") | .completed_at" \
+                      | head -n1)
+            if [ -n "$done_at" ]; then
+              LAST="$done_at"
+              break
+            fi
           done
 
           if [ -z "$LAST" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
-            echo "reason=no successful Main CI / Full found on main in last 100 commits" >> "$GITHUB_OUTPUT"
+            echo "reason=no successful $TIER_4_JOB_NAME found in last $RUN_PAGE_SIZE workflow runs" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           AGE_DAYS=$(( ( $(date +%s) - $(date -d "$LAST" +%s) ) / 86400 ))
-          echo "last successful Main CI / Full on main: $LAST (${AGE_DAYS}d ago)"
+          echo "last successful $TIER_4_JOB_NAME: $LAST (${AGE_DAYS}d ago)"
           if [ "$AGE_DAYS" -gt "$STALE_DAYS" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "reason=stale (${AGE_DAYS}d > ${STALE_DAYS}d) and PR is $ADDED lines" >> "$GITHUB_OUTPUT"

--- a/packages/measures/scripts/gen-workflows/precheck-job.ts
+++ b/packages/measures/scripts/gen-workflows/precheck-job.ts
@@ -1,9 +1,19 @@
-// Tier-4 precheck job. PR size + freshness of the last successful nightly
-// Tier-4 carrier together gate Tier 4 on PRs into main.
+// Tier-4 precheck job. Gates Tier 4 on PRs by PR size and the freshness of
+// the last successful Tier-4 run anywhere on this workflow.
+//
+// Freshness query: this workflow only fires on pull_request, so commit-keyed
+// check-runs against main never carry a `tier-4-analyzers` entry. Instead we
+// page recent successful runs of this workflow and look for the most recent
+// one whose `tier-4-analyzers` job concluded success (skipped runs don't
+// count). That timestamp is the staleness signal.
 
 import type {WorkflowSpec} from '../../src/checks/_workflow-types.ts'
 
 import type {Job} from './_types.ts'
+
+const WORKFLOW_FILE = 'measures-budget-gate.yml'
+const TIER_4_JOB_NAME = 'tier-4-analyzers'
+const RUN_PAGE_SIZE = 20
 
 export function precheckJob(jobId: string, trigger: WorkflowSpec['trigger']): Job {
     const decideScript = [
@@ -27,21 +37,24 @@ export function precheckJob(jobId: string, trigger: WorkflowSpec['trigger']): Jo
         'fi',
         '',
         'LAST=""',
-        'for sha in $(gh api "repos/$REPO/commits?sha=main&per_page=100" --jq \'.[].sha\'); do',
-        '  LAST=$(gh api "repos/$REPO/commits/$sha/check-runs" \\',
-        '         --jq \'.check_runs[] | select(.name=="Main CI / Full" and .conclusion=="success") | .completed_at\' \\',
-        '         | head -n1)',
-        '  [ -n "$LAST" ] && break',
+        `for run_id in $(gh api "repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?status=success&per_page=$RUN_PAGE_SIZE" --jq '.workflow_runs[].id'); do`,
+        '  done_at=$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" \\',
+        '            --jq ".jobs[] | select(.name==\\"$TIER_4_JOB_NAME\\" and .conclusion==\\"success\\") | .completed_at" \\',
+        '            | head -n1)',
+        '  if [ -n "$done_at" ]; then',
+        '    LAST="$done_at"',
+        '    break',
+        '  fi',
         'done',
         '',
         'if [ -z "$LAST" ]; then',
         '  echo "should_run=true" >> "$GITHUB_OUTPUT"',
-        '  echo "reason=no successful Main CI / Full found on main in last 100 commits" >> "$GITHUB_OUTPUT"',
+        `  echo "reason=no successful $TIER_4_JOB_NAME found in last $RUN_PAGE_SIZE workflow runs" >> "$GITHUB_OUTPUT"`,
         '  exit 0',
         'fi',
         '',
         'AGE_DAYS=$(( ( $(date +%s) - $(date -d "$LAST" +%s) ) / 86400 ))',
-        'echo "last successful Main CI / Full on main: $LAST (${AGE_DAYS}d ago)"',
+        `echo "last successful $TIER_4_JOB_NAME: $LAST (\${AGE_DAYS}d ago)"`,
         'if [ "$AGE_DAYS" -gt "$STALE_DAYS" ]; then',
         '  echo "should_run=true" >> "$GITHUB_OUTPUT"',
         '  echo "reason=stale (${AGE_DAYS}d > ${STALE_DAYS}d) and PR is $ADDED lines" >> "$GITHUB_OUTPUT"',
@@ -70,6 +83,9 @@ export function precheckJob(jobId: string, trigger: WorkflowSpec['trigger']): Jo
                     GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
                     REPO: '${{ github.repository }}',
                     PR_NUMBER: '${{ github.event.pull_request.number }}',
+                    WORKFLOW_FILE,
+                    TIER_4_JOB_NAME,
+                    RUN_PAGE_SIZE: String(RUN_PAGE_SIZE),
                     LARGE_FLOOR: '1000',
                     LARGE_CEILING: '10000',
                     STALE_DAYS: '7',

--- a/packages/measures/src/checks/_types.ts
+++ b/packages/measures/src/checks/_types.ts
@@ -20,6 +20,10 @@ export type CheckDef = {
 
 const e2eTimeoutMs = 30 * 60 * 1000
 
+// Stryker on a full package routinely needs 30–90 minutes. Mutation testing
+// gets its own budget so the e2e ceiling doesn't silently terminate it.
+const mutationTimeoutMs = 2 * 60 * 60 * 1000
+
 const npmRun = (name: string, extras: readonly string[] = []): string[] =>
     ['npm', 'run', name, ...(extras.length ? ['--', ...extras] : [])]
 
@@ -39,6 +43,7 @@ const playwrightJsonArgs = (): string[] => ['--reporter=json']
 
 export const checkArgs = {
     e2eTimeoutMs,
+    mutationTimeoutMs,
     npmRun,
     npmExec,
     npmWorkspaceRun,

--- a/packages/measures/src/checks/tier_4/analyzers/mutation-graph-model.ts
+++ b/packages/measures/src/checks/tier_4/analyzers/mutation-graph-model.ts
@@ -2,10 +2,10 @@ import {checkArgs, type CheckDef} from '../../_types.ts'
 
 export const check: CheckDef = {
     id: 'mutation-graph-model',
-    name: 'Mutation Testing — graph-model smoke (Stryker, break=70%)',
+    name: 'Mutation Testing — graph-model (Stryker, break=70%)',
     category: 'Other',
-    display: 'npm --workspace @vt/graph-model run test:mutation:smoke',
-    args: () => checkArgs.npmWorkspaceRun('@vt/graph-model', 'test:mutation:smoke'),
+    display: 'npm --workspace @vt/graph-model run test:mutation',
+    args: () => checkArgs.npmWorkspaceRun('@vt/graph-model', 'test:mutation'),
     parser: 'none',
-    timeoutMs: checkArgs.e2eTimeoutMs,
+    timeoutMs: checkArgs.mutationTimeoutMs,
 }

--- a/packages/measures/src/checks/tier_4/analyzers/mutation-graph-state.ts
+++ b/packages/measures/src/checks/tier_4/analyzers/mutation-graph-state.ts
@@ -2,10 +2,10 @@ import {checkArgs, type CheckDef} from '../../_types.ts'
 
 export const check: CheckDef = {
     id: 'mutation-graph-state',
-    name: 'Mutation Testing — graph-state smoke (Stryker, break=85%)',
+    name: 'Mutation Testing — graph-state (Stryker, break=65%)',
     category: 'Other',
-    display: 'npm --workspace @vt/graph-state run test:mutation:smoke',
-    args: () => checkArgs.npmWorkspaceRun('@vt/graph-state', 'test:mutation:smoke'),
+    display: 'npm --workspace @vt/graph-state run test:mutation',
+    args: () => checkArgs.npmWorkspaceRun('@vt/graph-state', 'test:mutation'),
     parser: 'none',
-    timeoutMs: checkArgs.e2eTimeoutMs,
+    timeoutMs: checkArgs.mutationTimeoutMs,
 }


### PR DESCRIPTION
## Summary

Two related tier-4 bugs surfaced during PR #115's CI scramble:

1. **Mutation timeout too short.** Both mutation CheckDefs were reusing `checkArgs.e2eTimeoutMs` (30 min). Full-package Stryker routinely needs 30–90 min, so `tier-4-analyzers` was SIGTERM'd at exactly 30:01 on PR #115 — the temporary workaround in e2eb718f narrowed mutation to a 3-file smoke surface. This PR restores full coverage and gives mutation its own 2h budget via a new `checkArgs.mutationTimeoutMs`.

2. **Precheck staleness query was structurally broken.** It looked for `name=="Main CI / Full"` on recent main commits. This workflow only `pull_request`-triggers, so no main commit ever has a `tier-4-analyzers` check-run, and the query silently returned empty on every PR — falling through to the "no successful Main CI / Full found" branch and unconditionally setting `should_run=true`. PR #115 ran tier-4 because of this bug, not because it was >10k lines (it's 7528). Replaced with a workflow-runs query: pages recent successful runs of this workflow and finds the most recent one whose `tier-4-analyzers` job concluded success (skipped runs don't count). Confirmed against the live API.

## Validation

- `workflows-drift.test.ts` (9 tests) passes — regenerated yaml round-trips.
- Pre-commit tier-0 (lint + policy + static) and pre-push tier-1 (typecheck, systems-health, orange-gate, structure) all green.
- Live `gh api repos/voicetreelab/voicetree/actions/workflows/measures-budget-gate.yml/runs?status=success` returns expected data.

## Test plan

- [ ] Merge into `dev-manu` so PR #115 picks it up.
- [ ] Watch the next PR #115 push for the precheck log line `last successful tier-4-analyzers: ... (Xd ago)` — confirms the new query is wired.
- [ ] Tier-4 mutation timing: the first PR ≥1k lines after merge will exercise the new 2h budget on full Stryker. Expected wall-clock: 30–60 min for graph-model + graph-state combined.