### PR TITLE
Fix budget gate branch dependencies

### DIFF
--- a/.github/workflows/measures-budget-gate.generated.yml
+++ b/.github/workflows/measures-budget-gate.generated.yml
@@ -649,8 +649,8 @@ jobs:
 
   budget-gate:
     name: budget-gate
-    needs: [tier-0-pre-commit-lint, tier-0-pre-commit-policy, tier-0-pre-commit-static, tier-1-coverage, tier-1-e2e, tier-1-health, tier-1-structure, tier-1-typecheck, tier-2-contract, tier-2-e2e, tier-2-fuzz, tier-2-lint, tier-2-unit, tier-3-analyzers, tier-3-e2e, tier-4-analyzers, tier4-precheck]
-    if: "always()"
+    needs: [tier-0-pre-commit-lint, tier-0-pre-commit-policy, tier-0-pre-commit-static, tier-1-coverage, tier-1-e2e, tier-1-health, tier-1-structure, tier-1-typecheck, tier-2-contract, tier-2-e2e, tier-2-fuzz, tier-2-lint, tier-2-unit]
+    if: "always() && github.base_ref == 'dev'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -677,7 +677,43 @@ jobs:
           GITHUB_BASE_REF: "${{ github.base_ref }}"
           MEASURES_CONDITIONAL_JOBS_BY_BASE_REF: "{\"main\":[\"tier-4-analyzers\"]}"
           MEASURES_CONDITIONAL_PRECHECK_BY_JOB_ID: "{\"tier-4-analyzers\":\"tier4-precheck\"}"
-          MEASURES_REQUIRED_JOBS_BY_BASE_REF: "{\"dev\":[\"budget-gate\",\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\"],\"main\":[\"budget-gate\",\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\",\"tier-3-analyzers\",\"tier-3-e2e\"]}"
+          MEASURES_REQUIRED_JOBS_BY_BASE_REF: "{\"dev\":[\"budget-gate\",\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\"],\"main\":[\"budget-gate-main\",\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\",\"tier-3-analyzers\",\"tier-3-e2e\"]}"
+          MEASURES_WORKFLOW_NEEDS_JSON: "${{ toJson(needs) }}"
+        run: |
+          node --no-warnings=ExperimentalWarning --experimental-strip-types \
+            packages/measures/scripts/check-tier-budgets.ts
+
+  budget-gate-main:
+    name: budget-gate-main
+    needs: [tier-0-pre-commit-lint, tier-0-pre-commit-policy, tier-0-pre-commit-static, tier-1-coverage, tier-1-e2e, tier-1-health, tier-1-structure, tier-1-typecheck, tier-2-contract, tier-2-e2e, tier-2-fuzz, tier-2-lint, tier-2-unit, tier-3-analyzers, tier-3-e2e, tier-4-analyzers, tier4-precheck]
+    if: "always() && github.base_ref == 'main'"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm install --frozen-lockfile
+      - name: Download all check reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: reports-*
+          path: health-dashboard/reports/checks/
+          merge-multiple: true
+      - name: "Run tier budget gate (max tier 4)"
+        env:
+          GITHUB_BASE_REF: "${{ github.base_ref }}"
+          MEASURES_CONDITIONAL_JOBS_BY_BASE_REF: "{\"main\":[\"tier-4-analyzers\"]}"
+          MEASURES_CONDITIONAL_PRECHECK_BY_JOB_ID: "{\"tier-4-analyzers\":\"tier4-precheck\"}"
+          MEASURES_REQUIRED_JOBS_BY_BASE_REF: "{\"dev\":[\"budget-gate\",\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\"],\"main\":[\"budget-gate-main\",\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\",\"tier-3-analyzers\",\"tier-3-e2e\"]}"
           MEASURES_WORKFLOW_NEEDS_JSON: "${{ toJson(needs) }}"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \

