### PR TITLE
Fix recovery rows for terminal sidebar

### DIFF
--- a/packages/libraries/vt-daemon-protocol/src/rpc-contracts.ts
+++ b/packages/libraries/vt-daemon-protocol/src/rpc-contracts.ts
@@ -81,7 +81,7 @@ export interface UnseenNodeInfo {
  * that picks up where the prior one left off.
  */
 export interface AttachCapability {
-    readonly sessionName: string
+    readonly session: UnclaimedTmuxSession
 }
 export interface ResumeCapability {
     readonly cliType: 'claude' | 'codex'
@@ -97,8 +97,16 @@ export interface RecoverableAgentSession {
     readonly metadataPath: string
     readonly terminalData: TerminalData
     readonly isClaimed: boolean
+    readonly status: 'running' | 'exited' | 'killed'
     readonly attach?: AttachCapability
     readonly resume?: ResumeCapability
+    readonly worktreeName?: string
+    readonly title?: string
+    readonly agentTypeName?: string
+    readonly startedAt?: string
+    readonly endedAt?: string
+    readonly closedAt?: number
+    readonly killReason?: string
 }
 
 export type ResumePersistedResult =

--- a/packages/systems/vt-daemon-client/src/__tests__/wrappers.recovery.test.ts
+++ b/packages/systems/vt-daemon-client/src/__tests__/wrappers.recovery.test.ts
@@ -15,6 +15,7 @@ import type {
     ResumePersistedResult,
     TerminalData,
     TerminalId,
+    UnclaimedTmuxSession,
 } from '@vt/vt-daemon-protocol'
 
 import {bindVtDaemonClient} from '../wrappers/index.ts'
@@ -48,6 +49,17 @@ function makeTerminalData(id: string): TerminalData {
 
 describe('vt-daemon-client wrappers — recovery facade', (): void => {
     let server: FakeRpcServerHandle
+    const attachSession: UnclaimedTmuxSession = {
+        sessionName: 'voicetree-recover-1',
+        terminalId: 'recover-1',
+        hash: 'aaaaaaaaaa',
+        classification: 'this-vault',
+        attachable: true,
+        createdAt: 1_700_000_000_000,
+        panePid: 4242,
+        agentName: 'agent-recover-1',
+        projectRoot: '/var/voicetree',
+    }
 
     const sessionRows: readonly RecoverableAgentSession[] = [
         {
@@ -56,7 +68,8 @@ describe('vt-daemon-client wrappers — recovery facade', (): void => {
             metadataPath: '/var/voicetree/recover-1.json',
             terminalData: makeTerminalData('recover-1'),
             isClaimed: false,
-            attach: {sessionName: 'voicetree-recover-1'},
+            status: 'running',
+            attach: {session: attachSession},
             resume: {cliType: 'claude'},
         },
     ]
@@ -85,7 +98,8 @@ describe('vt-daemon-client wrappers — recovery facade', (): void => {
         const sessions = await vtd.recovery.discoverRecoverableAgentSessions()
         expect(sessions).toHaveLength(1)
         expect(sessions[0].terminalId).toBe('recover-1')
-        expect(sessions[0].attach?.sessionName).toBe('voicetree-recover-1')
+        expect(sessions[0].attach?.session.sessionName).toBe('voicetree-recover-1')
+        expect(sessions[0].attach?.session.classification).toBe('this-vault')
         expect(sessions[0].resume?.cliType).toBe('claude')
         expect(server.received[0].method).toBe('discoverRecoverableAgentSessions')
         expect(server.received[0].params).toEqual({})

--- a/packages/systems/vt-daemon/integration-tests/rpcRoutes.real-deps.test.ts
+++ b/packages/systems/vt-daemon/integration-tests/rpcRoutes.real-deps.test.ts
@@ -322,7 +322,7 @@ describe('rpc routes — headless', () => {
 // ─── Recovery ───────────────────────────────────────────────────────────────
 
 describe('rpc routes — recovery', () => {
-    it('discoverRecoverableAgentSessions projects attach.session → attach.sessionName at the wire boundary', async () => {
+    it('discoverRecoverableAgentSessions preserves attach session details for the renderer', async () => {
         // Stand up a real recoverable tmux session by spawning + dropping the
         // registry row; discovery picks it up via the metadata directory.
         const terminalId: TerminalId = makeTerminalId('recovery-disc')
@@ -345,13 +345,14 @@ describe('rpc routes — recovery', () => {
 
         // Discovery may legitimately return [] if no recoverable sessions are
         // found in the test sandbox. What matters is the wire shape: an
-        // array of records whose attach (when present) carries
-        // sessionName, not the full session object. Smoke-check both.
+        // array of records whose attach (when present) carries the same tmux
+        // session details the Surviving Agents renderer consumes.
         expect(Array.isArray(result)).toBe(true)
-        for (const session of result as readonly {attach?: {sessionName?: unknown; session?: unknown}}[]) {
+        for (const session of result as readonly {attach?: {session?: {sessionName?: unknown; classification?: unknown; panePid?: unknown}}}[]) {
             if (session.attach) {
-                expect(typeof session.attach.sessionName).toBe('string')
-                expect(session.attach.session).toBeUndefined() // narrowed by the handler
+                expect(typeof session.attach.session?.sessionName).toBe('string')
+                expect(['this-vault', 'foreign-vault']).toContain(session.attach.session?.classification)
+                expect(typeof session.attach.session?.panePid).toBe('number')
             }
         }
         // Silence "unused" diagnostics from the data variable.

--- a/packages/systems/vt-daemon/src/rpc/recoveryRoutes.ts
+++ b/packages/systems/vt-daemon/src/rpc/recoveryRoutes.ts
@@ -41,8 +41,16 @@ const discoverRecoverableAgentSessionsRoute: RpcRoute = {
             metadataPath: s.metadataPath,
             terminalData: s.terminalData,
             isClaimed: s.isClaimed,
-            attach: s.attach ? {sessionName: s.attach.session.sessionName} : undefined,
+            status: s.status,
+            attach: s.attach ? {session: s.attach.session} : undefined,
             resume: s.resume ? {cliType: s.resume.cliType} : undefined,
+            worktreeName: s.worktreeName,
+            title: s.title,
+            agentTypeName: s.agentTypeName,
+            startedAt: s.startedAt,
+            endedAt: s.endedAt,
+            closedAt: s.closedAt,
+            killReason: s.killReason,
         }))
         return buildJsonResponse(projected)
     },

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-context-node-agent.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-context-node-agent.spec.ts
@@ -204,6 +204,13 @@ test.describe('Context Node Agent Terminal E2E', () => {
     console.log('=== STEP 6: Verify spawn request returned a terminal id ===');
     console.log(`✓ Terminal spawn returned ID: ${terminalId}`);
 
+    console.log('=== STEP 7: Verify spawned agent appears in the terminal tree sidebar ===');
+    await expect(appWindow.getByTestId('terminal-tree-sidebar')).toBeVisible({ timeout: 15000 });
+    const terminalTreeRow = appWindow.locator(`[data-testid="terminal-tree-sidebar"] [data-terminal-id="${terminalId}"]`);
+    await expect(terminalTreeRow).toBeVisible({ timeout: 15000 });
+    await expect(terminalTreeRow).toContainText(terminalId);
+    console.log(`✓ Terminal tree sidebar shows spawned agent: ${terminalId}`);
+
     console.log('');
     console.log('=== TEST SUMMARY ===');
     console.log('✓ Agent command configured with -p flag');
@@ -212,6 +219,7 @@ test.describe('Context Node Agent Terminal E2E', () => {
     console.log('✓ Context node created from Node 5');
     console.log('✓ Terminal spawned with CONTEXT_NODE_PATH env var');
     console.log('✓ Terminal spawned for the generated context node');
+    console.log('✓ Terminal tree sidebar rendered the spawned agent');
     console.log('✓ Needle from Node 3 (2 hops away) found in context node');
     console.log('');
     console.log('✅ CONTEXT NODE AGENT TERMINAL TEST PASSED');


### PR DESCRIPTION
## Summary
- restore the recoverable-agent RPC row shape consumed by `SurvivingAgentsSection`
- include attach session details and lifecycle/display metadata in `discoverRecoverableAgentSessions` responses
- add an Electron regression assertion that spawned fake agents appear in the terminal tree sidebar

## Verification
- `pnpm --filter @vt/vt-daemon-client test -- --runInBand`
- focused webapp recovery/sidebar vitests
- `pnpm --filter @vt/vt-daemon exec vitest run integration-tests/rpcRoutes.real-deps.test.ts`
- `pnpm --filter voicetree-webapp exec tsc --noEmit`
- `pnpm --filter @vt/vt-daemon-protocol exec tsc --noEmit`
- `pnpm --filter @vt/vt-daemon-client exec tsc --noEmit`

## Notes
- The Electron critical spec was attempted twice but failed before reaching the new assertion because Cytoscape did not initialize within 30s.
- `pnpm --filter @vt/vt-daemon exec tsc --noEmit` currently fails on unrelated `RuntimeEnvProvider` drift (`getVaultSnapshot`/`getVaultPaths`).