### PR TITLE
fix(graph-db-server): make DELETE /graph/node/:id idempotent

### DIFF
--- a/packages/systems/graph-db-server/src/application/workflows/graph.ts
+++ b/packages/systems/graph-db-server/src/application/workflows/graph.ts
@@ -64,11 +64,6 @@ type ApplyDeltaOptions = {
   readonly recordForUndo?: boolean
 }
 
-type DeleteGraphNodeRequest = {
-  readonly ok: true
-  readonly delta: GraphDelta
-}
-
 type WritePositionsRequest = Extract<
   ReturnType<typeof parseWritePositionsRequest>,
   WorkflowParsed
@@ -160,22 +155,6 @@ async function applyGraphDeltaAndPublish(
   })
 }
 
-async function prepareDeleteGraphNode(
-  nodeId: string,
-): Promise<ParseOutcome<DeleteGraphNodeRequest>> {
-  const existingNode = await executeCommand({ type: 'ReadGraphNode', nodeId })
-  if (!existingNode) {
-    return {
-      ok: false,
-      error: `Node not found: ${nodeId}`,
-      code: 'NODE_NOT_FOUND',
-      status: 404,
-    }
-  }
-
-  return { ok: true, delta: buildDeleteNodeDelta(nodeId, existingNode) }
-}
-
 async function parseWritePositionsInOpenVault(
   rawBody: unknown,
 ): Promise<ParseOutcome<WritePositionsInOpenVault>> {
@@ -262,15 +241,21 @@ export async function applyGraphDeltaWithOptionsWorkflow(
   })
 }
 
