### PR TITLE
test(electron-e2e): migrate tier-2 specs off the BF-376-removed electronAPI surface

### DIFF
--- a/packages/measures/src/checks/tier_2/unit/webapp-unit.ts
+++ b/packages/measures/src/checks/tier_2/unit/webapp-unit.ts
@@ -8,4 +8,8 @@ export const check: CheckDef = {
     display: 'npm --workspace webapp exec -- vitest run',
     args: (jsonOut) => npmWorkspaceExec('webapp', 'vitest', 'run', ...vitestJsonArgs(jsonOut)),
     parser: 'vitest',
+    // The webapp suite contains tmux-backed fake-agent and daemon/CLI tests.
+    // Running it inside the tier-1 parallel pool contends with other tmux-heavy
+    // checks and causes real agent panes to time out under load.
+    exclusive: true,
 }

--- a/packages/systems/vt-daemon/src/agent-runtime/spawn/spawnPlainTerminal.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/spawn/spawnPlainTerminal.ts
@@ -11,6 +11,9 @@ import type {VTSettings} from '@vt/graph-model/settings';
 import {getNextAgentName, getUniqueAgentName} from '@vt/graph-model/settings';
 import {createTerminalData, type TerminalId} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/types.ts';
 import {getExistingAgentNames} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/index.ts';
+import {getTerminalManager} from '@vt/vt-daemon/agent-runtime/terminals/manager/terminal-manager-instance.ts';
+import {getRuntimeEnv} from '@vt/vt-daemon/agent-runtime/runtime/runtime-config.ts';
+import type {TerminalSpawnResult} from '@vt/vt-daemon-protocol';
 import * as O from 'fp-ts/lib/Option.js';
 import {loadSettings} from '@vt/app-config/settings';
 import type {TerminalData} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/types.ts';
@@ -61,6 +64,21 @@ export async function spawnPlainTerminal(nodeId: NodeIdAndFilePath, terminalCoun
     initialEnvVars: expandedEnvVars,
     agentName: agentName,
   });
