### PR TITLE
fix(devbox): ignore Stryker temp sandboxes

### DIFF
--- a/get_dev_healthy/mutagen-vt-remote.yml
+++ b/get_dev_healthy/mutagen-vt-remote.yml
@@ -8,6 +8,7 @@ sync:
       paths:
         - "**/node_modules"
         - "**/.node_modules-*"
+        - "**/.stryker-tmp"
         - "**/dist"
         - "**/dist-electron"
         - "**/dist-web"


### PR DESCRIPTION
## Summary
- add Mutagen ignore for Stryker temporary sandbox directories
- prevents one-way replica sync from deleting remote .stryker-tmp sandboxes during local-to-Onidel mutation runs

## Verification
- pre-commit tier-0 checks passed during commit
- pre-push tier-1 checks passed during push
- recreated vt-remote with the new ignore and confirmed live config includes **/.stryker-tmp
- ran @vt/graph-state incremental mutation against a 1-file setPan.ts touch; Stryker completed without the prior ENOENT sandbox crash