+// Idempotent per RFC 7231: a repeated DELETE produces the same observable
+// state. If the node is already absent from the graph the post-condition is
+// already satisfied, so we return success with `alreadyAbsent: true` instead
+// of 404 — callers driving cleanup loops (test fixtures, watcher reconcile,
+// retry-on-network-flake) no longer have to special-case "first call killed
+// it".
 export async function deleteGraphNodeWorkflow(
   nodeId: string,
   sessionId: string,
 ): Promise<HttpResult> {
-  const parsed = await prepareDeleteGraphNode(nodeId)
-  if (!parsed.ok) return parseRejectionResult(parsed)
+  const existingNode = await executeCommand({ type: 'ReadGraphNode', nodeId })
+  if (!existingNode) return jsonResult({ ok: true, alreadyAbsent: true })
 
   return await tracedApplyDeltaAndAck(
-    parsed.delta,
+    buildDeleteNodeDelta(nodeId, existingNode),
     sessionId,
     undefined,
     'GRAPH_NODE_DELETE_FAILED',

--- a/packages/systems/graph-db-server/src/data/graph/mutations/graphActionsToDBEffects.ts
+++ b/packages/systems/graph-db-server/src/data/graph/mutations/graphActionsToDBEffects.ts
@@ -203,16 +203,20 @@ function writeNodeToFile(node: GraphNode): FSWriteEffect<void> {
     )
 }
 
-/**
- * Delete a node file from filesystem
- */
+// Delete a node file from filesystem. ENOENT is treated as success: the
+// post-condition (file absent) already holds, so a concurrent unlink (watcher,
+// external editor, second DELETE) does not turn a node-removal into a 500.
 function deleteNodeFile(nodeId: NodeIdAndFilePath): FSWriteEffect<void> {
     return (env: Env) => TE.tryCatch(
         async () => {
             const plan: FileDeletePlan = createFileDeletePlan(nodeId, env.projectRoot)
 
             markPendingDelete(plan.fullPath)
-            await fs.unlink(plan.fullPath)
+            try {
+                await fs.unlink(plan.fullPath)
+            } catch (error) {
+                if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+            }
             await pruneEmptyParentDirectories(plan.fullPath, env.projectRoot)
         },
         toError

--- a/packages/systems/graph-db-server/tests/delete-node-idempotent.test.ts
+++ b/packages/systems/graph-db-server/tests/delete-node-idempotent.test.ts
@@ -1,0 +1,126 @@
+// DELETE /graph/node/:id is idempotent per RFC 7231: a repeated call (or a
+// call after the underlying file has already been removed out-of-band by the
+// watcher / external editor / a racing API caller) produces the same
+// observable post-condition — node absent from the graph — without surfacing
+// an error to the caller.
+//
+// Two failure modes used to violate this:
+//   - prepareDeleteGraphNode returned 404 when the node was already gone.
+//   - deleteNodeFile let fs.unlink's ENOENT bubble out as a 500 and left the
+//     in-memory node behind (the in-memory mutation runs as part of the same
+//     delta application that the FS failure aborts).
+// This suite asserts the post-fix contract.
+
+import { mkdir, mkdtemp, rm, unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as O from 'fp-ts/lib/Option.js'
+import type { GraphDelta, GraphNode } from '@vt/graph-model'
+import { createEmptyGraph } from '@vt/graph-model'
+
+import { startDaemon, type DaemonHandle } from '../src/daemon/index.ts'
+import { clearWatchFolderState } from '../src/state/watch-folder-store.ts'
+import { setGraph } from '../src/state/graph-store.ts'
+
+function leafNode(absolutePath: string, content: string): GraphNode {
+  return {
+    kind: 'leaf',
+    outgoingEdges: [],
+    absoluteFilePathIsID: absolutePath,
+    contentWithoutYamlOrLinks: content,
+    nodeUIMetadata: {
+      color: O.none,
+      position: O.none,
+      additionalYAMLProps: { agent_name: 'delete-idem-test' },
+    },
+  }
+}
+
+function upsertDelta(node: GraphNode): GraphDelta {
+  return [{ type: 'UpsertNode', nodeToUpsert: node, previousNode: O.none }]
+}
+
+async function postUpsert(baseUrl: string, node: GraphNode): Promise<void> {
+  const res = await fetch(`${baseUrl}/graph/delta`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(upsertDelta(node)),
+  })
+  expect(res.status).toBe(200)
+}
+
+async function deleteNode(baseUrl: string, nodeId: string): Promise<{ status: number; body: { ok?: boolean; alreadyAbsent?: boolean } }> {
+  const res = await fetch(`${baseUrl}/graph/node/${encodeURIComponent(nodeId)}`, { method: 'DELETE' })
+  return { status: res.status, body: await res.json() as { ok?: boolean; alreadyAbsent?: boolean } }
+}
+
+async function getGraphNodes(baseUrl: string): Promise<Record<string, unknown>> {
+  const res = await fetch(`${baseUrl}/graph`)
+  return (await res.json() as { nodes: Record<string, unknown> }).nodes
+}
+
+describe('DELETE /graph/node/:id idempotency', () => {
+  let root: string
+  let vault: string
+  let handle: DaemonHandle | null
+  let baseUrl: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'vt-graphd-delete-idem-'))
+    vault = path.join(root, 'vault')
+    await mkdir(vault, { recursive: true })
+    clearWatchFolderState()
+    setGraph(createEmptyGraph())
+    handle = await startDaemon({
+      vault,
+      appSupportPath: path.join(root, 'app-support'),
+      createStarterIfEmpty: false,
+    })
+    baseUrl = `http://127.0.0.1:${handle.port}`
+  })
+
+  afterEach(async () => {
+    await handle?.stop().catch(() => {})
+    handle = null
+    clearWatchFolderState()
+    setGraph(createEmptyGraph())
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('returns 200 with alreadyAbsent=true when the node was never in the graph', async () => {
+    const ghost = path.join(vault, 'never-existed.md')
+    const { status, body } = await deleteNode(baseUrl, ghost)
+    expect(status).toBe(200)
+    expect(body).toEqual({ ok: true, alreadyAbsent: true })
+  })
+
+  it('returns 200 when the file is unlinked out-of-band before DELETE runs (no 500 ENOENT)', async () => {
+    // Models the watcher-vs-api race that produced the original fuzz flake: the
+    // graph still has the node, but the file is already gone from disk by the
+    // time DELETE arrives. Pre-fix this raised 500 GRAPH_NODE_DELETE_FAILED
+    // *and* left the in-memory node behind.
+    const nodePath = path.join(vault, 'racy-delete.md')
+    await postUpsert(baseUrl, leafNode(nodePath, '# Racy\n'))
+    await unlink(nodePath)
+
+    const { status } = await deleteNode(baseUrl, nodePath)
+    expect(status).toBe(200)
+
+    const nodes = await getGraphNodes(baseUrl)
+    expect(nodes[nodePath]).toBeUndefined()
+  })
+
+  it('a second DELETE on the same node is a no-op success', async () => {
+    const nodePath = path.join(vault, 'double-delete.md')
+    await postUpsert(baseUrl, leafNode(nodePath, '# Twice\n'))
+
+    const first = await deleteNode(baseUrl, nodePath)
+    expect(first.status).toBe(200)
+    expect(first.body.alreadyAbsent).toBeUndefined()
+
+    const second = await deleteNode(baseUrl, nodePath)
+    expect(second.status).toBe(200)
+    expect(second.body).toEqual({ ok: true, alreadyAbsent: true })
+  })
+})

--- a/packages/systems/graph-db-server/tests/e2e-system.test.ts
+++ b/packages/systems/graph-db-server/tests/e2e-system.test.ts
@@ -428,15 +428,7 @@ describe('@vt/graph-db-server system contract', () => {
       expect(body.error).toMatch(/Invalid/i)
     })
 
-    it('returns 404 NODE_NOT_FOUND when DELETEing an unknown node', async () => {
-      const res = await fetch(
-        `${baseUrl}/graph/node/${encodeURIComponent(path.join(vault, 'ghost.md'))}`,
-        { method: 'DELETE' },
-      )
-      expect(res.status).toBe(404)
-      const body = (await res.json()) as { code: string }
-      expect(body.code).toBe('NODE_NOT_FOUND')
-    })
+    // Idempotency cases covered in delete-node-idempotent.test.ts.
 
     it('returns 404 on session-scoped routes when the session does not exist', async () => {
       const folderId = `${vault}/`

--- a/webapp/src/shell/edge/main/graph/applyGraphActionsToDB.test.ts
+++ b/webapp/src/shell/edge/main/graph/applyGraphActionsToDB.test.ts
@@ -276,7 +276,10 @@ describe('apply_graph_deltas_to_db', () => {
       expect(nodeDelete1).toBeUndefined()
     })
 
-    it('should fail when deleting non-existent file (fail fast)', async () => {
+    it('is idempotent: DeleteNode against an already-absent file succeeds', async () => {
+      // Post-condition (file absent) already holds, so the delta is a no-op.
+      // Pre-fix this returned Left(ENOENT) and the higher-level workflow's
+      // in-memory delete aborted too — a 500 plus a leaked node.
       const action: DeleteNode = {
         type: 'DeleteNode',
         nodeId: 'non-existent',
@@ -286,11 +289,7 @@ describe('apply_graph_deltas_to_db', () => {
       const effect: FSWriteEffect<GraphDelta> = apply_graph_deltas_to_db([action])
       const result: E.Either<Error, GraphDelta> = await effect(testEnv)()
 
-      // Fail fast - deleting non-existent file should fail
-      expect(E.isLeft(result)).toBe(true)
-      if (E.isLeft(result)) {
-        expect(result.left.message).toContain('ENOENT')
-      }
+      expect(E.isRight(result)).toBe(true)
     })
 
     it('should return the deltas that were applied', async () => {


### PR DESCRIPTION
## Summary

RFC 7231 mandates that DELETE be idempotent: repeated calls (or calls after the underlying file has been removed out-of-band) must produce the same observable post-condition without surfacing an error. The current daemon violates this in two paths.

## What broke

1. **\`prepareDeleteGraphNode\`** returned **404 \`NODE_NOT_FOUND\`** whenever the node was already absent — so cleanup loops, sync logic, and retry-on-flake callers had to special-case \"first call killed it\".
2. **\`deleteNodeFile\`** let \`fs.unlink\`'s **ENOENT** bubble out as a **500**. This fired whenever the daemon's own unlink raced with the watcher's unlink (or a concurrent DELETE, or an external editor deleting the file). The in-memory node persisted because the delta application aborted — so the caller saw a 500 _and_ the post-condition was violated. Worst of both worlds.

This is exactly the race surfaced (and worked around) in PR #140 — the fuzz test had to instrument the daemon to discover the daemon was silently leaving nodes in the graph after returning a 500.

## Fix

- \`deleteGraphNodeWorkflow\` returns **200 \`{ ok: true, alreadyAbsent: true }\`** when the node is not in the graph. Inlines the (now-trivial) \`prepareDeleteGraphNode\` and drops the unused \`DeleteGraphNodeRequest\` type.
- \`deleteNodeFile\` catches \`ENOENT\` from \`fs.unlink\` and treats it as success — the file-absent post-condition already holds. Same idiom as \`rm -f\`.

## Tests

New focused suite \`delete-node-idempotent.test.ts\` covering:
- DELETE on a never-seen node → 200 \`{ ok: true, alreadyAbsent: true }\`
- DELETE on a node whose file was unlinked out-of-band → 200, in-memory node also removed (the exact race that produced the original 500/leak)
- Second DELETE on the same node → 200 \`{ ok: true, alreadyAbsent: true }\`

Removes the obsolete \"returns 404 NODE_NOT_FOUND\" assertion from \`e2e-system.test.ts\` — its post-condition was the bug, not the contract.

## Caller impact

Any code path that relied on the **404 NODE_NOT_FOUND** branch as a signal needs to switch to checking \`{ alreadyAbsent: true }\` in the response body (still 200). Quick scan of in-repo callers shows no consumer of the 404 — they all swallow non-200 with \`.catch(() => {})\`, which is precisely the bug-induced defensive code that the fix lets us delete in follow-up.

## Not run locally

Remote dev box (mutagen \`vt-wts\` beta) disconnected mid-session — could not exercise the new test suite before pushing. CI is the verification.

## Test plan

- [ ] CI green on this branch (in particular \`tier-2-unit\`, \`tier-2-e2e\`, and \`tier-2-fuzz (fuzz-system-lifecycle)\`)
- [ ] Manual verification that no caller in the tree (electron-main, webapp, vt CLI) was switch-casing on 404 NODE_NOT_FOUND for this endpoint

## Follow-up

Once this lands, PR #140's \`cleanupSequence\` workaround can be simplified — the test no longer needs to maintain a cross-sequence \`deletedNodeIds\` ledger to compensate for daemon bugs. Leaving that simplification for a separate PR to keep the diff small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)