### PR TITLE
systems-health workspace resolution + vt-resume display fix

### DIFF
--- a/packages/measures/src/_shared/discovery/discover-packages.ts
+++ b/packages/measures/src/_shared/discovery/discover-packages.ts
@@ -23,6 +23,7 @@ export type PackageInfo = {
     readonly name: string
     readonly dirName: string
     readonly packageJsonRelativePath: string
+    readonly relDir: string
     readonly srcRoot: string
     readonly absDir: string
     /**
@@ -152,6 +153,7 @@ export async function discoverPackages(repoRoot: string = DEFAULT_REPO_ROOT): Pr
                         name: pkgJson.name,
                         dirName: basename(absDir),
                         packageJsonRelativePath: relative(repoRoot, join(absDir, 'package.json')).replaceAll('\\', '/'),
+                        relDir: normalizePath(relDir),
                         srcRoot: srcDir,
                         absDir,
                         facadeRelativePaths: resolveFacadeRelativePaths(absDir, repoRoot, pkgJson.exports),
@@ -174,4 +176,8 @@ export async function discoverPackages(repoRoot: string = DEFAULT_REPO_ROOT): Pr
 
     await walk(repoRoot, '')
     return found.sort((a, b) => a.dirName.localeCompare(b.dirName))
+}
+
+function normalizePath(path: string): string {
+    return path.replaceAll('\\', '/')
 }

--- a/packages/measures/src/_shared/graph/call-graph.ts
+++ b/packages/measures/src/_shared/graph/call-graph.ts
@@ -2,7 +2,6 @@ import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
     Node,
-    Project,
     SyntaxKind,
     ts,
     type FunctionDeclaration,
@@ -11,6 +10,8 @@ import {
     type SourceFile,
     type VariableDeclaration,
 } from 'ts-morph'
+import { discoverPackages, type PackageInfo } from '../discovery/discover-packages'
+import { createRepoTsMorphProject } from './repo-ts-morph-project'
 
 export type FunctionNode = {
     readonly id: string
@@ -36,43 +37,34 @@ export type CallGraph = {
 }
 
 const TEST_DIR: string = dirname(fileURLToPath(import.meta.url))
-const REPO_ROOT: string = resolve(TEST_DIR, '../../../../..')
+const DEFAULT_REPO_ROOT: string = resolve(TEST_DIR, '../../../../..')
 
-let graphPromise: Promise<CallGraph> | undefined
-
-export async function buildCallGraph(): Promise<CallGraph> {
-    graphPromise ??= Promise.resolve(createCallGraph())
-    return graphPromise
+export async function buildCallGraph(
+    repoRoot: string = DEFAULT_REPO_ROOT,
+    packages?: readonly PackageInfo[],
+): Promise<CallGraph> {
+    return createCallGraph(repoRoot, packages ?? await discoverPackages(repoRoot))
 }
 
-function createCallGraph(): CallGraph {
-    const project = new Project({
-        compilerOptions: {
-            moduleResolution: ts.ModuleResolutionKind.Bundler,
-            module: ts.ModuleKind.ESNext,
-            target: ts.ScriptTarget.ES2022,
-            allowJs: false,
-            skipLibCheck: true,
-            jsx: ts.JsxEmit.Preserve,
-        },
-    })
+function createCallGraph(repoRoot: string, packages: readonly PackageInfo[]): CallGraph {
+    const project = createRepoTsMorphProject(repoRoot, packages)
     const sourceFiles = project.addSourceFilesAtPaths([
-        `${REPO_ROOT}/packages/libraries/**/*.{ts,tsx}`,
-        `${REPO_ROOT}/packages/systems/**/*.{ts,tsx}`,
-        `${REPO_ROOT}/webapp/src/**/*.{ts,tsx}`,
-        `!${REPO_ROOT}/**/*.test.ts`,
-        `!${REPO_ROOT}/**/*.test.tsx`,
-        `!${REPO_ROOT}/**/*.spec.ts`,
-        `!${REPO_ROOT}/**/*.spec.tsx`,
-        `!${REPO_ROOT}/**/*.d.ts`,
-        `!${REPO_ROOT}/**/__tests__/**`,
-        `!${REPO_ROOT}/**/tests/**`,
-        `!${REPO_ROOT}/**/__generated__/**`,
-        `!${REPO_ROOT}/**/integration-tests/**`,
-        `!${REPO_ROOT}/**/node_modules/**`,
-        `!${REPO_ROOT}/**/dist/**`,
-        `!${REPO_ROOT}/**/build/**`,
-        `!${REPO_ROOT}/**/*.config.ts`,
+        `${repoRoot}/packages/libraries/**/*.{ts,tsx}`,
+        `${repoRoot}/packages/systems/**/*.{ts,tsx}`,
+        `${repoRoot}/webapp/src/**/*.{ts,tsx}`,
+        `!${repoRoot}/**/*.test.ts`,
+        `!${repoRoot}/**/*.test.tsx`,
+        `!${repoRoot}/**/*.spec.ts`,
+        `!${repoRoot}/**/*.spec.tsx`,
+        `!${repoRoot}/**/*.d.ts`,
+        `!${repoRoot}/**/__tests__/**`,
+        `!${repoRoot}/**/tests/**`,
+        `!${repoRoot}/**/__generated__/**`,
+        `!${repoRoot}/**/integration-tests/**`,
+        `!${repoRoot}/**/node_modules/**`,
+        `!${repoRoot}/**/dist/**`,
+        `!${repoRoot}/**/build/**`,
+        `!${repoRoot}/**/*.config.ts`,
     ]).filter(sourceFile => isProductionSourcePath(sourceFile.getFilePath()))
     if (sourceFiles.length === 0) {
         throw new Error('buildCallGraph found 0 production source files; check for concurrent package moves before changing globs')
@@ -83,13 +75,13 @@ function createCallGraph(): CallGraph {
 
     for (const sourceFile of sourceFiles) {
         for (const fn of sourceFile.getDescendantsOfKind(SyntaxKind.FunctionDeclaration)) {
-            addFunctionDeclaration(nodes, functionIdsBySyntaxNode, sourceFile, fn)
+            addFunctionDeclaration(repoRoot, nodes, functionIdsBySyntaxNode, sourceFile, fn)
         }
         for (const method of sourceFile.getDescendantsOfKind(SyntaxKind.MethodDeclaration)) {
-            addMethodDeclaration(nodes, functionIdsBySyntaxNode, sourceFile, method)
+            addMethodDeclaration(repoRoot, nodes, functionIdsBySyntaxNode, sourceFile, method)
         }
         for (const variable of sourceFile.getDescendantsOfKind(SyntaxKind.VariableDeclaration)) {
-            addVariableFunction(nodes, functionIdsBySyntaxNode, sourceFile, variable)
+            addVariableFunction(repoRoot, nodes, functionIdsBySyntaxNode, sourceFile, variable)
         }
     }
 
@@ -164,6 +156,7 @@ function isProductionSourcePath(path: string): boolean {
 }
 
 function addFunctionDeclaration(
+    repoRoot: string,
     nodes: Map<string, FunctionNode>,
     functionIdsBySyntaxNode: Map<MorphNode, string>,
     sourceFile: SourceFile,
@@ -171,12 +164,13 @@ function addFunctionDeclaration(
 ): void {
     if (!fn.getBody()) return
     const name = fn.getName() ?? 'default'
-    const node = createFunctionNode(sourceFile, fn.getNameNode() ?? fn, fn, name, 'function', fn.isExported())
+    const node = createFunctionNode(repoRoot, sourceFile, fn.getNameNode() ?? fn, fn, name, 'function', fn.isExported())
     nodes.set(node.id, node)
     functionIdsBySyntaxNode.set(fn, node.id)
 }
 
 function addMethodDeclaration(
+    repoRoot: string,
     nodes: Map<string, FunctionNode>,
     functionIdsBySyntaxNode: Map<MorphNode, string>,
     sourceFile: SourceFile,
@@ -185,12 +179,13 @@ function addMethodDeclaration(
     if (!method.getBody()) return
     const classDecl = method.getParentIfKind(SyntaxKind.ClassDeclaration)
     const name = method.getName()
-    const node = createFunctionNode(sourceFile, method.getNameNode(), method, name, 'method', classDecl?.isExported() ?? false)
+    const node = createFunctionNode(repoRoot, sourceFile, method.getNameNode(), method, name, 'method', classDecl?.isExported() ?? false)
     nodes.set(node.id, node)
     functionIdsBySyntaxNode.set(method, node.id)
 }
 
 function addVariableFunction(
+    repoRoot: string,
     nodes: Map<string, FunctionNode>,
     functionIdsBySyntaxNode: Map<MorphNode, string>,
     sourceFile: SourceFile,
@@ -202,6 +197,7 @@ function addVariableFunction(
     const name = variable.getName()
     const variableStatement = variable.getVariableStatement()
     const node = createFunctionNode(
+        repoRoot,
         sourceFile,
         variable.getNameNode(),
         initializer,
@@ -215,6 +211,7 @@ function addVariableFunction(
 }
 
 function createFunctionNode(
+    repoRoot: string,
     sourceFile: SourceFile,
     locationNode: MorphNode,
     node: MorphNode,
@@ -222,7 +219,7 @@ function createFunctionNode(
     kind: FunctionNode['kind'],
     isExported: boolean,
 ): FunctionNode {
-    const file = normalizePath(relative(REPO_ROOT, sourceFile.getFilePath()))
+    const file = normalizePath(relative(repoRoot, sourceFile.getFilePath()))
     const line = sourceFile.getLineAndColumnAtPos(locationNode.getStart()).line
     return {
         id: `${file}:${line}:${name}`,

--- a/packages/measures/src/_shared/graph/repo-ts-morph-project.ts
+++ b/packages/measures/src/_shared/graph/repo-ts-morph-project.ts
@@ -1,0 +1,80 @@
+import {Project, ts} from 'ts-morph'
+import type {PackageInfo} from '../discovery/discover-packages'
+
+export function createRepoTsMorphProject(repoRoot: string, packages: readonly PackageInfo[]): Project {
+    return new Project({
+        compilerOptions: repoTsMorphCompilerOptions(repoRoot, packages),
+    })
+}
+
+function repoTsMorphCompilerOptions(repoRoot: string, packages: readonly PackageInfo[]): ts.CompilerOptions {
+    return {
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        allowJs: false,
+        allowImportingTsExtensions: true,
+        skipLibCheck: true,
+        jsx: ts.JsxEmit.Preserve,
+        baseUrl: repoRoot,
+        paths: workspacePackagePaths(packages),
+    }
+}
+
+function workspacePackagePaths(packages: readonly PackageInfo[]): Record<string, string[]> {
+    const paths: Record<string, string[]> = {}
+    for (const pkg of packages) {
+        addPackagePaths(paths, pkg)
+    }
+    return paths
+}
+
+function addPackagePaths(paths: Record<string, string[]>, pkg: PackageInfo): void {
+    const relPackageDir = normalizePath(pkg.relDir)
+    const mainTarget = pkg.main ?? './src/index.ts'
+    addPath(paths, pkg.name, packageTarget(relPackageDir, mainTarget))
+
+    for (const [exportKey, exportValue] of exportEntries(pkg.exports)) {
+        const specifier = exportSpecifier(pkg.name, exportKey)
+        if (!specifier) continue
+        for (const target of exportStringTargets(exportValue)) {
+            addPath(paths, specifier, packageTarget(relPackageDir, target))
+        }
+    }
+
+    addPath(paths, `${pkg.name}/*`, `${relPackageDir}/src/*`)
+}
+
+function exportEntries(exportsField: unknown): readonly (readonly [string, unknown])[] {
+    if (!exportsField || typeof exportsField !== 'object' || Array.isArray(exportsField)) return []
+    return Object.entries(exportsField)
+}
+
+function exportSpecifier(packageName: string, exportKey: string): string | null {
+    if (exportKey === '.') return packageName
+    if (!exportKey.startsWith('./')) return null
+    return `${packageName}/${exportKey.slice(2)}`
+}
+
+function exportStringTargets(value: unknown): readonly string[] {
+    if (typeof value === 'string') return [value]
+    if (Array.isArray(value)) return value.flatMap(exportStringTargets)
+    if (!value || typeof value !== 'object') return []
+    return Object.values(value).flatMap(exportStringTargets)
+}
+
+function packageTarget(relPackageDir: string, target: string): string | null {
+    if (!target.startsWith('./')) return null
+    return normalizePath(`${relPackageDir}/${target.slice(2)}`)
+}
+
+function addPath(paths: Record<string, string[]>, specifier: string, target: string | null): void {
+    if (!target) return
+    const targets = paths[specifier] ?? []
+    if (targets.includes(target)) return
+    paths[specifier] = [...targets, target]
+}
+
+function normalizePath(path: string): string {
+    return path.replaceAll('\\', '/')
+}

--- a/packages/measures/src/health/coupling/semantic-coupling-graph.test.ts
+++ b/packages/measures/src/health/coupling/semantic-coupling-graph.test.ts
@@ -34,9 +34,9 @@ type PackageContext = {
 describe('ts-morph semantic coupling canary', () => {
     it('stays within 18% of the semantic coupling ratchet baselines', async () => {
         const started = performance.now()
-        const graph = await buildCallGraph()
+        const packages = await discoverPackages(REPO_ROOT)
+        const graph = await buildCallGraph(REPO_ROOT, packages)
         const buildMs = Math.round(performance.now() - started)
-        const packages = await discoverPackages()
         const pairReports = collectSemanticCouplingPairReports(graph, packages)
         const pairs = pairReports.flatMap(report => report.pairs)
         const topPair = pairs.slice().sort(compareByTotal)[0]

--- a/packages/measures/src/health/purity/transitive-purity-graph.test.ts
+++ b/packages/measures/src/health/purity/transitive-purity-graph.test.ts
@@ -3,9 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
     Node,
-    Project,
     SyntaxKind,
-    ts,
     type FunctionDeclaration,
     type FunctionExpression,
     type Identifier,
@@ -14,7 +12,9 @@ import {
     type SourceFile,
     type VariableDeclaration,
 } from 'ts-morph'
+import {discoverPackages, type PackageInfo} from '../../_shared/discovery/discover-packages'
 import { buildCallGraph, type CallGraph } from '../../_shared/graph/call-graph'
+import { createRepoTsMorphProject } from '../../_shared/graph/repo-ts-morph-project'
 import { recordHealthMetric } from '../../_shared/writers/report-writer'
 
 const TEST_DIR: string = dirname(fileURLToPath(import.meta.url))
@@ -50,9 +50,10 @@ type FunctionSyntax = FunctionDeclaration | MethodDeclaration | FunctionExpressi
 describe('transitive impurity (ts-morph call graph)', () => {
     it('transitive impurity functions stay under budget', async () => {
         const started = performance.now()
-        const graph = await buildCallGraph()
+        const packages = await discoverPackages(REPO_ROOT)
+        const graph = await buildCallGraph(REPO_ROOT, packages)
         const buildMs = Math.round(performance.now() - started)
-        const directIds = collectDirectlyImpureFunctionIds(graph)
+        const directIds = collectDirectlyImpureFunctionIds(graph, packages)
         const scopedNodeIds = [...graph.nodes.keys()].filter(id => id.startsWith('packages/'))
         const transitiveIds = scopedNodeIds
             .filter(id => directIds.has(id) || graph.reachesAny(id, node => directIds.has(node.id)))
@@ -111,17 +112,8 @@ describe('transitive impurity (ts-morph call graph)', () => {
     }, 120000)
 })
 
-function collectDirectlyImpureFunctionIds(graph: CallGraph): ReadonlySet<string> {
-    const project = new Project({
-        compilerOptions: {
-            moduleResolution: ts.ModuleResolutionKind.Bundler,
-            module: ts.ModuleKind.ESNext,
-            target: ts.ScriptTarget.ES2022,
-            allowJs: false,
-            skipLibCheck: true,
-            jsx: ts.JsxEmit.Preserve,
-        },
-    })
+function collectDirectlyImpureFunctionIds(graph: CallGraph, packages: readonly PackageInfo[]): ReadonlySet<string> {
+    const project = createRepoTsMorphProject(REPO_ROOT, packages)
     const files = [...new Set([...graph.nodes.values()].map(node => resolve(REPO_ROOT, node.file)))]
     const sourceFiles = project.addSourceFilesAtPaths(files)
     const functionNodes = new Map<string, FunctionSyntax>()

--- a/packages/measures/src/health/shape/import-graph-invariants.test.ts
+++ b/packages/measures/src/health/shape/import-graph-invariants.test.ts
@@ -1,8 +1,10 @@
 import {existsSync} from 'node:fs'
 import {dirname, join, relative, resolve} from 'node:path'
 import {fileURLToPath} from 'node:url'
-import {Project, ts, type ExportDeclaration, type ImportDeclaration, type SourceFile} from 'ts-morph'
+import {ts, type ExportDeclaration, type ImportDeclaration, type Project, type SourceFile} from 'ts-morph'
 import {beforeAll, describe, expect, it} from 'vitest'
+import {discoverPackages, type PackageInfo} from '../../_shared/discovery/discover-packages'
+import {createRepoTsMorphProject} from '../../_shared/graph/repo-ts-morph-project'
 import {recordHealthMetric} from '../../_shared/writers/report-writer'
 
 const TEST_DIR: string = dirname(fileURLToPath(import.meta.url))
@@ -69,17 +71,8 @@ function importerIsServer(pkg: string): boolean {
     return pkg === SERVER_PACKAGE_DIR || pkg.startsWith(`${SERVER_PACKAGE_DIR}/`)
 }
 
-function buildProject(): Project {
-    const project = new Project({
-        compilerOptions: {
-            moduleResolution: ts.ModuleResolutionKind.Bundler,
-            module: ts.ModuleKind.ESNext,
-            target: ts.ScriptTarget.ES2022,
-            allowJs: false,
-            skipLibCheck: true,
-            jsx: ts.JsxEmit.Preserve,
-        },
-    })
+function buildProject(packages: readonly PackageInfo[]): Project {
+    const project = createRepoTsMorphProject(REPO_ROOT, packages)
     project.addSourceFilesAtPaths([
         `${REPO_ROOT}/packages/libraries/**/*.{ts,tsx}`,
         `${REPO_ROOT}/packages/systems/**/*.{ts,tsx}`,
@@ -247,7 +240,7 @@ function formatRelativeViolation(e: ImportEdge): string {
 let edgesPromise: Promise<readonly ImportEdge[]> | undefined
 
 async function getEdges(): Promise<readonly ImportEdge[]> {
-    edgesPromise ??= Promise.resolve(collectEdges(buildProject()))
+    edgesPromise ??= discoverPackages(REPO_ROOT).then(packages => collectEdges(buildProject(packages)))
     return edgesPromise
 }
 

--- a/packages/systems/agent-runtime/bin/vt-resume.ts
+++ b/packages/systems/agent-runtime/bin/vt-resume.ts
@@ -166,7 +166,7 @@ function formatRow(row: RecoverableAgentSession): string {
     const status: string = row.isClaimed ? 'CLAIMED' : 'unclaimed'
     const capabilities: string[] = []
     if (row.attach) capabilities.push(`attach=${row.attach.session.sessionName}`)
-    if (row.resume) capabilities.push(`resume=${row.resume.cliType}:${row.resume.nativeSessionId}`)
+    if (row.resume) capabilities.push(`resume=${row.resume.cliType}`)
     if (capabilities.length === 0) capabilities.push('-')
     return `${row.terminalId.padEnd(24)}  ${(row.agentName ?? '').padEnd(20)}  ${status.padEnd(10)}  ${capabilities.join('  ')}`
 }
@@ -201,7 +201,7 @@ async function runResume(paths: ResolvedPaths, terminalId: string, noAttach: boo
     if (!target.resume) die(`terminal '${terminalId}' has neither attach nor resume capability.`)
 
     process.stdout.write(
-        `resuming '${terminalId}' via ${target.resume.cliType} (native session ${target.resume.nativeSessionId})\n`,
+        `resuming '${terminalId}' via ${target.resume.cliType} (native session id resolved lazily by resolveNativeSession)\n`,
     )
     const result = await resumePersistedAgentSession(target.terminalId)
     if (result.kind !== 'spawned') {

--- a/scripts/run-remote.mjs
+++ b/scripts/run-remote.mjs
@@ -134,7 +134,10 @@ function repairLocalWorktreeMetadataIfNeeded({cwd = process.cwd()} = {}) {
 }
 
 function runLocal(cmd, args) {
-  const child = spawn(cmd, args, {stdio: 'inherit'})
+  const child = spawn(cmd, args, {
+    stdio: 'inherit',
+    env: {...process.env, [RECURSION_GUARD]: '1'},
+  })
   child.on('exit', (code, signal) => {
     if (signal) process.kill(process.pid, signal)
     else process.exit(code ?? 1)


### PR DESCRIPTION
## Summary

Combines two independently-verified bodies of work targeting `dev`:

- **Part A (Eli's fix)** — `Fix systems health workspace resolution` (1 commit). Adds `repo-ts-morph-project.ts`, parameterises `buildCallGraph(repoRoot, packages?)`, extends `PackageInfo` with `relDir`, and now also keeps dev's `packageJsonRelativePath` + `facadeRelativePaths` fields (real 3-way merge). All 3 originally failing health tests + the full `packages/measures/src/health/` suite (89 tests) pass.
- **Part B (Dan's BF-333 chain)** — partially landed. The only commit applied is `fix(vt-resume): drop nativeSessionId display refs` (4-line tsc cleanup). BF-333a / BF-333b / BF-334 / BF-335 are **deferred** — see "Why BF-333 deferred" below.

## Part A — Systems health workspace resolution

- `packages/measures/src/_shared/discovery/discover-packages.ts` — merged: dev's `packageJsonRelativePath`, `facadeRelativePaths`, `PackageExports`/`ConditionalExport`/`validateExports`/`ParsedPackageJson` types are preserved; branch's `relDir` field and `normalizePath` helper added (both needed — `repo-ts-morph-project.ts` consumes `pkg.relDir`).
- `packages/measures/src/_shared/graph/repo-ts-morph-project.ts` — new file. Builds `ts.CompilerOptions` with `baseUrl: repoRoot` and synthesises `paths` from the discovered workspace packages so semantic-coupling and import-graph health checks resolve `@vt/...` specifiers correctly.
- `packages/measures/src/_shared/graph/call-graph.ts` — `buildCallGraph` is now parameterised `(repoRoot, packages?)`.
- `scripts/run-remote.mjs` — small runLocal env propagation (RECURSION_GUARD), included in Eli's commit.
- Tests now use the parameterised entry points.

### Verified locally
- `vitest run packages/measures/src/health/` — **89/89 pass** (48 files, ~25s).
- All 3 originally failing tests green: `import-graph-invariants.test.ts`, `semantic-coupling-graph.test.ts`, `transitive-purity-graph.test.ts`.

## Part B — vt-resume display fix only

- `packages/systems/agent-runtime/bin/vt-resume.ts` — 4-line change: drop `nativeSessionId` from two display strings. `ResumeCapability` was narrowed to `{cliType}` in a prior refactor; the native session id is resolved lazily by `resolveNativeSession` at click time, so the display refs were dead. This silences two pre-existing tsc errors.

### Why BF-333 deferred

BF-333a (env through resolvers) and BF-333b (env through discovery + persistence) were attempted as cherry-picks. They apply mechanically (imports/path-rewrites resolved cleanly: `@vt/agent-runtime/...` → `@vt/vt-daemon/agent-runtime/...`; `./classifier/classifier` → `./classifier` against the flattened post-Lane-A layout). **However**, they regress 56 recovery tests on dev — every test that calls the legacy zero-arg shim functions (e.g. `removePersistedAgentRecord(id)`, `discoverRecoverableAgentSessions()`) now throws `Agent runtime env provider not configured` because the shims call `getRecoveryEnv()` internally.

This is the fixture-update gap Dan flagged in the BF-333b commit message ("test fixtures will need env signature updates once Manu's path fixes land — left out of this commit to minimize the diff"). The shell-side wiring that BF-333 assumes (Electron main / vt-mcpd / vt-resume calling `configureAgentRuntime({env: {recovery: ...}})`) was supposed to land as part of BF-334's `createRecoveryAPI` facade — which was already deferred due to the modify/delete conflict against Lane A's API surface deletion.

Recommendation (Option A from Dan's report): re-do BF-334 + BF-335 fresh against the new `vt-daemon/src/agent-runtime/recovery/` layout, including test-fixture updates, then land BF-333 + BF-334 + BF-335 together so the contract change and its shell wiring + test fixtures arrive atomically.

Recovery baseline on dev: `vitest run packages/systems/vt-daemon/src/agent-runtime/recovery/` — **140/140 pass** (14 files).

## CI gate bypass rationale

Pushed with `--no-verify` per user authorisation. The pre-push `npm run test:t1` gate fails on `vt-daemon-unit` because 10 concurrent agents on this devbox hold OTLP ports 4318-4327, causing `startOtlpReceiver: all ports 4318-4327 in use`. Not a regression — this branch touches nothing under `packages/systems/vt-daemon/src/transport`. Same precedent as PR #136 / commit `bfb95c956`.

## Reviewer context

- `/Users/bobbobby/repos/voicetree-public/get_dev_healthy/voicetree-28-5/task1c248v0systemshealthrebasepass.md` — Eli's rebase background
- `/Users/bobbobby/repos/voicetree-public/get_dev_healthy/voicetree-28-5/wt-recovery-fp-gates-rebase-aborted.md` — Dan's abort report

## Test plan
- [ ] CI green on the systems-health checks
- [ ] Spot-check `discover-packages.ts` consumers in CI:  `parse-subgraph.ts`, the new `repo-ts-morph-project.ts`
- [ ] Confirm no regression in `vitest run packages/systems/vt-daemon/src/agent-runtime/recovery/` (should be 140/140)