### PR TITLE
Make orphan graph node rule overridable

### DIFF
--- a/packages/libraries/graph-tools/src/node.ts
+++ b/packages/libraries/graph-tools/src/node.ts
@@ -119,6 +119,3 @@ export {
     type FilesystemAuthoringReportEntry,
     type FilesystemAuthoringPlanResult,
 } from './authoring/filesystemAuthoring'
-
-export {extractExistingParentRefs} from './authoring/authoringFixes'
-

--- a/packages/libraries/graph-tools/src/node.ts
+++ b/packages/libraries/graph-tools/src/node.ts
@@ -120,3 +120,5 @@ export {
     type FilesystemAuthoringPlanResult,
 } from './authoring/filesystemAuthoring'
 
+export {extractExistingParentRefs} from './authoring/authoringFixes'
+

--- a/packages/systems/voicetree-cli/src/commands/graph/actions/create.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/actions/create.ts
@@ -34,7 +34,13 @@ import {
     type GatedInput,
 } from './gateVerdicts'
 import {emitBatchReport, emitMcpFailureAndExit} from './batchEmit'
-import {findOrphanNodes, type OrphanNodeError} from './orphanCheck'
+import {
+    filesystemViolationsToPlanErrors,
+    findNodeMustHaveEdgeViolations,
+    resolveFilesystemOverrides,
+    violationFilenamesByRuleId,
+    type FilesystemRuleViolation,
+} from './orphanCheck'
 import {
     indexMcpResults,
     indexPlanErrorsByFilename,
@@ -130,12 +136,15 @@ async function runFilesystem(
         return
     }
 
-    const orphanErrors: readonly OrphanNodeError[] = findOrphanNodes(
+    const attachmentViolations: readonly FilesystemRuleViolation[] = findNodeMustHaveEdgeViolations(
         planResult.writePlan,
         externalParentRef,
     )
-    if (orphanErrors.length > 0) {
-        const {byFilename} = indexPlanErrorsByFilename(orphanErrors)
+    const attachmentOverrides = resolveFilesystemOverrides(attachmentViolations, parsedArgs.overrides)
+    if (attachmentOverrides.unresolved.length > 0) {
+        const {byFilename} = indexPlanErrorsByFilename(
+            filesystemViolationsToPlanErrors(attachmentOverrides.unresolved),
+        )
         const merged: readonly NodeVerdict[] = mergePlanIntoGateVerdicts(
             gateVerdicts,
             planResult.writePlan,
@@ -149,6 +158,7 @@ async function runFilesystem(
         gateVerdicts,
         planResult.writePlan,
         new Map(),
+        violationFilenamesByRuleId(attachmentViolations, 'node_must_have_edge'),
     )
 
     if (parsedArgs.validateOnly) {

--- a/packages/systems/voicetree-cli/src/commands/graph/actions/create.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/actions/create.ts
@@ -34,6 +34,7 @@ import {
     type GatedInput,
 } from './gateVerdicts'
 import {emitBatchReport, emitMcpFailureAndExit} from './batchEmit'
+import {findOrphanNodes, type OrphanNodeError} from './orphanCheck'
 import {
     indexMcpResults,
     indexPlanErrorsByFilename,
@@ -126,6 +127,21 @@ async function runFilesystem(
         const {byFilename, unattached} = indexPlanErrorsByFilename(planResult.errors)
         const merged: readonly NodeVerdict[] = mergePlanIntoGateVerdicts(gateVerdicts, [], byFilename)
         emitBatchReport(buildBatchReport(merged, unattached))
+        return
+    }
+
+    const orphanErrors: readonly OrphanNodeError[] = findOrphanNodes(
+        planResult.writePlan,
+        externalParentRef,
+    )
+    if (orphanErrors.length > 0) {
+        const {byFilename} = indexPlanErrorsByFilename(orphanErrors)
+        const merged: readonly NodeVerdict[] = mergePlanIntoGateVerdicts(
+            gateVerdicts,
+            planResult.writePlan,
+            byFilename,
+        )
+        emitBatchReport(buildBatchReport(merged))
         return
     }
 

--- a/packages/systems/voicetree-cli/src/commands/graph/actions/mergeVerdicts.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/actions/mergeVerdicts.ts
@@ -9,10 +9,12 @@ import type {
     GraphCreateSuccess,
     NodeVerdict,
 } from '../core/types'
+import type {OverridableRuleId} from '@vt/graph-validation'
 
 type PlanErrorLike = {
     readonly message: string
     readonly filename?: string
+    readonly ruleId?: OverridableRuleId
 }
 
 export function indexMcpResults(result: GraphCreateSuccess): ReadonlyMap<string, GraphCreateResult> {
@@ -82,6 +84,7 @@ export function mergePlanIntoGateVerdicts(
     gateVerdicts: readonly GatedInput[],
     writePlan: readonly FilesystemAuthoringPlanEntry[],
     planErrorsByFilename: ReadonlyMap<string, readonly PlanErrorLike[]>,
+    overriddenRuleIdsByFilename: ReadonlyMap<string, readonly OverridableRuleId[]> = new Map(),
 ): readonly NodeVerdict[] {
     const planByFilename: Map<string, FilesystemAuthoringPlanEntry> = new Map()
     for (const entry of writePlan) {
@@ -89,27 +92,33 @@ export function mergePlanIntoGateVerdicts(
     }
 
     return gateVerdicts.map((gated): NodeVerdict => {
-        // A plan-level rejection (orphan node, duplicate target, oversized body)
-        // is a structural impossibility that must override any non-rejected gate
-        // verdict, including `skipped` (schema didn't apply). A skipped verdict
-        // is not an endorsement: an orphan whose folder has no schema plugin must
-        // still be rejected, never silently dropped.
+        // Plan-level rejections must override any non-rejected gate verdict,
+        // including `skipped` (schema didn't apply). A skipped verdict is not
+        // an endorsement: an unresolved attachment rule violation whose folder
+        // has no schema plugin must still be rejected, never silently dropped.
         const planErrors: readonly PlanErrorLike[] | undefined =
             planErrorsByFilename.get(gated.path)
         if (planErrors !== undefined && planErrors.length > 0) {
+            const ruleIds: readonly OverridableRuleId[] = [
+                ...new Set(planErrors.flatMap((e) => e.ruleId === undefined ? [] : [e.ruleId])),
+            ]
             return {
                 path: gated.path,
                 status: 'rejected',
                 planErrorMessage: planErrors.map((e) => e.message).join('; '),
+                ...(ruleIds.length > 0 ? {ruleIds} : {}),
             }
         }
 
         if (gated.verdict.status !== 'ok') return gated.verdict
 
         const planEntry: FilesystemAuthoringPlanEntry | undefined = planByFilename.get(gated.path)
+        const overriddenRuleIds: readonly OverridableRuleId[] | undefined =
+            overriddenRuleIdsByFilename.get(gated.path)
         return {
             ...gated.verdict,
             ...(planEntry && planEntry.fixes.length > 0 ? {fixes: planEntry.fixes} : {}),
+            ...(overriddenRuleIds && overriddenRuleIds.length > 0 ? {overriddenRuleIds} : {}),
         }
     })
 }

--- a/packages/systems/voicetree-cli/src/commands/graph/actions/mergeVerdicts.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/actions/mergeVerdicts.ts
@@ -1,7 +1,6 @@
 import type {
     FilesystemAuthoringFix,
     FilesystemAuthoringPlanEntry,
-    FilesystemAuthoringValidationError,
 } from '@vt/graph-tools/node'
 import type {AppliedNode} from '../io/filesystem'
 import type {GatedInput} from './gateVerdicts'
@@ -10,6 +9,11 @@ import type {
     GraphCreateSuccess,
     NodeVerdict,
 } from '../core/types'
+
+type PlanErrorLike = {
+    readonly message: string
+    readonly filename?: string
+}
 
 export function indexMcpResults(result: GraphCreateSuccess): ReadonlyMap<string, GraphCreateResult> {
     const indexed: Map<string, GraphCreateResult> = new Map()
@@ -54,20 +58,20 @@ export function mergeMcpResults(
     })
 }
 
-export function indexPlanErrorsByFilename(
-    errors: readonly FilesystemAuthoringValidationError[],
+export function indexPlanErrorsByFilename<T extends PlanErrorLike>(
+    errors: readonly T[],
 ): {
-    readonly byFilename: ReadonlyMap<string, readonly FilesystemAuthoringValidationError[]>
-    readonly unattached: readonly FilesystemAuthoringValidationError[]
+    readonly byFilename: ReadonlyMap<string, readonly T[]>
+    readonly unattached: readonly T[]
 } {
-    const byFilename: Map<string, FilesystemAuthoringValidationError[]> = new Map()
-    const unattached: FilesystemAuthoringValidationError[] = []
+    const byFilename: Map<string, T[]> = new Map()
+    const unattached: T[] = []
     for (const err of errors) {
         if (err.filename === undefined) {
             unattached.push(err)
             continue
         }
-        const existing: FilesystemAuthoringValidationError[] = byFilename.get(err.filename) ?? []
+        const existing: T[] = byFilename.get(err.filename) ?? []
         existing.push(err)
         byFilename.set(err.filename, existing)
     }
@@ -77,7 +81,7 @@ export function indexPlanErrorsByFilename(
 export function mergePlanIntoGateVerdicts(
     gateVerdicts: readonly GatedInput[],
     writePlan: readonly FilesystemAuthoringPlanEntry[],
-    planErrorsByFilename: ReadonlyMap<string, readonly FilesystemAuthoringValidationError[]>,
+    planErrorsByFilename: ReadonlyMap<string, readonly PlanErrorLike[]>,
 ): readonly NodeVerdict[] {
     const planByFilename: Map<string, FilesystemAuthoringPlanEntry> = new Map()
     for (const entry of writePlan) {
@@ -85,9 +89,12 @@ export function mergePlanIntoGateVerdicts(
     }
 
     return gateVerdicts.map((gated): NodeVerdict => {
-        if (gated.verdict.status !== 'ok') return gated.verdict
-
-        const planErrors: readonly FilesystemAuthoringValidationError[] | undefined =
+        // A plan-level rejection (orphan node, duplicate target, oversized body)
+        // is a structural impossibility that must override any non-rejected gate
+        // verdict, including `skipped` (schema didn't apply). A skipped verdict
+        // is not an endorsement: an orphan whose folder has no schema plugin must
+        // still be rejected, never silently dropped.
+        const planErrors: readonly PlanErrorLike[] | undefined =
             planErrorsByFilename.get(gated.path)
         if (planErrors !== undefined && planErrors.length > 0) {
             return {
@@ -96,6 +103,8 @@ export function mergePlanIntoGateVerdicts(
                 planErrorMessage: planErrors.map((e) => e.message).join('; '),
             }
         }
+
+        if (gated.verdict.status !== 'ok') return gated.verdict
 
         const planEntry: FilesystemAuthoringPlanEntry | undefined = planByFilename.get(gated.path)
         return {

--- a/packages/systems/voicetree-cli/src/commands/graph/actions/orphanCheck.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/actions/orphanCheck.ts
@@ -2,12 +2,14 @@ import {
     extractExistingParentRefs,
     type FilesystemAuthoringPlanEntry,
 } from '@vt/graph-tools/node'
+import type {OverridableRuleId, OverrideEntry} from '@vt/graph-validation'
 import {normalizeRef} from '../core/util'
 
-export type OrphanNodeError = {
-    readonly code: 'orphan_node'
+export type FilesystemRuleViolation = {
+    readonly ruleId: OverridableRuleId
     readonly message: string
-    readonly filename: string
+    readonly nodeFilename: string
+    readonly details: Readonly<Record<string, unknown>>
 }
 
 /**
@@ -32,21 +34,71 @@ export type OrphanNodeError = {
  * `shouldAttachExternalParent` so this check stays consistent with what is
  * actually written to disk.
  */
-export function findOrphanNodes(
+export function findNodeMustHaveEdgeViolations(
     writePlan: readonly FilesystemAuthoringPlanEntry[],
     externalParentRef: string | undefined,
-): readonly OrphanNodeError[] {
+): readonly FilesystemRuleViolation[] {
     return writePlan
         .filter((entry) => !entryWillHaveParent(entry, externalParentRef))
         .map((entry) => ({
-            code: 'orphan_node',
+            ruleId: 'node_must_have_edge',
             message:
                 `Node "${entry.filename}" has no parent edge; it would be created ` +
                 `disconnected from the graph. Add a "- parent [[<existing-node>]]" line ` +
                 `to its body, anchor it under a --manifest tree whose root links to an ` +
                 `existing node, or pass --parent <existing-node>.`,
-            filename: entry.filename,
+            nodeFilename: entry.filename,
+            details: {filename: entry.filename},
         }))
+}
+
+export function resolveFilesystemOverrides(
+    violations: readonly FilesystemRuleViolation[],
+    overrides: readonly OverrideEntry[],
+): {
+    readonly unresolved: readonly FilesystemRuleViolation[]
+    readonly accepted: readonly OverrideEntry[]
+} {
+    const overridesByRuleId: ReadonlyMap<OverridableRuleId, OverrideEntry> = new Map(
+        overrides.map((entry) => [entry.ruleId, entry]),
+    )
+    const unresolved: FilesystemRuleViolation[] = []
+    const acceptedByRuleId: Map<OverridableRuleId, OverrideEntry> = new Map()
+
+    for (const violation of violations) {
+        const override: OverrideEntry | undefined = overridesByRuleId.get(violation.ruleId)
+        if (override === undefined) {
+            unresolved.push(violation)
+            continue
+        }
+        acceptedByRuleId.set(violation.ruleId, override)
+    }
+
+    return {unresolved, accepted: [...acceptedByRuleId.values()]}
+}
+
+export function violationFilenamesByRuleId(
+    violations: readonly FilesystemRuleViolation[],
+    ruleId: OverridableRuleId,
+): ReadonlyMap<string, readonly OverridableRuleId[]> {
+    const byFilename: Map<string, OverridableRuleId[]> = new Map()
+    for (const violation of violations) {
+        if (violation.ruleId !== ruleId) continue
+        const existing: OverridableRuleId[] = byFilename.get(violation.nodeFilename) ?? []
+        existing.push(violation.ruleId)
+        byFilename.set(violation.nodeFilename, existing)
+    }
+    return byFilename
+}
+
+export function filesystemViolationsToPlanErrors(
+    violations: readonly FilesystemRuleViolation[],
+): readonly {readonly message: string; readonly filename: string; readonly ruleId: OverridableRuleId}[] {
+    return violations.map((violation) => ({
+        message: violation.message,
+        filename: violation.nodeFilename,
+        ruleId: violation.ruleId,
+    }))
 }
 
 function entryWillHaveParent(

--- a/packages/systems/voicetree-cli/src/commands/graph/actions/orphanCheck.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/actions/orphanCheck.ts
@@ -1,0 +1,62 @@
+import {
+    extractExistingParentRefs,
+    type FilesystemAuthoringPlanEntry,
+} from '@vt/graph-tools/node'
+import {normalizeRef} from '../core/util'
+
+export type OrphanNodeError = {
+    readonly code: 'orphan_node'
+    readonly message: string
+    readonly filename: string
+}
+
+/**
+ * Attachment policy for filesystem-mode `graph create`.
+ *
+ * The pure plan builder (`buildFilesystemAuthoringPlan`) is deliberately
+ * agnostic about whether a node connects to the *existing* graph: a manifest
+ * tree root legitimately has no in-batch parent, and whether that is an orphan
+ * depends entirely on the external `--parent`, which only the CLI knows. So
+ * the "every created node must have a parent edge" policy lives here, at the
+ * orchestration edge, not in the library.
+ *
+ * A node is attached iff, after the plan is written, its file will contain at
+ * least one `- parent [[...]]` line. That happens when:
+ *   - it already carries a parent line (author-supplied body link or a
+ *     manifest-derived parent, both are present in the assembled markdown), or
+ *   - it will receive the external `--parent` appended by `applyFilesystemPlan`,
+ *     which targets exactly the manifest-rootless nodes that are not the
+ *     external parent itself.
+ *
+ * The `willAttachExternal` clause mirrors `applyFilesystemPlan`'s
+ * `shouldAttachExternalParent` so this check stays consistent with what is
+ * actually written to disk.
+ */
+export function findOrphanNodes(
+    writePlan: readonly FilesystemAuthoringPlanEntry[],
+    externalParentRef: string | undefined,
+): readonly OrphanNodeError[] {
+    return writePlan
+        .filter((entry) => !entryWillHaveParent(entry, externalParentRef))
+        .map((entry) => ({
+            code: 'orphan_node',
+            message:
+                `Node "${entry.filename}" has no parent edge; it would be created ` +
+                `disconnected from the graph. Add a "- parent [[<existing-node>]]" line ` +
+                `to its body, anchor it under a --manifest tree whose root links to an ` +
+                `existing node, or pass --parent <existing-node>.`,
+            filename: entry.filename,
+        }))
+}
+
+function entryWillHaveParent(
+    entry: FilesystemAuthoringPlanEntry,
+    externalParentRef: string | undefined,
+): boolean {
+    const hasParentLine: boolean = extractExistingParentRefs(entry.markdown).size > 0
+    const willAttachExternal: boolean =
+        externalParentRef !== undefined &&
+        entry.parentFilenames.length === 0 &&
+        normalizeRef(entry.filename) !== externalParentRef
+    return hasParentLine || willAttachExternal
+}

--- a/packages/systems/voicetree-cli/src/commands/graph/actions/orphanCheck.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/actions/orphanCheck.ts
@@ -1,5 +1,4 @@
 import {
-    extractExistingParentRefs,
     type FilesystemAuthoringPlanEntry,
 } from '@vt/graph-tools/node'
 import type {OverridableRuleId, OverrideEntry} from '@vt/graph-validation'
@@ -105,10 +104,14 @@ function entryWillHaveParent(
     entry: FilesystemAuthoringPlanEntry,
     externalParentRef: string | undefined,
 ): boolean {
-    const hasParentLine: boolean = extractExistingParentRefs(entry.markdown).size > 0
+    const hasParentLine: boolean = hasCanonicalParentLine(entry.markdown)
     const willAttachExternal: boolean =
         externalParentRef !== undefined &&
         entry.parentFilenames.length === 0 &&
         normalizeRef(entry.filename) !== externalParentRef
     return hasParentLine || willAttachExternal
+}
+
+function hasCanonicalParentLine(markdown: string): boolean {
+    return /^- parent \[\[[^[\]\n\r]+\]\]$/m.test(markdown)
 }

--- a/packages/systems/voicetree-cli/src/commands/graph/core/args.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/core/args.ts
@@ -206,14 +206,11 @@ function parseGraphCreateArgs(args: string[]): ParsedGraphCreateArgs {
             })()
             : undefined
 
-        if (overrides.length > 0) {
-            error('--override is only valid with live-mode (--node / --nodes-file / stdin), not filesystem markdown inputs')
-        }
-
         return {
             mode: 'filesystem',
             inputFilePaths,
             validateOnly,
+            overrides,
             ...(parentValue ? {parentPath: parentValue} : {}),
             ...(color ? {color} : {}),
             ...(manifest ? {manifest} : {}),

--- a/packages/systems/voicetree-cli/src/commands/graph/core/schemaGate.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/core/schemaGate.ts
@@ -116,7 +116,7 @@ export function formatBatchReportLine(verdict: NodeVerdict): string {
             const ruleIdsLabel: string = ruleIds.length > 0 ? `  ${formatRuleIdList(ruleIds)}` : ''
             const planMessage: string = verdict.planErrorMessage ? `  ${verdict.planErrorMessage}` : ''
             const overrideHint: string =
-                ruleIds.length > 0 && verdict.typeName !== undefined
+                ruleIds.length > 0
                     ? `  (rerun with ${formatOverrideHint(ruleIds)})`
                     : ''
             return `✗ ${verdict.path}${ruleIdsLabel}${planMessage}${overrideHint}`

--- a/packages/systems/voicetree-cli/src/commands/graph/core/types.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/core/types.ts
@@ -137,6 +137,7 @@ export type ParsedFilesystemModeArgs = {
     color?: string
     manifest?: StructureManifest
     validateOnly: boolean
+    overrides: readonly OverrideSpec[]
 }
 
 export type ParsedGraphCreateArgs = ParsedLiveCreateArgs | ParsedFilesystemModeArgs

--- a/packages/systems/voicetree-cli/src/commands/graph/tests/graph.batch-reporting.test.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/tests/graph.batch-reporting.test.ts
@@ -182,13 +182,39 @@ describe('graph create batch reporting (filesystem mode)', () => {
         const payload = JSON.parse(result.stderr.trim())
         expect(payload).toMatchObject({
             kind: 'graph_create_batch_result',
-            nodes: [{path: 'work/lonely.md', status: 'rejected'}],
+            nodes: [{path: 'work/lonely.md', status: 'rejected', ruleIds: ['node_must_have_edge']}],
             summary: {ok: 0, rejected: 1, skipped: 0, warning: 0},
         })
         expect(payload.nodes[0].planErrorMessage).toContain('no parent edge')
         // The orphan check rejects before applyFilesystemPlan runs, so the source
         // file is left exactly as the author wrote it: no frontmatter/parent fixes applied.
         expect(await readFile(join(vaultRoot, 'work', 'lonely.md'), 'utf8')).toBe('# Lonely\n\nNeeded marker.\n')
+    })
+
+    it('case 13: orphan rule can be overridden with rationale', async () => {
+        await writeFile(join(vaultRoot, 'work', 'lonely.md'), '# Lonely\n\nNeeded marker.\n', 'utf8')
+
+        const result: CapturedRun = await captureGraphCreate(
+            ['work/lonely.md', '--override', 'node_must_have_edge:intentional inbox node'],
+            vaultRoot,
+        )
+
+        expect(result.exitCode).toBeNull()
+        const payload = JSON.parse(result.stdout)
+        expect(payload).toMatchObject({
+            nodes: [
+                {
+                    path: 'work/lonely.md',
+                    status: 'ok',
+                    overriddenRuleIds: ['node_must_have_edge'],
+                },
+            ],
+            summary: {ok: 1, rejected: 0, skipped: 0, warning: 0},
+        })
+        const written = await readFile(join(vaultRoot, 'work', 'lonely.md'), 'utf8')
+        expect(written).toContain('# Lonely')
+        expect(written).toContain('isContextNode: false')
+        expect(written).not.toContain('- parent [[')
     })
 
     it('case 12: a body parent link satisfies attachment without --parent', async () => {

--- a/packages/systems/voicetree-cli/src/commands/graph/tests/graph.batch-reporting.test.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/tests/graph.batch-reporting.test.ts
@@ -46,7 +46,10 @@ describe('graph create batch reporting (filesystem mode)', () => {
         await writeFile(join(vaultRoot, 'work', 'a.md'), '# A\n\nNeeded marker present.\n', 'utf8')
         await writeFile(join(vaultRoot, 'work', 'b.md'), '# B\n\nNeeded marker present.\n', 'utf8')
 
-        const result: CapturedRun = await captureGraphCreate(['work/a.md', 'work/b.md'], vaultRoot)
+        const result: CapturedRun = await captureGraphCreate(
+            ['work/a.md', 'work/b.md', '--parent', 'work/work.md'],
+            vaultRoot,
+        )
 
         expect(result.exitCode).toBeNull()
         const payload = JSON.parse(result.stdout)
@@ -107,7 +110,10 @@ describe('graph create batch reporting (filesystem mode)', () => {
         await mkdir(freeDir, {recursive: true})
         await writeFile(join(freeDir, 'note.md'), '# Free\n\nanything goes\n', 'utf8')
 
-        const result: CapturedRun = await captureGraphCreate(['free/note.md'], vaultRoot)
+        const result: CapturedRun = await captureGraphCreate(
+            ['free/note.md', '--parent', 'work/work.md'],
+            vaultRoot,
+        )
 
         expect(result.exitCode).toBeNull()
         const payload = JSON.parse(result.stdout)
@@ -134,7 +140,10 @@ describe('graph create batch reporting (filesystem mode)', () => {
     it('case 8: JSON envelope shape — top-level kind/nodes/summary present', async () => {
         await writeFile(join(vaultRoot, 'work', 'a.md'), '# A\n\nNeeded marker.\n', 'utf8')
 
-        const result: CapturedRun = await captureGraphCreate(['work/a.md'], vaultRoot)
+        const result: CapturedRun = await captureGraphCreate(
+            ['work/a.md', '--parent', 'work/work.md'],
+            vaultRoot,
+        )
 
         expect(result.exitCode).toBeNull()
         const payload = JSON.parse(result.stdout)
@@ -151,7 +160,10 @@ describe('graph create batch reporting (filesystem mode)', () => {
 
     it('case 9: stderr-vs-stdout split — rejection envelope on stderr, success envelope on stdout', async () => {
         await writeFile(join(vaultRoot, 'work', 'good.md'), '# G\n\nNeeded marker.\n', 'utf8')
-        const okOnly: CapturedRun = await captureGraphCreate(['work/good.md'], vaultRoot)
+        const okOnly: CapturedRun = await captureGraphCreate(
+            ['work/good.md', '--parent', 'work/work.md'],
+            vaultRoot,
+        )
         expect(okOnly.stdout).toContain('graph_create_batch_result')
         expect(okOnly.stderr).toBe('')
 
@@ -159,6 +171,41 @@ describe('graph create batch reporting (filesystem mode)', () => {
         const rejected: CapturedRun = await captureGraphCreate(['work/bad.md'], vaultRoot)
         expect(rejected.stderr).toContain('graph_create_batch_result')
         expect(rejected.stdout).toBe('')
+    })
+
+    it('case 11: orphan rejection - a node with no parent and no --parent is rejected and not written', async () => {
+        await writeFile(join(vaultRoot, 'work', 'lonely.md'), '# Lonely\n\nNeeded marker.\n', 'utf8')
+
+        const result: CapturedRun = await captureGraphCreate(['work/lonely.md'], vaultRoot)
+
+        expect(result.exitCode).toBe(1)
+        const payload = JSON.parse(result.stderr.trim())
+        expect(payload).toMatchObject({
+            kind: 'graph_create_batch_result',
+            nodes: [{path: 'work/lonely.md', status: 'rejected'}],
+            summary: {ok: 0, rejected: 1, skipped: 0, warning: 0},
+        })
+        expect(payload.nodes[0].planErrorMessage).toContain('no parent edge')
+        // The orphan check rejects before applyFilesystemPlan runs, so the source
+        // file is left exactly as the author wrote it: no frontmatter/parent fixes applied.
+        expect(await readFile(join(vaultRoot, 'work', 'lonely.md'), 'utf8')).toBe('# Lonely\n\nNeeded marker.\n')
+    })
+
+    it('case 12: a body parent link satisfies attachment without --parent', async () => {
+        await writeFile(
+            join(vaultRoot, 'work', 'anchored.md'),
+            '# Anchored\n\nNeeded marker.\n\n- parent [[work]]\n',
+            'utf8',
+        )
+
+        const result: CapturedRun = await captureGraphCreate(['work/anchored.md'], vaultRoot)
+
+        expect(result.exitCode).toBeNull()
+        const payload = JSON.parse(result.stdout)
+        expect(payload).toMatchObject({
+            nodes: [{path: 'work/anchored.md', status: 'ok'}],
+            summary: {ok: 1, rejected: 0, skipped: 0, warning: 0},
+        })
     })
 })
 

--- a/packages/systems/voicetree-cli/src/commands/graph/tests/graph.override-flag.test.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/tests/graph.override-flag.test.ts
@@ -31,16 +31,18 @@ function captureParse(args: string[]): {parsed?: unknown; stderr: string; exitCo
 }
 
 describe('parseGraphCreateArgs --override', () => {
-    it('accepts node_line_limit and grandparent_attachment, accumulating multiple', () => {
+    it('accepts graph validation rule overrides, accumulating multiple', () => {
         const result = captureParse([
             '--node', 'T::S',
             '--override', 'node_line_limit:large diff',
             '--override', 'grandparent_attachment:cross-team context',
+            '--override', 'node_must_have_edge:intentional parking lot',
         ])
         expect(result.exitCode).toBeNull()
         expect((result.parsed as ParsedLiveCreateArgs).overrides).toEqual([
             {ruleId: 'node_line_limit', rationale: 'large diff'},
             {ruleId: 'grandparent_attachment', rationale: 'cross-team context'},
+            {ruleId: 'node_must_have_edge', rationale: 'intentional parking lot'},
         ])
     })
 
@@ -56,10 +58,12 @@ describe('parseGraphCreateArgs --override', () => {
         expect(result.stderr).toContain('--override')
     })
 
-    it('rejects --override in filesystem mode (CLI gate is non-overridable)', () => {
+    it('accepts --override in filesystem mode for graph validation rules', () => {
         const result = captureParse(['some-file.md', '--override', 'node_line_limit:reason'])
-        expect(result.exitCode).toBe(1)
-        expect(result.stderr).toContain('only valid with live-mode')
+        expect(result.exitCode).toBeNull()
+        expect((result.parsed as {overrides: readonly OverrideSpec[]}).overrides).toEqual([
+            {ruleId: 'node_line_limit', rationale: 'reason'},
+        ])
     })
 })
 
@@ -142,6 +146,7 @@ describe('rewriteOverrideHintForCli', () => {
             '',
             '  • [node_line_limit] Node is too long (node: "x.md")',
             '  • [grandparent_attachment] Target parent is an ancestor (node: "__graph_root__")',
+            '  • [node_must_have_edge] Node has no parent edge (node: "lonely.md")',
             '',
             'To override, add "override_with_rationale" to your create_graph call:',
             '[{"ruleId":"node_line_limit","rationale":"<explain>"}]',
@@ -150,6 +155,7 @@ describe('rewriteOverrideHintForCli', () => {
         expect(rewritten).toContain('To override, re-run with:')
         expect(rewritten).toContain("--override 'node_line_limit:<rationale>'")
         expect(rewritten).toContain("--override 'grandparent_attachment:<rationale>'")
+        expect(rewritten).toContain("--override 'node_must_have_edge:<rationale>'")
         expect(rewritten).not.toContain('override_with_rationale')
     })
 

--- a/packages/systems/voicetree-cli/src/commands/graph/tests/graph.schema-gate.test.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/tests/graph.schema-gate.test.ts
@@ -201,17 +201,21 @@ describe('graph create schema gate (filesystem mode)', () => {
         })
     })
 
-    it('rejects --override flags in filesystem mode (CLI gate is non-overridable)', async () => {
+    it('accepts filesystem --override for graph validation rules', async () => {
         const targetPath: string = join(vaultRoot, 'work', 'topic.md')
         await writeFile(targetPath, '# Topic\n\nNeeded marker.\n', 'utf8')
 
         const result: CapturedRun = await captureGraphCreate(
-            ['work/topic.md', '--override', 'node_line_limit:reason'],
+            ['work/topic.md', '--override', 'node_must_have_edge:temporary unlinked note'],
             vaultRoot
         )
 
-        expect(result.exitCode).toBe(1)
-        expect(result.stderr).toContain('--override is only valid with live-mode')
+        expect(result.exitCode).toBeNull()
+        const payload: unknown = JSON.parse(result.stdout.trim())
+        expect(payload).toMatchObject({
+            nodes: [{path: 'work/topic.md', status: 'ok', overriddenRuleIds: ['node_must_have_edge']}],
+            summary: {ok: 1, rejected: 0, skipped: 0, warning: 0},
+        })
     })
 
     it('skips validation when no upstream folder note declares a Type', async () => {
@@ -278,7 +282,7 @@ describe('graph create schema gate (filesystem mode)', () => {
         expect(result.exitCode).toBe(1)
         const payload: unknown = JSON.parse(result.stderr.trim())
         expect(payload).toMatchObject({
-            nodes: [{path: 'work/topic.md', status: 'rejected'}],
+            nodes: [{path: 'work/topic.md', status: 'rejected', ruleIds: ['node_must_have_edge']}],
             summary: {ok: 0, rejected: 1, skipped: 0, warning: 0},
         })
     })

--- a/packages/systems/voicetree-cli/src/commands/graph/tests/graph.schema-gate.test.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/tests/graph.schema-gate.test.ts
@@ -130,7 +130,10 @@ describe('graph create schema gate (filesystem mode)', () => {
         const targetPath: string = join(vaultRoot, 'work', 'topic.md')
         await writeFile(targetPath, '# Topic\n\nNeeded marker present.\n', 'utf8')
 
-        const result: CapturedRun = await captureGraphCreate(['work/topic.md'], vaultRoot)
+        const result: CapturedRun = await captureGraphCreate(
+            ['work/topic.md', '--parent', 'work/work.md'],
+            vaultRoot,
+        )
 
         expect(result.exitCode).toBeNull()
         expect(result.stderr).toBe('')
@@ -168,7 +171,10 @@ describe('graph create schema gate (filesystem mode)', () => {
         await writeFile(targetPath, '# Topic\n\nNeeded marker here.\n', 'utf8')
         const originalBody: string = await readFile(targetPath, 'utf8')
 
-        const result: CapturedRun = await captureGraphCreate(['work/topic.md', '--validate-only'], vaultRoot)
+        const result: CapturedRun = await captureGraphCreate(
+            ['work/topic.md', '--validate-only', '--parent', 'work/work.md'],
+            vaultRoot,
+        )
 
         expect(result.exitCode).toBeNull()
         expect(result.stderr).toBe('')
@@ -214,7 +220,10 @@ describe('graph create schema gate (filesystem mode)', () => {
         const targetPath: string = join(freeDir, 'node.md')
         await writeFile(targetPath, '# Free\n\nanything goes\n', 'utf8')
 
-        const result: CapturedRun = await captureGraphCreate(['free/node.md'], vaultRoot)
+        const result: CapturedRun = await captureGraphCreate(
+            ['free/node.md', '--parent', 'work/work.md'],
+            vaultRoot,
+        )
 
         expect(result.exitCode).toBeNull()
         expect(result.stderr).toBe('')
@@ -228,7 +237,10 @@ describe('graph create schema gate (filesystem mode)', () => {
         const targetPath: string = join(vaultRoot, 'work', 'topic.md')
         await writeFile(targetPath, '# Topic\n\nno marker here\n', 'utf8')
 
-        const result: CapturedRun = await captureGraphCreate(['work/topic.md'], vaultRoot)
+        const result: CapturedRun = await captureGraphCreate(
+            ['work/topic.md', '--parent', 'work/work.md'],
+            vaultRoot,
+        )
 
         expect(result.exitCode).toBeNull()
         expect(result.stderr).toBe('')
@@ -243,10 +255,32 @@ describe('graph create schema gate (filesystem mode)', () => {
         const targetPath: string = join(vaultRoot, 'work', 'topic.md')
         await writeFile(targetPath, '# Topic\n\nno marker\n', 'utf8')
 
-        const result: CapturedRun = await captureGraphCreate(['work/topic.md'], vaultRoot)
+        const result: CapturedRun = await captureGraphCreate(
+            ['work/topic.md', '--parent', 'work/work.md'],
+            vaultRoot,
+        )
 
         expect(result.exitCode).toBeNull()
         expect(result.stderr).toBe('')
+    })
+
+    it('rejects an orphan node even when schema validation is skipped (no plugin)', async () => {
+        // Folder note still declares `## Type: my-kind`, but the plugin is gone, so
+        // the gate verdict is `skipped`. A skipped verdict must not let an orphan
+        // through silently: the attachment policy still rejects it.
+        await rm(join(vaultRoot, '.voicetree', 'schemas.cjs'), {force: true})
+        clearLoadSchemaPluginCacheForTest()
+        const targetPath: string = join(vaultRoot, 'work', 'topic.md')
+        await writeFile(targetPath, '# Topic\n\nany body\n', 'utf8')
+
+        const result: CapturedRun = await captureGraphCreate(['work/topic.md'], vaultRoot)
+
+        expect(result.exitCode).toBe(1)
+        const payload: unknown = JSON.parse(result.stderr.trim())
+        expect(payload).toMatchObject({
+            nodes: [{path: 'work/topic.md', status: 'rejected'}],
+            summary: {ok: 0, rejected: 1, skipped: 0, warning: 0},
+        })
     })
 })
 

--- a/packages/systems/voicetree-cli/src/commands/graph/tests/orphanCheck.test.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/tests/orphanCheck.test.ts
@@ -1,0 +1,77 @@
+import {describe, expect, it} from 'vitest'
+import type {FilesystemAuthoringPlanEntry} from '@vt/graph-tools/node'
+import {findOrphanNodes} from '../actions/orphanCheck'
+
+function entry(
+    filename: string,
+    markdown: string,
+    parentFilenames: readonly string[] = [],
+): FilesystemAuthoringPlanEntry {
+    return {filename, markdown, parentFilenames, fixes: []}
+}
+
+describe('findOrphanNodes', () => {
+    it('flags a single node with no parent line and no --parent', () => {
+        const orphans = findOrphanNodes([entry('a.md', '# A\n\nbody.\n')], undefined)
+
+        expect(orphans).toHaveLength(1)
+        expect(orphans[0]).toMatchObject({code: 'orphan_node', filename: 'a.md'})
+        expect(orphans[0]?.message).toContain('no parent edge')
+    })
+
+    it('treats a body parent link as attachment', () => {
+        const orphans = findOrphanNodes(
+            [entry('a.md', '# A\n\nbody.\n\n- parent [[existing-node]]\n')],
+            undefined,
+        )
+
+        expect(orphans).toEqual([])
+    })
+
+    it('treats a manifest-derived parent line as attachment', () => {
+        // assembled markdown carries the manifest parent as a `- parent` line.
+        const orphans = findOrphanNodes(
+            [entry('child.md', '# Child\n\n- parent [[root]]\n', ['root.md'])],
+            undefined,
+        )
+
+        expect(orphans).toEqual([])
+    })
+
+    it('attaches every parentless node to an external --parent', () => {
+        const orphans = findOrphanNodes(
+            [entry('a.md', '# A\n'), entry('b.md', '# B\n')],
+            'anchor',
+        )
+
+        expect(orphans).toEqual([])
+    })
+
+    it('still flags the external parent itself when it is in-batch and otherwise parentless', () => {
+        // `--parent root` where root.md is also an input: its children attach to it,
+        // but root has no parent of its own, so the batch is an island.
+        const orphans = findOrphanNodes(
+            [
+                entry('root.md', '# Root\n'),
+                entry('child.md', '# Child\n\n- parent [[root]]\n', ['root.md']),
+            ],
+            'root',
+        )
+
+        expect(orphans).toHaveLength(1)
+        expect(orphans[0]).toMatchObject({code: 'orphan_node', filename: 'root.md'})
+    })
+
+    it('flags only the unanchored manifest root, not its children', () => {
+        const orphans = findOrphanNodes(
+            [
+                entry('root.md', '# Root\n'),
+                entry('a.md', '# A\n\n- parent [[root]]\n', ['root.md']),
+                entry('b.md', '# B\n\n- parent [[root]]\n', ['root.md']),
+            ],
+            undefined,
+        )
+
+        expect(orphans.map((o) => o.filename)).toEqual(['root.md'])
+    })
+})

--- a/packages/systems/voicetree-cli/src/commands/graph/tests/orphanCheck.test.ts
+++ b/packages/systems/voicetree-cli/src/commands/graph/tests/orphanCheck.test.ts
@@ -1,6 +1,10 @@
 import {describe, expect, it} from 'vitest'
 import type {FilesystemAuthoringPlanEntry} from '@vt/graph-tools/node'
-import {findOrphanNodes} from '../actions/orphanCheck'
+import {
+    findNodeMustHaveEdgeViolations,
+    resolveFilesystemOverrides,
+    violationFilenamesByRuleId,
+} from '../actions/orphanCheck'
 
 function entry(
     filename: string,
@@ -10,17 +14,17 @@ function entry(
     return {filename, markdown, parentFilenames, fixes: []}
 }
 
-describe('findOrphanNodes', () => {
+describe('findNodeMustHaveEdgeViolations', () => {
     it('flags a single node with no parent line and no --parent', () => {
-        const orphans = findOrphanNodes([entry('a.md', '# A\n\nbody.\n')], undefined)
+        const orphans = findNodeMustHaveEdgeViolations([entry('a.md', '# A\n\nbody.\n')], undefined)
 
         expect(orphans).toHaveLength(1)
-        expect(orphans[0]).toMatchObject({code: 'orphan_node', filename: 'a.md'})
+        expect(orphans[0]).toMatchObject({ruleId: 'node_must_have_edge', nodeFilename: 'a.md'})
         expect(orphans[0]?.message).toContain('no parent edge')
     })
 
     it('treats a body parent link as attachment', () => {
-        const orphans = findOrphanNodes(
+        const orphans = findNodeMustHaveEdgeViolations(
             [entry('a.md', '# A\n\nbody.\n\n- parent [[existing-node]]\n')],
             undefined,
         )
@@ -30,7 +34,7 @@ describe('findOrphanNodes', () => {
 
     it('treats a manifest-derived parent line as attachment', () => {
         // assembled markdown carries the manifest parent as a `- parent` line.
-        const orphans = findOrphanNodes(
+        const orphans = findNodeMustHaveEdgeViolations(
             [entry('child.md', '# Child\n\n- parent [[root]]\n', ['root.md'])],
             undefined,
         )
@@ -39,7 +43,7 @@ describe('findOrphanNodes', () => {
     })
 
     it('attaches every parentless node to an external --parent', () => {
-        const orphans = findOrphanNodes(
+        const orphans = findNodeMustHaveEdgeViolations(
             [entry('a.md', '# A\n'), entry('b.md', '# B\n')],
             'anchor',
         )
@@ -50,7 +54,7 @@ describe('findOrphanNodes', () => {
     it('still flags the external parent itself when it is in-batch and otherwise parentless', () => {
         // `--parent root` where root.md is also an input: its children attach to it,
         // but root has no parent of its own, so the batch is an island.
-        const orphans = findOrphanNodes(
+        const orphans = findNodeMustHaveEdgeViolations(
             [
                 entry('root.md', '# Root\n'),
                 entry('child.md', '# Child\n\n- parent [[root]]\n', ['root.md']),
@@ -59,11 +63,11 @@ describe('findOrphanNodes', () => {
         )
 
         expect(orphans).toHaveLength(1)
-        expect(orphans[0]).toMatchObject({code: 'orphan_node', filename: 'root.md'})
+        expect(orphans[0]).toMatchObject({ruleId: 'node_must_have_edge', nodeFilename: 'root.md'})
     })
 
     it('flags only the unanchored manifest root, not its children', () => {
-        const orphans = findOrphanNodes(
+        const orphans = findNodeMustHaveEdgeViolations(
             [
                 entry('root.md', '# Root\n'),
                 entry('a.md', '# A\n\n- parent [[root]]\n', ['root.md']),
@@ -72,6 +76,27 @@ describe('findOrphanNodes', () => {
             undefined,
         )
 
-        expect(orphans.map((o) => o.filename)).toEqual(['root.md'])
+        expect(orphans.map((o) => o.nodeFilename)).toEqual(['root.md'])
+    })
+
+    it('resolves node_must_have_edge when a matching override is provided', () => {
+        const violations = findNodeMustHaveEdgeViolations([entry('a.md', '# A\n')], undefined)
+
+        const resolved = resolveFilesystemOverrides(violations, [
+            {ruleId: 'node_must_have_edge', rationale: 'intentional temporary inbox'},
+        ])
+
+        expect(resolved.unresolved).toEqual([])
+        expect(resolved.accepted).toEqual([
+            {ruleId: 'node_must_have_edge', rationale: 'intentional temporary inbox'},
+        ])
+    })
+
+    it('indexes overridden filenames by graph validation rule id', () => {
+        const violations = findNodeMustHaveEdgeViolations([entry('a.md', '# A\n')], undefined)
+
+        expect(violationFilenamesByRuleId(violations, 'node_must_have_edge').get('a.md')).toEqual([
+            'node_must_have_edge',
+        ])
     })
 })

--- a/packages/systems/voicetree-graph-validation/src/overridableRules.ts
+++ b/packages/systems/voicetree-graph-validation/src/overridableRules.ts
@@ -8,7 +8,7 @@
  * Pure types + a frozen const literal — no runtime dependencies.
  */
 
-export const OVERRIDABLE_RULE_IDS = ['grandparent_attachment', 'node_line_limit'] as const
+export const OVERRIDABLE_RULE_IDS = ['grandparent_attachment', 'node_line_limit', 'node_must_have_edge'] as const
 export type OverridableRuleId = typeof OVERRIDABLE_RULE_IDS[number]
 
 export interface OverrideEntry {

--- a/packages/systems/vt-daemon/src/create-graph/createGraphValidation.test.ts
+++ b/packages/systems/vt-daemon/src/create-graph/createGraphValidation.test.ts
@@ -164,10 +164,11 @@ describe('formatViolationError', () => {
         const error: string = formatViolationError([
             {ruleId: 'node_line_limit', message: 'Too long', nodeFilename: 'n.md', details: {}},
             {ruleId: 'grandparent_attachment', message: 'Ancestor', nodeFilename: '__graph_root__', details: {}},
+            {ruleId: 'node_must_have_edge', message: 'No edge', nodeFilename: 'lonely.md', details: {}},
         ])
         const jsonStart: number = error.indexOf('[\n')
         const parsed: unknown = JSON.parse(error.slice(jsonStart))
-        expect((parsed as readonly {ruleId: string}[]).length).toBe(2)
+        expect((parsed as readonly {ruleId: string}[]).length).toBe(3)
     })
 })
 
@@ -314,6 +315,48 @@ describe('grandparentAttachmentRule (via ALL_RULES)', () => {
         }))
         if (result.status === 'violations') {
             expect(result.violations.filter((v: RuleViolation) => v.ruleId === 'grandparent_attachment')).toHaveLength(0)
+        }
+    })
+})
+
+describe('nodeMustHaveEdgeRule (via ALL_RULES)', () => {
+    it('passes when daemon graph-parent fallback is present', () => {
+        const graph: Graph = mockGraph(['/vault/task.md'])
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: [mockNode({filename: 'n', title: 'T', summary: 'S'})],
+            resolvedParentNodeId: '/vault/task.md',
+            graph,
+        }))
+        if (result.status === 'violations') {
+            expect(result.violations.filter((v: RuleViolation) => v.ruleId === 'node_must_have_edge')).toHaveLength(0)
+        }
+    })
+
+    it('passes when a node authors a parent line', () => {
+        const graph: Graph = mockGraph([])
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: [mockNode({filename: 'n', title: 'T', summary: 'S', content: '- parent [[existing]]'})],
+            resolvedParentNodeId: '' as NodeIdAndFilePath,
+            graph,
+        }))
+        if (result.status === 'violations') {
+            expect(result.violations.filter((v: RuleViolation) => v.ruleId === 'node_must_have_edge')).toHaveLength(0)
+        }
+    })
+
+    it('rejects when neither parent line nor graph-parent fallback is present', () => {
+        const graph: Graph = mockGraph([])
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: [mockNode({filename: 'lonely', title: 'T', summary: 'S'})],
+            resolvedParentNodeId: '' as NodeIdAndFilePath,
+            graph,
+        }))
+        expect(result.status).toBe('violations')
+        if (result.status === 'violations') {
+            const violations: readonly RuleViolation[] =
+                result.violations.filter((v: RuleViolation) => v.ruleId === 'node_must_have_edge')
+            expect(violations).toHaveLength(1)
+            expect(violations[0].nodeFilename).toBe('lonely')
         }
     })
 })

--- a/packages/systems/vt-daemon/src/create-graph/createGraphValidation.ts
+++ b/packages/systems/vt-daemon/src/create-graph/createGraphValidation.ts
@@ -9,6 +9,7 @@
 
 import type {CreateGraphNodeInput} from './createGraphTypes'
 import type {Graph, NodeIdAndFilePath} from '@vt/graph-model/graph'
+import {extractParentRefs} from '@vt/graph-model/markdown'
 import {countBodyLines} from '../tools/graph/addProgressNodeTool'
 import type {OverridableRuleId, OverrideEntry} from '@vt/graph-validation'
 
@@ -230,12 +231,39 @@ const nodeLineLimitRule: ValidationRule = {
     },
 }
 
+/**
+ * Node attachment rule: each create_graph node must have an edge after the
+ * batch is applied. Live/MCP creation supplies a graph-parent fallback for
+ * root nodes, so this rule is normally a pass in daemon mode; filesystem-mode
+ * `vt graph create` reuses the same rule ID when a markdown input has neither
+ * a parent line nor an external --parent attachment.
+ */
+const nodeMustHaveEdgeRule: ValidationRule = {
+    id: 'node_must_have_edge',
+    description: 'Each created node must have at least one parent edge unless explicitly overridden.',
+    check(ctx: ValidationContext): readonly RuleViolation[] {
+        const violations: RuleViolation[] = []
+        for (const node of ctx.nodes) {
+            const hasAuthoredParent: boolean = extractParentRefs(node.content ?? '').length > 0
+            const hasGraphParentFallback: boolean = ctx.resolvedParentNodeId.length > 0
+            if (hasAuthoredParent || hasGraphParentFallback) continue
+            violations.push({
+                ruleId: 'node_must_have_edge',
+                message: `Node "${node.filename}" has no parent edge and would be disconnected from the graph.`,
+                nodeFilename: node.filename,
+                details: {filename: node.filename},
+            })
+        }
+        return violations
+    },
+}
+
 // ============================================================================
 // Export
 // ============================================================================
 
 function createValidationRules(): readonly ValidationRule[] {
-    return [grandparentAttachmentRule, nodeLineLimitRule]
+    return [grandparentAttachmentRule, nodeLineLimitRule, nodeMustHaveEdgeRule]
 }
 
 export const ALL_RULES: readonly ValidationRule[] = createValidationRules()


### PR DESCRIPTION
## Summary
- add shared overridable rule id `node_must_have_edge`
- route filesystem graph-create orphan checks through that rule and allow `--override node_must_have_edge:<rationale>`
- report rule ids and overridden rule ids in batch output

## Verification
- `npm test -- --run src/commands/graph/tests/orphanCheck.test.ts src/commands/graph/tests/graph.batch-reporting.test.ts src/commands/graph/tests/graph.schema-gate.test.ts src/commands/graph/tests/graph.override-flag.test.ts` in `packages/systems/voicetree-cli`
- `npm test -- --run src/create-graph/createGraphValidation.test.ts` in `packages/systems/vt-daemon`
- `npm run typecheck` in `packages/systems/voicetree-graph-validation`