--- a/packages/measures/scripts/check-tier-budgets.ts
+++ b/packages/measures/scripts/check-tier-budgets.ts
@@ -222,7 +222,7 @@ function evaluateCiIntegrity(
     const conditionalJobs = conditionalJobsByBase[opts.baseRef] ?? []
     const failures: EvaluationResult['ciFailures'][number][] = []
 
-    for (const jobId of requiredJobs.filter(id => id !== 'budget-gate')) {
+    for (const jobId of requiredJobs.filter(id => !isBudgetGateJobId(id))) {
         const result = needs[jobId]?.result ?? 'missing'
         if (result !== 'success') {
             failures.push({
@@ -283,6 +283,10 @@ function parseNeeds(json: string): Record<string, WorkflowNeed> {
     } catch {
         return {}
     }
+}
+
+function isBudgetGateJobId(id: string): boolean {
+    return id === 'budget-gate' || id.startsWith('budget-gate-')
 }
 
 function parseJsonRecord(json: string): Record<string, readonly string[]> {

--- a/packages/measures/scripts/gen-workflows.ts
+++ b/packages/measures/scripts/gen-workflows.ts
@@ -1,7 +1,7 @@
 // CI workflow generator. Reads the folder tree under packages/measures/src/checks/
 // and emits .github/workflows/measures-budget-gate.generated.yml — one GHA job per
-// `tier_N/<concern>/` folder, plus a final `budget-gate` job that downloads
-// every tier's check-report artifacts and runs the tier-4 budget gate.
+// `tier_N/<concern>/` folder, plus base-ref-specific budget-gate jobs that
+// download the check-report artifacts for that branch's required jobs.
 //
 // Architecture (per CLAUDE.md — functional core, imperative shell):
 //   discoverTiers()       → impure I/O, reads folder tree + check IDs
@@ -51,7 +51,7 @@ export type TierSpecs = {
     // Stable iteration order: tier ascending, concern alphabetical.
     readonly concerns: readonly ConcernSpec[]
     // All tier folder names participating (e.g. ['tier_0_pre_commit', 'tier_1', ...]).
-    // Used to compute `budget-gate.needs` and `<tier>.needs` membership.
+    // Used to compute `<tier>.needs` membership.
     readonly tierFolderNames: readonly string[]
 }
 
@@ -176,8 +176,9 @@ export function tierSpecsToWorkflow(input: TierSpecs): WorkflowYaml {
         }
     }
 
-    // Final budget-gate job: depends on every tier job, runs always.
-    jobs.push(budgetGateJob(jobs, maxTier, input))
+    // Base-ref-specific budget gates: each protected branch waits only for
+    // the jobs that are required or conditionally relevant for that branch.
+    jobs.push(...budgetGateJobs(jobs, maxTier, input))
 
     return {name: 'Measures (generated)', jobs}
 }
@@ -225,7 +226,7 @@ function requiredJobContextsByBaseRef(
             for (const context of contexts) addToMapSet(out, baseRef, context)
         }
     }
-    for (const baseRef of protectedBranches) addToMapSet(out, baseRef, 'budget-gate')
+    for (const baseRef of protectedBranches) addToMapSet(out, baseRef, budgetGateJobIdForBaseRef(baseRef))
     return out
 }
 
@@ -371,17 +372,65 @@ function perCheckMatrixJob(conc: ConcernSpec, input: TierSpecs): Job {
     }
 }
 
-function budgetGateJob(upstreamJobs: readonly Job[], maxTier: number, input: TierSpecs): Job {
-    const upstreamJobIds = upstreamJobs
-        .filter(j => j.id !== 'budget-gate')
-        .map(j => j.id)
+function budgetGateJobIdForBaseRef(baseRef: string): string {
+    // Keep the existing dev context name so the ruleset transition does not
+    // strand the PR that changes the generated workflow.
+    return baseRef === 'dev' ? 'budget-gate' : `budget-gate-${baseRef.replace(/[^A-Za-z0-9_-]/g, '-')}`
+}
+
+function budgetGateJobs(upstreamJobs: readonly Job[], maxTier: number, input: TierSpecs): readonly Job[] {
+    const requiredJobs = requiredJobIdsByBaseRef(input)
+    const conditionalJobs = conditionalJobIdsByBaseRef(input)
+    const conditionalPrechecks = conditionalPrecheckByJobId(input)
+    const baseRefs = [...new Set([
+        ...Object.keys(requiredJobs),
+        ...Object.keys(conditionalJobs),
+    ])].sort()
+
+    return baseRefs
+        .filter(baseRef => (requiredJobs[baseRef] ?? []).length > 0)
+        .map(baseRef => budgetGateJob({
+            id: budgetGateJobIdForBaseRef(baseRef),
+            baseRef,
+            maxTier,
+            input,
+            upstreamJobs,
+            requiredJobIds: requiredJobs[baseRef] ?? [],
+            conditionalJobIds: conditionalJobs[baseRef] ?? [],
+            conditionalPrecheckByJobId: conditionalPrechecks,
+        }))
+}
+
+function budgetGateJob(params: {
+    readonly id: string
+    readonly baseRef: string
+    readonly maxTier: number
+    readonly input: TierSpecs
+    readonly upstreamJobs: readonly Job[]
+    readonly requiredJobIds: readonly string[]
+    readonly conditionalJobIds: readonly string[]
+    readonly conditionalPrecheckByJobId: Record<string, string>
+}): Job {
+    const upstreamJobIds = new Set(params.upstreamJobs.map(j => j.id))
+    const requiredNeeds = params.requiredJobIds.filter(id => !isBudgetGateJobId(id))
+    const conditionalNeeds = params.conditionalJobIds
+    const conditionalPrecheckNeeds = params.conditionalJobIds
+        .map(id => params.conditionalPrecheckByJobId[id])
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    const needs = [...new Set([
+        ...requiredNeeds,
+        ...conditionalNeeds,
+        ...conditionalPrecheckNeeds,
+    ])]
+        .filter(id => upstreamJobIds.has(id))
         .sort()
+
     return {
-        id: 'budget-gate',
-        name: 'budget-gate',
+        id: params.id,
+        name: params.id,
         runsOn: 'ubuntu-latest',
-        needs: upstreamJobIds,
-        ifExpr: 'always()',
+        needs,
+        ifExpr: `always() && github.base_ref == '${params.baseRef}'`,
         strategy: null,
         outputs: null,
         steps: [
@@ -392,7 +441,7 @@ function budgetGateJob(upstreamJobs: readonly Job[], maxTier: number, input: Tie
             {kind: 'download-artifact', pattern: 'reports-*', path: 'health-dashboard/reports/checks/'},
             {
                 kind: 'run',
-                name: `Run tier budget gate (max tier ${maxTier})`,
+                name: `Run tier budget gate (max tier ${params.maxTier})`,
                 run: [
                     'node --no-warnings=ExperimentalWarning --experimental-strip-types \\',
                     '  packages/measures/scripts/check-tier-budgets.ts',
@@ -400,13 +449,17 @@ function budgetGateJob(upstreamJobs: readonly Job[], maxTier: number, input: Tie
                 env: {
                     GITHUB_BASE_REF: '${{ github.base_ref }}',
                     MEASURES_WORKFLOW_NEEDS_JSON: '${{ toJson(needs) }}',
-                    MEASURES_REQUIRED_JOBS_BY_BASE_REF: JSON.stringify(requiredJobIdsByBaseRef(input)),
-                    MEASURES_CONDITIONAL_JOBS_BY_BASE_REF: JSON.stringify(conditionalJobIdsByBaseRef(input)),
-                    MEASURES_CONDITIONAL_PRECHECK_BY_JOB_ID: JSON.stringify(conditionalPrecheckByJobId(input)),
+                    MEASURES_REQUIRED_JOBS_BY_BASE_REF: JSON.stringify(requiredJobIdsByBaseRef(params.input)),
+                    MEASURES_CONDITIONAL_JOBS_BY_BASE_REF: JSON.stringify(conditionalJobIdsByBaseRef(params.input)),
+                    MEASURES_CONDITIONAL_PRECHECK_BY_JOB_ID: JSON.stringify(conditionalPrecheckByJobId(params.input)),
                 },
             },
         ],
     }
+}
+
+function isBudgetGateJobId(id: string): boolean {
+    return id === 'budget-gate' || id.startsWith('budget-gate-')
 }
 
 // ── Shell ────────────────────────────────────────────────────────────────────

--- a/packages/measures/src/health/meta/workflows-drift.test.ts
+++ b/packages/measures/src/health/meta/workflows-drift.test.ts
@@ -35,10 +35,10 @@ describe('workflow generator — pure transform on a synthesized fixture', () =>
     it('is deterministic: same fixture input → identical output across runs', async () => {
         const root = await mkdtemp(join(tmpdir(), 'workflow-gen-fixture-'))
         try {
-            await writeTierFixture(root, 'tier_0_pre_commit', {needs: []}, {
+            await writeTierFixture(root, 'tier_0_pre_commit', {needs: [], protection: {requiredOn: ['dev'], conditionalOn: []}}, {
                 'lint/foo.ts': checkSrc('foo-check'),
             })
-            await writeTierFixture(root, 'tier_1', {needs: []}, {
+            await writeTierFixture(root, 'tier_1', {needs: [], protection: {requiredOn: ['dev'], conditionalOn: []}}, {
                 'unit/bar.ts': checkSrc('bar-check'),
                 'unit/baz.ts': checkSrc('baz-check'),
             })
@@ -124,8 +124,40 @@ describe('workflow generator — pure transform on a synthesized fixture', () =>
                 'tier-2-fuzz (b-fuzz)',
             ])
             expect(contexts.main).toContain('tier-3-e2e')
-            expect(contexts.main).toContain('budget-gate')
+            expect(contexts.main).toContain('budget-gate-main')
             expect(contexts.main).not.toContain('tier-4-analyzers')
+        } finally {
+            await rm(root, {recursive: true, force: true})
+        }
+    })
+
+    it('limits each budget gate needs graph to that base ref required jobs', async () => {
+        const root = await mkdtemp(join(tmpdir(), 'workflow-gen-fixture-'))
+        try {
+            await writeTierFixture(root, 'tier_1', {needs: [], protection: {requiredOn: ['dev', 'main'], conditionalOn: []}}, {
+                'unit/fast.ts': checkSrc('fast-unit'),
+            })
+            await writeTierFixture(root, 'tier_2', {needs: ['tier_1'], protection: {requiredOn: ['dev', 'main'], conditionalOn: []}}, {
+                'contract/public-api.ts': checkSrc('public-api-contract'),
+            })
+            await writeTierFixture(root, 'tier_3', {needs: ['tier_2'], protection: {requiredOn: ['main'], conditionalOn: []}}, {
+                'e2e/heavy.ts': checkSrc('heavy-e2e'),
+            })
+
+            const text = workflowYamlToText(tierSpecsToWorkflow(await discoverTiers(root)))
+
+            expect(text).toContain(
+                '  budget-gate:\n' +
+                '    name: budget-gate\n' +
+                '    needs: [tier-1-unit, tier-2-contract]\n' +
+                '    if: "always() && github.base_ref == \'dev\'"',
+            )
+            expect(text).toContain(
+                '  budget-gate-main:\n' +
+                '    name: budget-gate-main\n' +
+                '    needs: [tier-1-unit, tier-2-contract, tier-3-e2e]\n' +
+                '    if: "always() && github.base_ref == \'main\'"',
+            )
         } finally {
             await rm(root, {recursive: true, force: true})
         }
@@ -192,13 +224,13 @@ describe('workflow ruleset sync — pure projection', () => {
     it('projects generated required contexts into dev/main ruleset plans only', () => {
         const plan = planRulesets({
             dev: ['budget-gate', 'tier-1-unit'],
-            main: ['budget-gate', 'tier-1-unit', 'tier-3-e2e'],
+            main: ['budget-gate-main', 'tier-1-unit', 'tier-3-e2e'],
             scratch: ['tier-9-experiment'],
         })
 
         expect(plan).toEqual([
             {baseRef: 'dev', name: 'Require fast CI on dev', requiredStatusChecks: ['budget-gate', 'tier-1-unit']},
-            {baseRef: 'main', name: 'Require CI green on main', requiredStatusChecks: ['budget-gate', 'tier-1-unit', 'tier-3-e2e']},
+            {baseRef: 'main', name: 'Require CI green on main', requiredStatusChecks: ['budget-gate-main', 'tier-1-unit', 'tier-3-e2e']},
         ])
     })
 


### PR DESCRIPTION
## Summary
- generate base-ref-specific budget gate jobs from measures workflow protection metadata
- keep dev on the existing `budget-gate` context while limiting its `needs` to tier 0-2 required jobs
- add `budget-gate-main` for main so main can continue waiting on tier 3 and conditional tier 4 inputs

## Verification
- `pnpm --filter @vt/measures run gen:workflows:local`
- `pnpm --filter @vt/measures exec vitest run src/health/meta/workflows-drift.test.ts src/checks/tier_4/analyzers/timing-budget-gate.test.ts`
- `pnpm --filter @vt/measures run sync:workflow-rulesets:local`
- `pnpm --filter @vt/measures exec vitest run src/health/meta src/checks/tier_4/analyzers/timing-budget-gate.test.ts`