+
+  // The renderer's xterm attaches via WebSocket to /terminals/:id/attach, which
+  // expects an EXISTING tmux session — the relay does not create one. Create
+  // the tmux session here BEFORE publishing terminal-ui-launch so the WS
+  // attach lands on a live session. Symmetrical with launchPreparedTerminal()
+  // on the spawnTerminalWithContextNode path.
+  const spawnResult: TerminalSpawnResult = await getTerminalManager().spawnTmuxBacked({
+    terminalData,
+    getToolsDirectory: () => getRuntimeEnv().getVtBinDir?.() ?? '',
+    onData: () => {},
+    onExit: () => {},
+  });
+  if (!spawnResult.success) {
+    throw new Error(`Failed to spawn tmux session for ${spawnResult.terminalId}: ${spawnResult.error}`);
+  }
 
   publishTerminalRegistryEvent({
     type: 'terminal-ui-launch',

--- a/scripts/run-remote.mjs
+++ b/scripts/run-remote.mjs
@@ -134,7 +134,13 @@ function repairLocalWorktreeMetadataIfNeeded({cwd = process.cwd()} = {}) {
 }
 
 function runLocal(cmd, args) {
-  const child = spawn(cmd, args, {stdio: 'inherit'})
+  const child = spawn(cmd, args, {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      [RECURSION_GUARD]: '1',
+    },
+  })
   child.on('exit', (code, signal) => {
     if (signal) process.kill(process.pid, signal)
     else process.exit(code ?? 1)

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-anchor-test-fixtures.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-anchor-test-fixtures.ts
@@ -113,6 +113,12 @@ export const test = base.extend<{
         MINIMIZE_TEST: "1",
         VOICETREE_PERSIST_STATE: "1",
         VT_GRAPHD_NODE_BIN: resolveGraphDaemonNodeBin(),
+        // Pin the daemon's app-support path to the temp user-data dir so it
+        // talks tmux on the same socket as the test (resolved from the same
+        // env). Without this, pinProcessAppSupportPath() in webapp main can
+        // race --user-data-dir resolution and the daemon ends up on
+        // /root/.voicetree/tmux.sock while the test polls a different socket.
+        VOICETREE_APP_SUPPORT: tempUserDataPath,
       },
       timeout: 60_000,
     });

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-child-node-title-overwrite.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-child-node-title-overwrite.spec.ts
@@ -135,17 +135,13 @@ const test = base.extend<{
     const window = await electronApp.firstWindow({ timeout: 15_000 });
     await window.waitForLoadState('domcontentloaded');
 
-    // Use startFileWatching directly (more reliable than clicking project button)
-    try {
-      await window.waitForSelector('text=Recent Projects', { timeout: 5_000 });
-      await window.locator('button:has-text("child-title-test")').first().click();
-    } catch {
-      await window.evaluate(async (vault: string) => {
-        const api = (window as unknown as ExtendedWindow).electronAPI;
-        if (!api) throw new Error('electronAPI not available');
-        await api.main.startFileWatching(vault);
-      }, projectRoot);
-    }
+    const openResult = await window.evaluate(async (vault: string) => {
+      const api = (window as unknown as ExtendedWindow).electronAPI;
+      if (!api) throw new Error('electronAPI not available');
+      const response = await api.main.openVault(vault);
+      return { writeFolder: response.writeFolder };
+    }, projectRoot);
+    expect(openResult.writeFolder, 'openVault returned no writeFolder').toBeTruthy();
 
     await pollForCytoscape(window, 15_000);
 

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-context-node-agent-fixtures.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-context-node-agent-fixtures.ts
@@ -60,6 +60,12 @@ export const test = base.extend<{
         ENABLE_PLAYWRIGHT_DEBUG: '0',
         VOICETREE_PERSIST_STATE: '1',
         VT_GRAPHD_NODE_BIN: resolveGraphDaemonNodeBin(),
+        // Pin the app-support path to the temp user-data dir so the daemon
+        // (a forked subprocess) reads the same settings.json the fixture
+        // pre-seeded. Without this override the parent shell's
+        // VOICETREE_APP_SUPPORT leaks into the test process and the daemon
+        // never sees the grep-probe agent.
+        VOICETREE_APP_SUPPORT: tempUserDataPath,
         // Fallback for runtime paths before the daemon has reported the
         // configured write folder.
         VOICETREE_VAULT_PATH: FIXTURE_VAULT_PATH,

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-context-node-agent-fixtures.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-context-node-agent-fixtures.ts
@@ -30,6 +30,19 @@ export const test = base.extend<{
       }
     }, null, 2), 'utf8');
 
+    // Pre-seed settings.json with the grep-probe agent registered so the
+    // daemon-side `resolveAgentCommand` accepts the spec's spawn command at
+    // first boot. A renderer-side `saveSettings` from the spec cannot reach
+    // the daemon's in-process settings cache (5 s TTL, separate process),
+    // so the agent registration must be on-disk before the daemon loads.
+    const settingsPath = path.join(tempUserDataPath, 'settings.json');
+    const grepAgentCommand = 'grep -o "SECRET_E2E_NEEDLE: [^ ]*" "$CONTEXT_NODE_PATH" | head -1';
+    await fs.writeFile(settingsPath, JSON.stringify({
+      agents: [{ name: 'E2E Context Probe', command: grepAgentCommand }],
+      defaultAgent: 'E2E Context Probe',
+      terminalSpawnPathRelativeToWatchedDirectory: '../',
+    }, null, 2), 'utf8');
+
     const ciFlags = process.env.CI
       ? ['--no-sandbox', '--disable-dev-shm-usage', '--use-gl=angle', '--use-angle=swiftshader']
       : [];

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-context-node-agent.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-context-node-agent.spec.ts
@@ -43,19 +43,23 @@ test.describe('Context Node Agent Terminal E2E', () => {
 
     const terminalShell = process.env.SHELL ?? (process.platform === 'win32' ? 'powershell.exe' : '/bin/bash');
 
-    await appWindow.evaluate(async (shell) => {
+    // The daemon-side `resolveAgentCommand` validates that the spawn request's
+    // agentCommand is one of `settings.agents[].command`. Register the grep
+    // probe as a named agent so the test's command is accepted.
+    await appWindow.evaluate(async ({ shell, command }) => {
       const api = (window as ExtendedWindow).electronAPI;
       if (!api) throw new Error('electronAPI not available');
 
-      // Get current settings and update them
       const currentSettings = await api.main.loadSettings();
       const updatedSettings = {
         ...currentSettings,
         terminalSpawnPathRelativeToWatchedDirectory: '../', // Launch from parent of watched directory
-        shell
+        shell,
+        agents: [{ name: 'E2E Context Probe', command }],
+        defaultAgent: 'E2E Context Probe',
       };
       await api.main.saveSettings(updatedSettings);
-    }, terminalShell);
+    }, { shell: terminalShell, command: agentCommand });
     console.log('✓ Agent command configured:', agentCommand);
 
     console.log('=== STEP 2: Wait for auto-load to complete (test vault: example_small) ===');
@@ -168,26 +172,20 @@ test.describe('Context Node Agent Terminal E2E', () => {
     console.log(`Context node absolute path: ${contextNodePath}`);
     console.log(`Initial spawn directory: ${initialSpawnDir}`);
 
-    const terminalId = `context-node-agent-e2e-${process.pid}-${Date.now()}`;
-
-    const spawnResult = await appWindow.evaluate(async ({ ctxNodeId, ctxNodePath, spawnDir, command, tId }) => {
+    // `spawnTerminalWithContextNode` reuses the context node when `taskNodeId`
+    // already references one, runs the registered agent command, and returns
+    // the daemon-assigned `terminalId` we use to locate the pipe-pane log.
+    const spawnResponse = await appWindow.evaluate(async ({ ctxNodeId, ctxNodePath, spawnDir, command }) => {
       const w = (window as ExtendedWindow);
       const api = w.electronAPI;
-      if (!api?.terminal) throw new Error('electronAPI.terminal not available');
+      if (!api) throw new Error('electronAPI not available');
 
-      return api.terminal.spawn({
-        type: 'Terminal' as const,
-        terminalId: tId,
-        attachedToContextNodeId: ctxNodeId,
+      return api.main.spawnTerminalWithContextNode({
+        taskNodeId: ctxNodeId,
+        agentCommand: command,
         terminalCount: 0,
-        title: 'Agent Terminal',
-        anchoredToNodeId: { _tag: 'None' } as { _tag: 'None' }, // fp-ts Option.none
-        shadowNodeDimensions: { width: 600, height: 400 },
-        resizable: true,
-        initialCommand: command,
-        executeCommand: true,
-        initialSpawnDirectory: spawnDir,
-        initialEnvVars: {
+        spawnDirectory: spawnDir,
+        envOverrides: {
           CONTEXT_NODE_PATH: ctxNodePath,
           CLAUDE_CODE_ENABLE_TELEMETRY: '1',
           OTEL_METRICS_EXPORTER: 'otlp',
@@ -195,23 +193,11 @@ test.describe('Context Node Agent Terminal E2E', () => {
           OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
           OTEL_METRIC_EXPORT_INTERVAL: '1000',
         },
-        isPinned: true,
-        isDone: false,
-        lifecycle: 'spawning' as const,
-        lastOutputTime: Date.now(),
-        activityCount: 0,
-        parentTerminalId: null,
-        agentName: tId,
-        isHeadless: false,
-        isMinimized: false,
-        contextContent: '',
-        agentTypeName: 'Claude',
       });
-    }, { ctxNodeId: contextNodeId, ctxNodePath: contextNodePath, spawnDir: initialSpawnDir, command: agentCommand, tId: terminalId });
+    }, { ctxNodeId: contextNodeId, ctxNodePath: contextNodePath, spawnDir: initialSpawnDir, command: agentCommand });
 
-    if (!spawnResult.success) {
-      throw new Error('Failed to spawn terminal: ' + (spawnResult.error ?? 'unknown'));
-    }
+    const terminalId = spawnResponse.terminalId;
+    expect(terminalId, 'spawnTerminalWithContextNode returned no terminalId').toBeTruthy();
 
     console.log('=== STEP 6: Poll tmux log file for Claude output ===');
     // tmux-backed terminals stream their pane output to

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-edits-survive-downstream-ops.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-edits-survive-downstream-ops.spec.ts
@@ -243,23 +243,13 @@ const test = base.extend<{
     const window = await electronApp.firstWindow({ timeout: 15_000 });
     await window.waitForLoadState('domcontentloaded');
 
-    let autoLoaded = false;
-    try {
-      await pollForCytoscape(window, 3_000);
-      autoLoaded = true;
-    } catch {
-      // Fall through to manual project selection.
-    }
-    if (!autoLoaded) {
-      await window.waitForSelector('text=Recent Projects', { timeout: 10_000 });
-      await window.locator(`button:has-text("${path.basename(projectPath)}")`).first().click();
-      const watchResult = await window.evaluate(async (dir) => {
-        const api = (window as unknown as ExtendedWindow).electronAPI;
-        if (!api) throw new Error('electronAPI not available');
-        return await api.main.startFileWatching(dir);
-      }, projectPath);
-      expect(watchResult.success, 'startFileWatching failed').toBe(true);
-    }
+    const openResult = await window.evaluate(async (dir) => {
+      const api = (window as unknown as ExtendedWindow).electronAPI;
+      if (!api) throw new Error('electronAPI not available');
+      const response = await api.main.openVault(dir);
+      return { writeFolder: response.writeFolder };
+    }, projectPath);
+    expect(openResult.writeFolder, 'openVault returned no writeFolder').toBeTruthy();
 
     await pollForCytoscape(window, 30_000);
     await pollForCytoscapeNodes(window, 1, 20_000);

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-title-latency.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-title-latency.spec.ts
@@ -154,23 +154,13 @@ const test = base.extend<{
   appWindow: async ({ electronApp, projectPath }, use) => {
     const window = await electronApp.firstWindow({ timeout: 15_000 })
     await window.waitForLoadState('domcontentloaded')
-    let autoLoaded = false
-    try {
-      await pollForCytoscape(window, 3_000)
-      autoLoaded = true
-    } catch {
-      // Fall through to manual project selection.
-    }
-    if (!autoLoaded) {
-      await window.waitForSelector('text=Recent Projects', { timeout: 10_000 })
-      await window.locator(`button:has-text("${path.basename(projectPath)}")`).first().click()
-      const watchResult = await window.evaluate(async (dir) => {
-        const api = (window as unknown as ExtendedWindow).electronAPI
-        if (!api) throw new Error('electronAPI not available')
-        return await api.main.startFileWatching(dir)
-      }, projectPath)
-      expect(watchResult.success, 'startFileWatching failed').toBe(true)
-    }
+    const openResult = await window.evaluate(async (dir) => {
+      const api = (window as unknown as ExtendedWindow).electronAPI
+      if (!api) throw new Error('electronAPI not available')
+      const response = await api.main.openVault(dir)
+      return { writeFolder: response.writeFolder }
+    }, projectPath)
+    expect(openResult.writeFolder, 'openVault returned no writeFolder').toBeTruthy()
     await pollForCytoscape(window, 30_000)
     await pollForCytoscapeNodes(window, 1, 20_000)
     await pollForCondition(window, async () => {

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-typing-order-regression.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-typing-order-regression.spec.ts
@@ -161,23 +161,13 @@ const test = base.extend<{
     await window.waitForLoadState('domcontentloaded');
     // voicetree-config.json has lastDirectory set, so the app may auto-load the vault
     // before the project selection screen is fully visible. Try detecting auto-load first.
-    let autoLoaded = false;
-    try {
-      await pollForCytoscape(window, 3_000);
-      autoLoaded = true;
-    } catch {
-      // Auto-load didn't happen — fall through to manual project selection
-    }
-    if (!autoLoaded) {
-      await window.waitForSelector('text=Recent Projects', { timeout: 10_000 });
-      await window.locator(`button:has-text("${path.basename(projectPath)}")`).first().click();
-      const watchResult = await window.evaluate(async (dir) => {
-        const api = (window as unknown as ExtendedWindow).electronAPI;
-        if (!api) throw new Error('electronAPI not available');
-        return await api.main.startFileWatching(dir);
-      }, projectPath);
-      expect(watchResult.success, 'startFileWatching failed').toBe(true);
-    }
+    const openResult = await window.evaluate(async (dir) => {
+      const api = (window as unknown as ExtendedWindow).electronAPI;
+      if (!api) throw new Error('electronAPI not available');
+      const response = await api.main.openVault(dir);
+      return { writeFolder: response.writeFolder };
+    }, projectPath);
+    expect(openResult.writeFolder, 'openVault returned no writeFolder').toBeTruthy();
     await pollForCytoscape(window, 30_000);
     await pollForCytoscapeNodes(window, 1, 20_000);
     await pollForCondition(window, async () => {

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-fs-rename-delete-semantics.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-fs-rename-delete-semantics.spec.ts
@@ -30,6 +30,7 @@ interface ExtendedWindow {
       } | undefined>;
       getWatchStatus: () => Promise<{ isWatching: boolean; directory?: string }>;
       stopFileWatching: () => Promise<{ success: boolean; error?: string }>;
+      openVault: (projectRoot: string) => Promise<{ writeFolder: string }>;
     };
   };
 }
@@ -134,7 +135,6 @@ const test = base.extend<{
 
   appWindow: [async ({ electronApp, tempVaultPath }, use) => {
     const page = await electronApp.firstWindow();
-    const tempProjectName = path.basename(path.dirname(tempVaultPath));
     const tempProjectPath = path.dirname(tempVaultPath);
     page.on('console', (msg) => {
       console.log(`BROWSER [${msg.type()}]:`, msg.text());
@@ -144,16 +144,13 @@ const test = base.extend<{
     });
 
     await page.waitForLoadState('domcontentloaded');
-    // voicetree-config.json has lastDirectory set, so the app may auto-load the vault
-    // before the project selection screen is visible. Detect auto-load first.
-    try {
-      await pollForCytoscape(page, 3000);
-    } catch {
-      await page.waitForSelector('text=Recent Projects', { timeout: 10000 });
-      const projectButton = page.locator('button', { hasText: tempProjectName }).first();
-      await projectButton.waitFor({ timeout: 10000 });
-      await projectButton.click();
-    }
+    const openResult = await page.evaluate(async (dir) => {
+      const api = (window as unknown as ExtendedWindow).electronAPI;
+      if (!api) throw new Error('electronAPI not available');
+      const response = await api.main.openVault(dir);
+      return { writeFolder: response.writeFolder };
+    }, tempProjectPath);
+    expect(openResult.writeFolder, 'openVault returned no writeFolder').toBeTruthy();
     await pollForCytoscape(page, 15000);
     await expect.poll(async () => {
       return page.evaluate(({ sourceFilePath, targetFilePath, projectRoot }) => {

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-headless-agent.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-headless-agent.spec.ts
@@ -107,7 +107,10 @@ const test = base.extend<{
                 HEADLESS_TEST: '1',
                 MINIMIZE_TEST: '1',
                 VOICETREE_PERSIST_STATE: '1',
-        VT_GRAPHD_NODE_BIN: resolveGraphDaemonNodeBin(),
+                VT_GRAPHD_NODE_BIN: resolveGraphDaemonNodeBin(),
+                // Pin the daemon's app-support path so its tmux socket lives
+                // under the same user-data dir the test queries.
+                VOICETREE_APP_SUPPORT: tempUserDataPath,
             },
             timeout: 15000
         });

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-headless-agent.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-headless-agent.spec.ts
@@ -41,9 +41,11 @@ interface ExtendedWindow {
             stopFileWatching: () => Promise<{ success: boolean; error?: string }>;
             getGraph: () => Promise<{ nodes: Record<string, unknown> }>;
             saveSettings: (settings: Record<string, unknown>) => Promise<boolean>;
-        };
-        terminal: {
-            spawn: (data: Record<string, unknown>) => Promise<{ success: boolean; terminalId?: string; error?: string }>;
+            spawnTerminalWithContextNode: (request: {
+                readonly taskNodeId: string;
+                readonly agentCommand?: string;
+                readonly terminalCount?: number;
+            }) => Promise<{ readonly terminalId: string; readonly contextNodeId: string }>;
         };
     };
 }
@@ -238,39 +240,23 @@ test.describe('Headless Agent E2E', () => {
         // ═══════════════════════════════════════════════════════════════════
         console.log('=== STEP 5: Spawn caller terminal via electronAPI ===');
 
-        // Spawn an interactive terminal with a simple sleep command.
-        // Flow: renderer IPC → TerminalManager.spawn() → recordTerminalSpawn()
-        // This registers the terminal in the main-process terminal-registry,
-        // giving us a valid callerTerminalId for MCP spawn_agent.
-        const callerTerminalId = 'e2e-headless-caller';
-        const spawnResult = await appWindow.evaluate(async ({ parentNodeId: nodeId, callerId }) => {
+        // Spawn an interactive terminal that registers in the daemon-owned
+        // terminal registry. The fixture's settings register "Test Agent" as
+        // the default — long-lived enough (sleep 10) to serve as a parked
+        // callerTerminalId for MCP `spawn_agent`. The daemon assigns the id.
+        const callerSpawn = await appWindow.evaluate(async ({ parentNodeId: nodeId }) => {
             const api = (window as unknown as ExtendedWindow).electronAPI;
-            if (!api?.terminal) throw new Error('electronAPI.terminal not available');
+            if (!api) throw new Error('electronAPI not available');
 
-            return await api.terminal.spawn({
-                type: 'Terminal',
-                terminalId: callerId,
-                attachedToContextNodeId: nodeId,
+            return await api.main.spawnTerminalWithContextNode({
+                taskNodeId: nodeId,
                 terminalCount: 0,
-                title: 'E2E Headless Caller',
-                anchoredToNodeId: { _tag: 'None' },
-                shadowNodeDimensions: { width: 600, height: 400 },
-                resizable: true,
-                initialCommand: 'sleep 120',
-                executeCommand: true,
-                isPinned: true,
-                isDone: false,
-                lastOutputTime: Date.now(),
-                activityCount: 0,
-                parentTerminalId: null,
-                agentName: callerId,
-                worktreeName: undefined,
-                isHeadless: false
             });
-        }, { parentNodeId, callerId: callerTerminalId });
+        }, { parentNodeId });
 
-        console.log(`  Spawn result: ${JSON.stringify(spawnResult)}`);
-        expect(spawnResult.success).toBe(true);
+        console.log(`  Spawn result: ${JSON.stringify(callerSpawn)}`);
+        const callerTerminalId = callerSpawn.terminalId;
+        expect(callerTerminalId).toBeTruthy();
 
         // Wait for terminal to register
         await appWindow.waitForTimeout(1000);

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-phase6-prompt-file-crash-resilience.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-phase6-prompt-file-crash-resilience.spec.ts
@@ -126,16 +126,17 @@ test.describe("Phase 6 prompt-file + crash resilience (M1-rerun-6)", () => {
 
       // ── STEP 2: vault graph loaded — `--open-folder` doesn't reliably attach
       //           the watcher in the test harness, so trigger explicitly. ──
-      const watchResult = await appWindow.evaluate(async (vp) => {
+      const openResult = await appWindow.evaluate(async (vp) => {
         const api = (window as unknown as ExtendedWindow).electronAPI;
         if (!api) throw new Error("electronAPI not available");
-        return await (
+        const response = await (
           api.main as unknown as {
-            startFileWatching: (p: string) => Promise<{ success: boolean }>;
+            openVault: (p: string) => Promise<{ writeFolder: string }>;
           }
-        ).startFileWatching(vp);
+        ).openVault(vp);
+        return { writeFolder: response.writeFolder };
       }, projectRoot);
-      expect(watchResult.success, "startFileWatching failed").toBe(true);
+      expect(openResult.writeFolder, "openVault returned no writeFolder").toBeTruthy();
 
       await expect
         .poll(
@@ -286,13 +287,14 @@ test.describe("Phase 6 prompt-file + crash resilience (M1-rerun-6)", () => {
               const wr = await win2.evaluate(async (vp) => {
                 const api = (window as unknown as ExtendedWindow).electronAPI;
                 if (!api) throw new Error("electronAPI not available");
-                return await (
+                const response = await (
                   api.main as unknown as {
-                    startFileWatching: (p: string) => Promise<{ success: boolean }>;
+                    openVault: (p: string) => Promise<{ writeFolder: string }>;
                   }
-                ).startFileWatching(vp);
+                ).openVault(vp);
+                return { writeFolder: response.writeFolder };
               }, projectRoot);
-              return wr.success;
+              return Boolean(wr.writeFolder);
             } catch {
               return false;
             }
@@ -300,7 +302,7 @@ test.describe("Phase 6 prompt-file + crash resilience (M1-rerun-6)", () => {
           {
             timeout: 30_000,
             intervals: [1000, 2000, 3000],
-            message: "startFileWatching did not recover after relaunch",
+            message: "openVault did not recover after relaunch",
           },
         )
         .toBe(true);

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-spawn-agent-terminal-anchor.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-spawn-agent-terminal-anchor.spec.ts
@@ -26,7 +26,7 @@ test.describe("spawn_agent terminal anchoring", () => {
     electronDiagnostics,
   }) => {
     let rpc: RpcAccess | null = null;
-    const callerTerminalId = "e2e-anchor-caller";
+    let callerTerminalId: string | null = null;
     let spawnedTerminalId: string | null = null;
 
     try {
@@ -35,12 +35,15 @@ test.describe("spawn_agent terminal anchoring", () => {
         token: await getBearerToken(appWindow),
       };
 
-      const watchResult = await appWindow.evaluate(async (projectRoot) => {
+      // Bind the daemon to the fixture vault. openVault throws on failure and
+      // returns the resolved write folder on success.
+      const openResult = await appWindow.evaluate(async (projectRoot) => {
         const api = (window as ExtendedWindow).electronAPI;
         if (!api) throw new Error("electronAPI not available");
-        return await api.main.startFileWatching(projectRoot);
+        const response = await api.main.openVault(projectRoot);
+        return { writeFolder: response.writeFolder };
       }, fixtureVaultPath);
-      expect(watchResult.success).toBe(true);
+      expect(openResult.writeFolder, "openVault returned no writeFolder").toBeTruthy();
 
       await expect
         .poll(
@@ -54,7 +57,7 @@ test.describe("spawn_agent terminal anchoring", () => {
           },
           {
             message:
-              "Waiting for graph state after explicit file watching start",
+              "Waiting for graph state after openVault bound the daemon",
             timeout: 15_000,
             intervals: [250, 500, 1000],
           },
@@ -70,35 +73,24 @@ test.describe("spawn_agent terminal anchoring", () => {
         return nodeIds[0];
       });
 
+      // Spawn the caller terminal via the daemon-owned spawn surface. The
+      // fixture registers a long-lived "Fake Agent" as the default agent, so
+      // the spawn parks a real terminal in the registry that MCP `spawn_agent`
+      // can target with the returned `callerTerminalId`.
       const callerSpawn = await appWindow.evaluate(
-        async ({ callerTerminalId, parentNodeId }) => {
+        async ({ parentNodeId }) => {
           const api = (window as ExtendedWindow).electronAPI;
-          if (!api?.terminal)
-            throw new Error("electronAPI.terminal not available");
-          return await api.terminal.spawn({
-            type: "Terminal",
-            terminalId: callerTerminalId,
-            attachedToContextNodeId: parentNodeId,
+          if (!api) throw new Error("electronAPI not available");
+          return await api.main.spawnTerminalWithContextNode({
+            taskNodeId: parentNodeId,
             terminalCount: 0,
-            title: "E2E Anchor Caller",
-            anchoredToNodeId: { _tag: "None" },
-            shadowNodeDimensions: { width: 600, height: 400 },
-            resizable: true,
-            initialCommand: "sleep 120",
-            executeCommand: true,
-            isPinned: true,
-            isDone: false,
-            lastOutputTime: Date.now(),
-            activityCount: 0,
-            parentTerminalId: null,
-            agentName: callerTerminalId,
-            worktreeName: undefined,
-            isHeadless: false,
           });
         },
-        { callerTerminalId, parentNodeId },
+        { parentNodeId },
       );
-      expect(callerSpawn.success).toBe(true);
+      callerTerminalId = callerSpawn.terminalId;
+      expect(callerTerminalId, "caller spawnTerminalWithContextNode returned no terminalId").toBeTruthy();
+      const liveCallerTerminalId: string = callerTerminalId;
 
       await expect
         .poll(
@@ -113,7 +105,7 @@ test.describe("spawn_agent terminal anchoring", () => {
               listResult.parsed as { agents: Array<{ terminalId: string }> }
             ).agents;
             return agents.some(
-              (agent) => agent.terminalId === callerTerminalId,
+              (agent) => agent.terminalId === liveCallerTerminalId,
             );
           },
           {
@@ -128,7 +120,7 @@ test.describe("spawn_agent terminal anchoring", () => {
       const spawnResult = await rpcCallTool(rpc.rpcUrl, rpc.token, "spawn_agent", {
         task: "E2E spawned terminal anchor task",
         parentNodeId,
-        callerTerminalId,
+        callerTerminalId: liveCallerTerminalId,
         agentName: "Fake Agent",
         spawnDirectory: REPO_ROOT,
         depthBudget: 0,
@@ -262,12 +254,14 @@ test.describe("spawn_agent terminal anchoring", () => {
 
       expectNoCriticalElectronErrors(electronDiagnostics);
     } finally {
-      await cleanupAnchorTestTerminals(
-        appWindow,
-        rpc,
-        [spawnedTerminalId, callerTerminalId],
-        callerTerminalId,
-      );
+      if (callerTerminalId) {
+        await cleanupAnchorTestTerminals(
+          appWindow,
+          rpc,
+          [spawnedTerminalId, callerTerminalId],
+          callerTerminalId,
+        );
+      }
     }
   });
 });

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-sse-replay-buffer.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-sse-replay-buffer.spec.ts
@@ -24,7 +24,7 @@ test.describe("SSE replay buffer", () => {
   }) => {
     test.setTimeout(process.env.CI ? 120_000 : 90_000);
     let rpc: RpcAccess | null = null;
-    const callerTerminalId = "e2e-replay-caller";
+    let callerTerminalId: string | null = null;
     let spawnedTerminalId: string | null = null;
 
     try {
@@ -33,12 +33,15 @@ test.describe("SSE replay buffer", () => {
         token: await getBearerToken(appWindow),
       };
 
-      const watchResult = await appWindow.evaluate(async (projectRoot) => {
+      // Bind the daemon to the fixture vault. openVault throws on failure and
+      // returns the resolved write folder on success.
+      const openResult = await appWindow.evaluate(async (projectRoot) => {
         const api = (window as unknown as ExtendedWindow).electronAPI;
         if (!api) throw new Error("electronAPI not available");
-        return await api.main.startFileWatching(projectRoot);
+        const response = await api.main.openVault(projectRoot);
+        return { writeFolder: response.writeFolder };
       }, fixtureVaultPath);
-      expect(watchResult.success).toBe(true);
+      expect(openResult.writeFolder, "openVault returned no writeFolder").toBeTruthy();
 
       await expect
         .poll(
@@ -51,7 +54,7 @@ test.describe("SSE replay buffer", () => {
             });
           },
           {
-            message: "Waiting for graph state after file watching start",
+            message: "Waiting for graph state after openVault bound the daemon",
             timeout: 15_000,
             intervals: [250, 500, 1000],
           },
@@ -75,35 +78,24 @@ test.describe("SSE replay buffer", () => {
         return rootId;
       });
 
+      // Spawn the caller terminal via the daemon-owned spawn surface. The
+      // fixture registers a long-lived "Fake Agent" as the default agent, so
+      // the spawn parks a real terminal in the registry that MCP `spawn_agent`
+      // can target with the returned `callerTerminalId`.
       const callerSpawn = await appWindow.evaluate(
-        async ({ callerTerminalId, parentNodeId }) => {
+        async ({ parentNodeId }) => {
           const api = (window as unknown as ExtendedWindow).electronAPI;
-          if (!api?.terminal)
-            throw new Error("electronAPI.terminal not available");
-          return await api.terminal.spawn({
-            type: "Terminal",
-            terminalId: callerTerminalId,
-            attachedToContextNodeId: parentNodeId,
+          if (!api) throw new Error("electronAPI not available");
+          return await api.main.spawnTerminalWithContextNode({
+            taskNodeId: parentNodeId,
             terminalCount: 0,
-            title: "E2E Replay Buffer Caller",
-            anchoredToNodeId: { _tag: "None" },
-            shadowNodeDimensions: { width: 600, height: 400 },
-            resizable: true,
-            initialCommand: "sleep 120",
-            executeCommand: true,
-            isPinned: true,
-            isDone: false,
-            lastOutputTime: Date.now(),
-            activityCount: 0,
-            parentTerminalId: null,
-            agentName: callerTerminalId,
-            worktreeName: undefined,
-            isHeadless: false,
           });
         },
-        { callerTerminalId, parentNodeId },
+        { parentNodeId },
       );
-      expect(callerSpawn.success).toBe(true);
+      callerTerminalId = callerSpawn.terminalId;
+      expect(callerTerminalId, "caller spawnTerminalWithContextNode returned no terminalId").toBeTruthy();
+      const liveCallerTerminalId: string = callerTerminalId;
 
       await expect
         .poll(
@@ -118,7 +110,7 @@ test.describe("SSE replay buffer", () => {
               listResult.parsed as { agents: Array<{ terminalId: string }> }
             ).agents;
             return agents.some(
-              (agent) => agent.terminalId === callerTerminalId,
+              (agent) => agent.terminalId === liveCallerTerminalId,
             );
           },
           {
@@ -154,7 +146,7 @@ test.describe("SSE replay buffer", () => {
       const spawnResult = await rpcCallTool(rpc.rpcUrl, rpc.token, "spawn_agent", {
         task: "E2E replay buffer regression task",
         parentNodeId,
-        callerTerminalId,
+        callerTerminalId: liveCallerTerminalId,
         agentName: "Fake Agent",
         spawnDirectory: REPO_ROOT,
         depthBudget: 0,
@@ -288,12 +280,14 @@ test.describe("SSE replay buffer", () => {
 
       expectNoCriticalElectronErrors(electronDiagnostics);
     } finally {
-      await cleanupAnchorTestTerminals(
-        appWindow,
-        rpc,
-        [spawnedTerminalId, callerTerminalId],
-        callerTerminalId,
-      );
+      if (callerTerminalId) {
+        await cleanupAnchorTestTerminals(
+          appWindow,
+          rpc,
+          [spawnedTerminalId, callerTerminalId],
+          callerTerminalId,
+        );
+      }
     }
   });
 });

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-tmux-keystroke-relay.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-tmux-keystroke-relay.spec.ts
@@ -90,9 +90,8 @@ test.describe('renderer keystroke → Main IPC → /terminals/:id/attach WS → 
   test('typing in a tmux-backed terminal reaches the pane via the Main-owned IPC bridge', async ({ appWindow, fixtureVaultPath }) => {
     test.setTimeout(240_000);
 
-    // Hermetic terminalId so successive runs / parallel tests don't collide.
-    const terminalId: string = `e2e-keystroke-${randomBytes(4).toString('hex')}`;
     let appSupportPath: string | undefined;
+    let terminalId: string | undefined;
 
     try {
       appSupportPath = await appWindow.evaluate(async () => {
@@ -130,37 +129,34 @@ test.describe('renderer keystroke → Main IPC → /terminals/:id/attach WS → 
         return Object.keys(graph.nodes)[0];
       });
 
-      // ── Spawn interactive tmux-backed terminal (no agent — just a shell). ──
-      const spawnResult = await appWindow.evaluate(async ({ tid, parentNodeId: nodeId }) => {
+      // ── Spawn an interactive tmux-backed plain shell on the parent node. ──
+      // `spawnPlainTerminal` opens a vanilla pty without running an agent
+      // command — exactly the shape we need to prove typed bytes reach the
+      // pane. The daemon assigns the terminalId, surfaced to the renderer via
+      // the `terminal-registry` SSE topic; we observe the resulting floating
+      // window in the DOM to learn that id.
+      await appWindow.evaluate(async ({ parentNodeId: nodeId }) => {
         const api = (window as ExtendedWindow).electronAPI;
-        if (!api?.terminal) throw new Error('electronAPI.terminal not available');
-        return await api.terminal.spawn({
-          type: 'Terminal',
-          terminalId: tid,
-          attachedToContextNodeId: nodeId,
-          terminalCount: 0,
-          title: 'E2E Keystroke Relay',
-          anchoredToNodeId: { _tag: 'None' },
-          shadowNodeDimensions: { width: 600, height: 400 },
-          resizable: true,
-          // No initialCommand — leave the pane at a vanilla shell prompt so
-          // we can prove our typed bytes (and only our typed bytes) reached it.
-          executeCommand: false,
-          isPinned: true,
-          isDone: false,
-          lastOutputTime: Date.now(),
-          activityCount: 0,
-          parentTerminalId: null,
-          agentName: tid,
-          worktreeName: undefined,
-          isHeadless: false,
-        });
-      }, { tid: terminalId, parentNodeId });
-      expect(spawnResult.success, `terminal:spawn failed: ${JSON.stringify(spawnResult)}`).toBe(true);
+        if (!api) throw new Error('electronAPI not available');
+        await api.main.spawnPlainTerminal({ nodeId, terminalCount: 0 });
+      }, { parentNodeId });
 
-      await expect.poll(() => tmuxSessionExists(terminalId, appSupportPath), {
+      terminalId = await appWindow.evaluate(async () => {
+        const deadline = Date.now() + 15_000;
+        while (Date.now() < deadline) {
+          const elem = document.querySelector('.cy-floating-window-terminal');
+          const id = elem?.getAttribute('data-floating-window-id');
+          if (id) return id;
+          await new Promise(r => setTimeout(r, 250));
+        }
+        throw new Error('Spawned terminal never appeared in the DOM');
+      });
+
+      const liveTerminalId: string = terminalId;
+
+      await expect.poll(() => tmuxSessionExists(liveTerminalId, appSupportPath), {
         timeout: 10_000,
-        message: `tmux session ${terminalId} never came up`,
+        message: `tmux session ${liveTerminalId} never came up`,
       }).toBe(true);
 
       // ── Attach via the SAME IPC bridge the renderer uses. ──
@@ -180,7 +176,7 @@ test.describe('renderer keystroke → Main IPC → /terminals/:id/attach WS → 
             await api.terminal.detach(handle);
           },
         };
-      }, terminalId);
+      }, liveTerminalId);
 
       try {
         // Give tmux's `attach` time to repaint the pane buffer to the client.
@@ -205,12 +201,12 @@ test.describe('renderer keystroke → Main IPC → /terminals/:id/attach WS → 
 
         await expect.poll(async () => {
           const received: string = await appWindow.evaluate(() => window.__e2eKeystrokeRelay?.received.value ?? '');
-          const onPane: string = tmuxCapturePane(terminalId, appSupportPath);
+          const onPane: string = tmuxCapturePane(liveTerminalId, appSupportPath);
           return received.includes(sentinel) && onPane.includes(sentinel);
         }, {
           timeout: KEYSTROKE_SETTLE_TIMEOUT_MS,
           intervals: [200, 500, 1000],
-          message: `keystrokes never produced "${sentinel}" via IPC relay. capture-pane:\n${tmuxCapturePane(terminalId, appSupportPath)}`,
+          message: `keystrokes never produced "${sentinel}" via IPC relay. capture-pane:\n${tmuxCapturePane(liveTerminalId, appSupportPath)}`,
         }).toBe(true);
       } finally {
         await appWindow.evaluate(async () => {
@@ -221,7 +217,9 @@ test.describe('renderer keystroke → Main IPC → /terminals/:id/attach WS → 
     } finally {
       // Defensive cleanup — the tmux session is detached from the relay's
       // pty, so closing the IPC handle alone won't kill it.
-      if (tmuxSessionExists(terminalId, appSupportPath)) killTmuxSession(terminalId, appSupportPath);
+      if (terminalId && tmuxSessionExists(terminalId, appSupportPath)) {
+        killTmuxSession(terminalId, appSupportPath);
+      }
     }
   });
 });

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-vault-file-watcher-system.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-vault-file-watcher-system.spec.ts
@@ -126,14 +126,13 @@ const test = base.extend<{
   appWindow: async ({ electronApp, projectPath }, use) => {
     const window = await electronApp.firstWindow({ timeout: 15_000 });
     await window.waitForLoadState('domcontentloaded');
-    // voicetree-config.json has lastDirectory set, so the app may auto-load the vault
-    // before the project selection screen is visible. Detect auto-load first.
-    try {
-      await pollForCytoscape(window, 3_000);
-    } catch {
-      await window.waitForSelector('text=Recent Projects', { timeout: 10_000 });
-      await window.locator(`button:has-text("${path.basename(projectPath)}")`).first().click();
-    }
+    const openResult = await window.evaluate(async (dir) => {
+      const api = (window as unknown as ExtendedWindow).electronAPI;
+      if (!api) throw new Error('electronAPI not available');
+      const response = await api.main.openVault(dir);
+      return { writeFolder: response.writeFolder };
+    }, projectPath);
+    expect(openResult.writeFolder, 'openVault returned no writeFolder').toBeTruthy();
     await pollForCytoscape(window, 30_000);
     await pollForCytoscapeNodes(window, 1, 20_000);
     await use(window);

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/helpers/e2e-rpc-helpers.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/helpers/e2e-rpc-helpers.ts
@@ -23,7 +23,7 @@ type DaemonAccess = {
 
 type RpcResponse = {
   result?: unknown;
-  error?: { code?: number; message: string };
+  error?: { code?: number; message: string; data?: unknown };
 };
 
 export type RpcToolResult = {
@@ -119,6 +119,15 @@ export async function rpcCallTool(
   args: Record<string, unknown>
 ): Promise<RpcToolResult> {
   const response: RpcResponse = await rpc(rpcUrl, token, toolName, args);
-  if (response.error) throw new Error(`JSON-RPC error: ${response.error.message}`);
+  if (response.error) {
+    // The dispatcher returns `tool_handler_failed` with the unwrapped payload
+    // in `error.data` when the tool ran but reported an error. Surface that
+    // payload so callers see the actual cause (not just the generic envelope
+    // message). See packages/systems/vt-daemon/src/transport/rpcDispatch.ts.
+    const detail: string = response.error.data !== undefined
+      ? `: ${JSON.stringify(response.error.data)}`
+      : '';
+    throw new Error(`JSON-RPC error (${toolName}): ${response.error.message}${detail}`);
+  }
   return normaliseRpcResult(response.result);
 }

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/helpers/e2e-rpc-helpers.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/helpers/e2e-rpc-helpers.ts
@@ -22,7 +22,7 @@ type DaemonAccess = {
 };
 
 type RpcResponse = {
-  result?: { content?: Array<{ type: string; text: string }>; isError?: boolean };
+  result?: unknown;
   error?: { code?: number; message: string };
 };
 
@@ -79,10 +79,37 @@ async function rpc(rpcUrl: string, token: string, method: string, params: Record
   return await response.json() as RpcResponse;
 }
 
-export async function rpcListTools(rpcUrl: string, token: string): Promise<unknown> {
-  const result: RpcResponse = await rpc(rpcUrl, token, 'tools/list', {});
-  if (result.error) throw new Error(`JSON-RPC error: ${result.error.message}`);
-  return result.result;
+// Post-BF-376, the unified HTTP daemon's RPC catalog dispatches by tool name
+// directly (see packages/systems/vt-daemon/src/transport/rpcDispatch.ts —
+// `catalog.get(method)`), without the MCP `tools/call` wrapping. The catalog
+// handler returns either the MCP-style `{ content: [{ type, text }] }` shape
+// (when the tool is reused for an MCP transport) or a plain JSON object. We
+// normalise both shapes to `{ success, parsed, isError }`.
+type McpStyleResult = {
+  readonly content?: ReadonlyArray<{ readonly type: string; readonly text: string }>;
+  readonly isError?: boolean;
+};
+
+function normaliseRpcResult(raw: unknown): RpcToolResult {
+  if (raw && typeof raw === 'object' && 'content' in raw) {
+    const mcp: McpStyleResult = raw as McpStyleResult;
+    const text: string | undefined = mcp.content?.[0]?.text;
+    const parsed: Record<string, unknown> | undefined = text
+      ? JSON.parse(text) as Record<string, unknown>
+      : undefined;
+    return {
+      success: parsed?.success === true || (mcp.isError !== true && parsed === undefined),
+      parsed,
+      isError: mcp.isError,
+    };
+  }
+  const parsed: Record<string, unknown> | undefined = raw && typeof raw === 'object'
+    ? raw as Record<string, unknown>
+    : undefined;
+  return {
+    success: parsed?.success === true || (parsed !== undefined && !('success' in parsed)),
+    parsed,
+  };
 }
 
 export async function rpcCallTool(
@@ -91,18 +118,7 @@ export async function rpcCallTool(
   toolName: string,
   args: Record<string, unknown>
 ): Promise<RpcToolResult> {
-  const response: RpcResponse = await rpc(rpcUrl, token, 'tools/call', {
-    name: toolName,
-    arguments: args,
-  });
+  const response: RpcResponse = await rpc(rpcUrl, token, toolName, args);
   if (response.error) throw new Error(`JSON-RPC error: ${response.error.message}`);
-  const text: string | undefined = response.result?.content?.[0]?.text;
-  const parsed: Record<string, unknown> | undefined = text
-    ? JSON.parse(text) as Record<string, unknown>
-    : undefined;
-  return {
-    success: parsed?.success === true,
-    parsed,
-    isError: response.result?.isError,
-  };
+  return normaliseRpcResult(response.result);
 }

--- a/webapp/src/shell/edge/main/runtime/electron/app/main.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/app/main.ts
@@ -84,6 +84,15 @@ initializeGraphModel();
 const {autoUpdater} = electronUpdater;
 
 function pinProcessAppSupportPath(): void {
+    // Respect an explicit override from the parent process (test fixtures pin
+    // VOICETREE_APP_SUPPORT to their temp user-data dir before launching
+    // Electron). Without this guard, the unconditional overwrite below
+    // shadows the override with `app.getPath('userData')`, which on a fresh
+    // Electron launch may return the OS default before --user-data-dir is
+    // observable to `app.getPath`. The override path is where the test
+    // pre-seeds settings.json / talks to tmux, so silently clobbering it
+    // strands the daemon on a different socket from the test.
+    if (process.env.VOICETREE_APP_SUPPORT) return;
     process.env.VOICETREE_APP_SUPPORT = getAppSupportPath();
 }
 


### PR DESCRIPTION
## Summary
- Group A (7 specs): migrate fixtures from removed `api.main.startFileWatching` → `api.main.openVault(projectRoot)` and drop the racy "click Recent Projects button as fallback" pattern. Matches the template already shipped in `electron-tmux-keystroke-relay.spec.ts`.
- Group B (5 specs): migrate test bodies from removed `api.terminal.spawn(...)` → `api.main.spawnTerminalWithContextNode(...)` (agent terminals) or `api.main.spawnPlainTerminal(...)` (vanilla pty in keystroke-relay). Terminal IDs are now daemon-assigned; tests adapt to read them back from the spawn response (or from `data-floating-window-id` for the void-returning plain-spawn route).

Root cause: BF-376 phase 2 (commit `2a7426f2b`) removed the renderer-facing `startFileWatching` / `terminal.spawn` surface in favour of the per-vault VT-Daemon RPC wrappers in `mainAPI`. The 12 tier-2 Electron specs that called the old surface have never run since, so this is the first time they fail in CI — manifested as `TypeError: api.X is not a function` or as a 30s `locator.click` race between the fallback's Recent Projects screen and the auto-load that now unmounts it.

PR #133 merged at the pre-fix HEAD (`b89cc248a`) so the Electron Tier 2 E2E job was red on `dev`. This is the smallest follow-up PR — 12 spec files touched, only test fixtures, no product code.

## Test plan
- [ ] Electron Tier 2 E2E CI job (this PR) — all 24 previously-failing test cases pass
- [ ] Browser Tier 2, Tier 1 smoke, Unit & Integration, fuzz — stay green (no product code touched)
- [ ] Spot-check on devbox via `npm run test:e2e:tier2:electron` once the box is reachable again