### PR TITLE
refactor(app): open projects through explicit entrypoint

### DIFF
--- a/packages/libraries/graph-model/src/pure/project/filtering.test.ts
+++ b/packages/libraries/graph-model/src/pure/project/filtering.test.ts
@@ -33,7 +33,6 @@ describe('filterDiscoveredProjects', () => {
                 name: 'project1',
                 type: 'git',
                 lastOpened: 1000,
-                voicetreeInitialized: false,
             },
             {
                 id: '2',
@@ -41,7 +40,6 @@ describe('filterDiscoveredProjects', () => {
                 name: 'project3',
                 type: 'git',
                 lastOpened: 2000,
-                voicetreeInitialized: true,
             },
         ];
         const result: readonly DiscoveredProject[] = filterDiscoveredProjects(discovered, saved);
@@ -59,7 +57,6 @@ describe('filterDiscoveredProjects', () => {
                 name: 'already-saved',
                 type: 'folder',
                 lastOpened: 1000,
-                voicetreeInitialized: false,
             },
         ];
         const result: readonly DiscoveredProject[] = filterDiscoveredProjects(discovered, saved);
@@ -77,7 +74,6 @@ describe('filterDiscoveredProjects', () => {
                 name: 'project1',
                 type: 'git',
                 lastOpened: 1000,
-                voicetreeInitialized: false,
             },
         ];
         const result: readonly DiscoveredProject[] = filterDiscoveredProjects(discovered, saved);
@@ -95,7 +91,6 @@ describe('filterDiscoveredProjects', () => {
                 name: 'project1',
                 type: 'git',
                 lastOpened: 1000,
-                voicetreeInitialized: false,
             },
         ];
         const discoveredCopy: readonly DiscoveredProject[] = [...discovered];

--- a/packages/libraries/graph-model/src/pure/project/sorting.test.ts
+++ b/packages/libraries/graph-model/src/pure/project/sorting.test.ts
@@ -15,7 +15,6 @@ describe('sortProjectsByLastOpened', () => {
             name: 'project',
             type: 'git',
             lastOpened: 1000,
-            voicetreeInitialized: false,
         };
         const result: readonly SavedProject[] = sortProjectsByLastOpened([project]);
         expect(result).toEqual([project]);
@@ -28,7 +27,6 @@ describe('sortProjectsByLastOpened', () => {
             name: 'oldest',
             type: 'git',
             lastOpened: 1000,
-            voicetreeInitialized: false,
         };
         const middle: SavedProject = {
             id: '2',
@@ -36,7 +34,6 @@ describe('sortProjectsByLastOpened', () => {
             name: 'middle',
             type: 'obsidian',
             lastOpened: 2000,
-            voicetreeInitialized: true,
         };
         const newest: SavedProject = {
             id: '3',
@@ -44,7 +41,6 @@ describe('sortProjectsByLastOpened', () => {
             name: 'newest',
             type: 'folder',
             lastOpened: 3000,
-            voicetreeInitialized: false,
         };
 
         const result: readonly SavedProject[] = sortProjectsByLastOpened([oldest, middle, newest]);
@@ -58,7 +54,6 @@ describe('sortProjectsByLastOpened', () => {
             name: 'a',
             type: 'git',
             lastOpened: 1000,
-            voicetreeInitialized: false,
         };
         const projectB: SavedProject = {
             id: 'b',
@@ -66,7 +61,6 @@ describe('sortProjectsByLastOpened', () => {
             name: 'b',
             type: 'git',
             lastOpened: 1000,
-            voicetreeInitialized: false,
         };
 
         const result: readonly SavedProject[] = sortProjectsByLastOpened([projectA, projectB]);
@@ -82,7 +76,6 @@ describe('sortProjectsByLastOpened', () => {
             name: 'oldest',
             type: 'git',
             lastOpened: 1000,
-            voicetreeInitialized: false,
         };
         const newest: SavedProject = {
             id: '2',
@@ -90,7 +83,6 @@ describe('sortProjectsByLastOpened', () => {
             name: 'newest',
             type: 'git',
             lastOpened: 2000,
-            voicetreeInitialized: false,
         };
 
         const original: readonly SavedProject[] = [oldest, newest];

--- a/packages/libraries/graph-model/src/pure/project/types.ts
+++ b/packages/libraries/graph-model/src/pure/project/types.ts
@@ -16,7 +16,6 @@ export interface SavedProject {
     readonly name: string;
     readonly type: ProjectType;
     readonly lastOpened: number;
-    readonly voicetreeInitialized: boolean;
 }
 
 /**

--- a/packages/libraries/paths/src/index.test.ts
+++ b/packages/libraries/paths/src/index.test.ts
@@ -23,4 +23,12 @@ describe('VoiceTree paths', () => {
     it('builds project-local .voicetree paths from the project path', () => {
         expect(getProjectDotVoicetreePath('/repo/project')).toBe('/repo/project/.voicetree')
     })
+
+    it('does not derive project-local runtime files from a write folder path', () => {
+        const projectPath: string = '/repo/project'
+        const writeFolderPath: string = '/repo/project/voicetree-29-5'
+
+        expect(getProjectDotVoicetreePath(projectPath)).toBe('/repo/project/.voicetree')
+        expect(getProjectDotVoicetreePath(projectPath)).not.toBe(`${writeFolderPath}/.voicetree`)
+    })
 })

--- a/packages/measures/perf/e2e-storm-mvp/launchElectron.ts
+++ b/packages/measures/perf/e2e-storm-mvp/launchElectron.ts
@@ -76,7 +76,6 @@ export function seedUserData(voicetreeHomePath: string, projectDir: string, proj
             name: projectName,
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2),
         'utf8',
     )

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/editor-disk-convergence-helpers.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/editor-disk-convergence-helpers.ts
@@ -80,7 +80,6 @@ export const test = base.extend<Record<string, never>, EditorDiskConvergenceWork
         name: path.basename(projectPath),
         type: 'folder',
         lastOpened: Date.now(),
-        voicetreeInitialized: true,
       }], null, 2),
       'utf8',
     );

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-child-node-title-overwrite.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-child-node-title-overwrite.spec.ts
@@ -87,7 +87,6 @@ const test = base.extend<{
       name: 'child-title-test',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true,
     };
 
     await fs.writeFile(path.join(userDataPath, 'projects.json'), JSON.stringify([savedProject], null, 2), 'utf8');

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-edits-survive-downstream-ops.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-edits-survive-downstream-ops.spec.ts
@@ -194,7 +194,6 @@ const test = base.extend<{
           name: path.basename(projectPath),
           type: 'folder',
           lastOpened: Date.now(),
-          voicetreeInitialized: true,
         },
       ], null, 2),
       'utf8',

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-title-latency.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-title-latency.spec.ts
@@ -106,7 +106,6 @@ const test = base.extend<{
           name: path.basename(projectPath),
           type: 'folder',
           lastOpened: Date.now(),
-          voicetreeInitialized: true,
         },
       ], null, 2),
       'utf8',

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-typing-order-regression.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-editor-typing-order-regression.spec.ts
@@ -109,7 +109,6 @@ const test = base.extend<{
       name: path.basename(projectPath),
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true,
     };
 
     await fs.writeFile(path.join(userDataPath, 'projects.json'), JSON.stringify([savedProject], null, 2), 'utf8');

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-fs-rename-delete-semantics.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-fs-rename-delete-semantics.spec.ts
@@ -101,7 +101,6 @@ const test = base.extend<{
       name: tempProjectName,
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true
     }], null, 2), 'utf8');
 
     const ciFlags = process.env.CI

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-headless-agent.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-headless-agent.spec.ts
@@ -69,7 +69,6 @@ const test = base.extend<{
             name: 'example_small',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         };
         await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-project-file-watcher-system.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-project-file-watcher-system.spec.ts
@@ -79,7 +79,6 @@ const test = base.extend<{
       name: path.basename(projectPath),
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true,
     };
     await fs.writeFile(path.join(userDataPath, 'projects.json'), JSON.stringify([savedProject], null, 2), 'utf8');
     await fs.writeFile(

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-project-selection.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-project-selection.spec.ts
@@ -209,7 +209,6 @@ test.describe('Project Selection Screen E2E', () => {
                 name: projectPath.split('/').pop() ?? 'test-project',
                 type: 'git' as const,
                 lastOpened: Date.now(),
-                voicetreeInitialized: false
             };
 
             await api.main.saveProject(newProject);
@@ -275,7 +274,6 @@ test.describe('Project Selection Screen E2E', () => {
                 name: projectPath.split('/').pop() ?? 'test-project',
                 type: 'git' as const,
                 lastOpened: Date.now(),
-                voicetreeInitialized: false
             };
             await api.main.saveProject(newProject);
         }, testProjectPath);
@@ -335,7 +333,6 @@ test.describe('Project Selection Screen E2E', () => {
             name: 'persistent-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         };
         await fs.writeFile(
             path.join(tempUserDataPath, 'projects.json'),
@@ -458,7 +455,6 @@ test.describe('Watched Folder Panel Regression', () => {
                 name: 'fresh-project',
                 type: 'folder' as const,
                 lastOpened: Date.now(),
-                voicetreeInitialized: true
             };
             await fs.writeFile(
                 path.join(tempUserDataPath, 'projects.json'),
@@ -584,7 +580,6 @@ test.describe('Watched Folder Panel Regression', () => {
                 name: 'existing-config-project',
                 type: 'folder' as const,
                 lastOpened: Date.now(),
-                voicetreeInitialized: true
             };
             await fs.writeFile(
                 path.join(tempUserDataPath, 'projects.json'),
@@ -770,7 +765,6 @@ test.describe('Watched Folder Panel Regression', () => {
                     name: 'with-config',
                     type: 'folder' as const,
                     lastOpened: Date.now(),
-                    voicetreeInitialized: true
                 },
                 {
                     id: 'without-config-id',
@@ -778,7 +772,6 @@ test.describe('Watched Folder Panel Regression', () => {
                     name: 'without-config',
                     type: 'folder' as const,
                     lastOpened: Date.now() - 1000, // Slightly older so "with-config" appears first
-                    voicetreeInitialized: true
                 }
             ];
             await fs.writeFile(

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/helpers/phase6-helpers.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/helpers/phase6-helpers.ts
@@ -185,7 +185,6 @@ export async function writePhase6Settings(
           name: path.basename(projectRoot),
           type: "folder",
           lastOpened: Date.now(),
-          voicetreeInitialized: true,
         },
       ],
       null,

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/debug/electron-cy-dump.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/debug/electron-cy-dump.spec.ts
@@ -73,7 +73,6 @@ const test = base.extend<{
             name: 'example_small',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8')
 
         const electronApp: ElectronApplication = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-agent-edit-cold-start.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-agent-edit-cold-start.spec.ts
@@ -74,7 +74,6 @@ const test = base.extend<{
             name: 'example_small',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8')
 
         const electronApp: ElectronApplication = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-agent-edit-reopen-sync.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-agent-edit-reopen-sync.spec.ts
@@ -76,7 +76,6 @@ const test = base.extend<{
             name: 'example_small',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8')
 
         const electronApp: ElectronApplication = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-editor-fs-sync.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-editor-fs-sync.spec.ts
@@ -67,7 +67,6 @@ const test = base.extend<{
       name: 'example_small',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true
     }], null, 2), 'utf8');
 
     const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-editor-fullscreen-zoom.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-editor-fullscreen-zoom.spec.ts
@@ -49,7 +49,6 @@ const test = base.extend<{
       name: '2025-09-30',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true
     };
     await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-markdown-table-rendering.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-markdown-table-rendering.spec.ts
@@ -64,7 +64,6 @@ const test = base.extend<{
       name: 'table-rendering-project',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true
     };
     await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-wikilink-title-chip.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/editors/electron-wikilink-title-chip.spec.ts
@@ -65,7 +65,6 @@ const test = base.extend<{
       name: 'test-project',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true
     };
     await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-filetree-load-child.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-filetree-load-child.spec.ts
@@ -23,7 +23,6 @@ interface ExtendedWindow {
                 readonly name: string;
                 readonly type: 'folder';
                 readonly lastOpened: number;
-                readonly voicetreeInitialized: boolean;
             }) => Promise<void>;
             readonly startFileWatching: (path: string) => Promise<{ success: boolean; error?: string }>;
             readonly stopFileWatching: () => Promise<void>;
@@ -98,7 +97,6 @@ const test = base.extend<{
             name: 'filetree-load-child',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({
@@ -169,7 +167,6 @@ const test = base.extend<{
                     name: 'filetree-load-child',
                     type: 'folder',
                     lastOpened: Date.now(),
-                    voicetreeInitialized: true,
                 });
             }, fixture.projectPath);
             await window.waitForTimeout(500);

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-handle-states.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-handle-states.spec.ts
@@ -96,7 +96,6 @@ const test = base.extend<{
             name: 'folder-handle-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-nodes-missing-scenarios.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-nodes-missing-scenarios.spec.ts
@@ -134,7 +134,6 @@ const test = base.extend<{
             name: 'folder-missing-scenarios-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-nodes-spec-behavior.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-nodes-spec-behavior.spec.ts
@@ -153,7 +153,6 @@ const test = base.extend<{
             name: 'folder-spec-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-note-dom.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-note-dom.spec.ts
@@ -111,7 +111,6 @@ const test = base.extend<{
             name: 'folder-note-dom-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-visibility.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-visibility.spec.ts
@@ -64,7 +64,6 @@ const test = base.extend<{
             name: 'folder-visibility-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/folder-tree-test-fixtures.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/folder-tree-test-fixtures.ts
@@ -99,7 +99,6 @@ export const test = base.extend<{
                 if (!api) throw new Error('electronAPI not available');
                 await api.main.saveProject({
                     id: crypto.randomUUID(), path: params.folderPath, name: 'test-folder-tree',
-                    type: 'folder' as const, lastOpened: Date.now(), voicetreeInitialized: false,
                 });
             }, { folderPath: testProjectPath });
             await window.waitForTimeout(500);

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/context/electron-zoom-after-agent-click-teleport.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/context/electron-zoom-after-agent-click-teleport.spec.ts
@@ -63,7 +63,6 @@ const test = base.extend<{ electronApp: ElectronApplication; appWindow: Page; pr
       name: 'zoom-teleport-project',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true,
     }], null, 2), 'utf8');
 
     const app = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/crud/electron-node-position-persistence.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/crud/electron-node-position-persistence.spec.ts
@@ -91,7 +91,6 @@ const test = base.extend<{
       name: 'position-test',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true
     };
     await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-extract-into-folder-cross-parent.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-extract-into-folder-cross-parent.spec.ts
@@ -174,7 +174,6 @@ const test = base.extend<{
             name: 'extract-cross-parent-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-extract-into-folder.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-extract-into-folder.spec.ts
@@ -244,7 +244,6 @@ const test = base.extend<{
             name: 'extract-folder-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-collapse.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-collapse.spec.ts
@@ -56,7 +56,6 @@ const test = base.extend<{
             name: 'collapse-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-compound-nodes.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-compound-nodes.spec.ts
@@ -63,7 +63,6 @@ const test = base.extend<{
             name: 'compound-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-interaction-improvements.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-interaction-improvements.spec.ts
@@ -52,7 +52,6 @@ const test = base.extend<{
             name: 'bf113-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-nodes-diagnostic.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-nodes-diagnostic.spec.ts
@@ -61,7 +61,6 @@ const test = base.extend<{
             name: 'folder-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-outline-width-diagnostic.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-outline-width-diagnostic.spec.ts
@@ -60,7 +60,6 @@ const test = base.extend<{
             name: 'outline-diag-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/electron-500-node-cdp-perf.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/electron-500-node-cdp-perf.spec.ts
@@ -83,7 +83,6 @@ const test = base.extend<{
         name: 'example_small',
         type: 'folder',
         lastOpened: Date.now(),
-        voicetreeInitialized: true,
       }], null, 2),
       'utf8'
     );

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/electron-500-node-realistic-perf/fixtures.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/electron-500-node-realistic-perf/fixtures.ts
@@ -165,7 +165,6 @@ export const test = base.extend<{
         name: 'perf-test-project',
         type: 'folder',
         lastOpened: Date.now(),
-        voicetreeInitialized: true,
       }], null, 2),
       'utf8'
     );

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/electron-dev-dev-layout-comparison.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/electron-dev-dev-layout-comparison.spec.ts
@@ -126,7 +126,6 @@ const test = base.extend<{
         name: 'dev-dev',
         type: 'folder',
         lastOpened: Date.now(),
-        voicetreeInitialized: true,
       }], null, 2),
       'utf8'
     );

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/electron-minimap-webgl-screenshot.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/electron-minimap-webgl-screenshot.spec.ts
@@ -27,7 +27,7 @@ interface ExtendedWindow {
       startFileWatching: (dir: string) => Promise<{ success: boolean; directory: string }>;
       saveProject: (project: {
         id: string; path: string; name: string;
-        type: 'folder'; lastOpened: number; voicetreeInitialized: boolean;
+        type: 'folder'; lastOpened: number;
       }) => Promise<void>;
     };
   };
@@ -95,7 +95,6 @@ const test = base.extend<{
         name: 'Minimap Test',
         type: 'folder',
         lastOpened: Date.now(),
-        voicetreeInitialized: true,
       });
 
       await api.main.startFileWatching(projectRoot);

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/electron-pan-zoom-diagnostic.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/electron-pan-zoom-diagnostic.spec.ts
@@ -71,7 +71,6 @@ const test = base.extend<{ electronApp: ElectronApplication; appWindow: Page; pr
       name: 'pan-zoom-diag-project',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true,
     }], null, 2), 'utf8');
 
     const app = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/perf-helpers/stormFixtures.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/perf/perf-helpers/stormFixtures.ts
@@ -68,7 +68,6 @@ export function makeStormTest(projectRoot: string): ReturnType<typeof base.exten
 
         electronApp: async ({ args, projectPath, voicetreeHomePath, projectLayout: _projectLayout }, use) => {
             // Seed projects.json so the picker shows the project project. We point
-            // `path` AND `voicetreeInitialized: true` at the project so the app
             // opens straight into graph view on click.
             const projectsPath = path.join(voicetreeHomePath, 'projects.json')
             const projectName = path.basename(path.dirname(projectPath))
@@ -80,7 +79,6 @@ export function makeStormTest(projectRoot: string): ReturnType<typeof base.exten
                     name: projectName,
                     type: 'folder',
                     lastOpened: Date.now(),
-                    voicetreeInitialized: true,
                 }], null, 2),
                 'utf8',
             )

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph_folder_loading/electron-folder-management/fixtures.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph_folder_loading/electron-folder-management/fixtures.ts
@@ -105,7 +105,6 @@ async function saveProjectForSelection(window: Page, folderPath: string, project
       name: params.projectName,
       type: 'folder' as const,
       lastOpened: Date.now(),
-      voicetreeInitialized: false,
     };
     await api.main.saveProject(project);
   }, { folderPath, projectName });

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/interactions/electron-trackpad-pan-folder.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/interactions/electron-trackpad-pan-folder.spec.ts
@@ -63,7 +63,6 @@ const test = base.extend<{
             name: 'trackpad-pan-test-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/interactions/electron-web-share-regression.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/interactions/electron-web-share-regression.spec.ts
@@ -54,7 +54,6 @@ const test = base.extend<{
       name: 'example_small',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true
     };
     await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/interactions/right-click-menu.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/interactions/right-click-menu.spec.ts
@@ -79,7 +79,6 @@ const test = base.extend<TestFixtures>({
                     name: 'bf250-test-project',
                     type: 'folder' as const,
                     lastOpened: Date.now(),
-                    voicetreeInitialized: false,
                 });
             }, { folderPath: testProjectPath });
             await win.waitForTimeout(500);

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/lazy_loading/electron-lazy-nodes-persist-on-folder-switch.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/lazy_loading/electron-lazy-nodes-persist-on-folder-switch.spec.ts
@@ -144,7 +144,6 @@ This is the only node in project 2.
       name: 'project1',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true
     };
     await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/pixel-diff/electron-pixel-diff-canonical-states.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/pixel-diff/electron-pixel-diff-canonical-states.spec.ts
@@ -71,7 +71,6 @@ const test = base.extend<{
         name: 'example_small',
         type: 'folder',
         lastOpened: Date.now(),
-        voicetreeInitialized: true,
       }], null, 2),
       'utf8'
     );

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/settings/electron-settings-integration.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/settings/electron-settings-integration.spec.ts
@@ -60,7 +60,6 @@ const test = base.extend<{
       name: 'example_small',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true
     };
     await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/store/electron-l5-205-store-consolidation.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/store/electron-l5-205-store-consolidation.spec.ts
@@ -72,7 +72,6 @@ const test = base.extend<{
                         name: 'l5-205-store-consolidation',
                         type: 'folder',
                         lastOpened: Date.now(),
-                        voicetreeInitialized: true,
                     },
                 ],
                 null,

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/content/electron-inject-badge-in-titlebar/inject-badge-fixture.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/content/electron-inject-badge-in-titlebar/inject-badge-fixture.ts
@@ -29,7 +29,6 @@ const test = base.extend<{
       name: 'example_small',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true
     };
     await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/content/electron-surviving-agents-helpers.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/content/electron-surviving-agents-helpers.ts
@@ -84,7 +84,6 @@ export interface ExtendedWindow {
                 readonly name: string;
                 readonly type: 'folder';
                 readonly lastOpened: number;
-                readonly voicetreeInitialized: boolean;
             }) => Promise<void>;
             listUnclaimedTmuxSessions: () => Promise<readonly UnclaimedTmuxSessionShape[]>;
             refreshUnclaimedTmuxSessions: () => Promise<readonly UnclaimedTmuxSessionShape[]>;
@@ -300,7 +299,6 @@ export const test = base.extend<{
             name: PROJECT_ID,
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8');
 
         const electronApp = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/lifecycle/electron-resume-persisted-helpers.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/lifecycle/electron-resume-persisted-helpers.ts
@@ -89,7 +89,6 @@ export const test = baseTest.extend<{
             name: PROJECT_ID,
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true,
         }], null, 2), 'utf8');
 
         const electronApp: ElectronApplication = await electron.launch({

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/lifecycle/electron-worktree-display-name.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/lifecycle/electron-worktree-display-name.spec.ts
@@ -155,7 +155,6 @@ const test = base.extend<{
                 name: 'test-worktree-display-e2e',
                 type: 'folder' as const,
                 lastOpened: Date.now(),
-                voicetreeInitialized: true,
             });
             await api.main.startFileWatching(projectRoot);
         }, tempGitRepoPath);

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/lifecycle/electron-worktree-hook.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/lifecycle/electron-worktree-hook.spec.ts
@@ -149,7 +149,6 @@ const test = base.extend<{
                 name: 'test-hook-e2e',
                 type: 'folder' as const,
                 lastOpened: Date.now(),
-                voicetreeInitialized: true,
             });
             await api.main.startFileWatching(projectRoot);
         }, tempGitRepoPath);

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/lifecycle/electron-worktree-spawn.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/lifecycle/electron-worktree-spawn.spec.ts
@@ -150,7 +150,6 @@ const test = base.extend<{
                 name: 'test-worktree-e2e',
                 type: 'folder' as const,
                 lastOpened: Date.now(),
-                voicetreeInitialized: true,
             });
             await api.main.startFileWatching(projectRoot);
         }, tempGitRepoPath);

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/permissions/electron-command-edit-not-blocked.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/permissions/electron-command-edit-not-blocked.spec.ts
@@ -97,7 +97,6 @@ const test = base.extend<{
                 name: 'test-cmd-edit',
                 type: 'folder' as const,
                 lastOpened: Date.now(),
-                voicetreeInitialized: true
             });
             await api.main.startFileWatching(projectRoot);
         }, FIXTURE_PROJECT_PATH);

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/permissions/electron-headless-prompt-delivery.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/permissions/electron-headless-prompt-delivery.spec.ts
@@ -57,7 +57,6 @@ const test = base.extend<{
             name: 'example_small',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         };
         await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/stop-gate/electron-stop-gate-audit.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/stop-gate/electron-stop-gate-audit.spec.ts
@@ -58,7 +58,6 @@ const test = base.extend<{
             name: 'example_small',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         };
         await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/stop-gate/electron-stop-gate-hooks.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/stop-gate/electron-stop-gate-hooks.spec.ts
@@ -158,7 +158,6 @@ const test = base.extend<{
       name: 'hooks-cli-project',
       type: 'folder',
       lastOpened: Date.now(),
-      voicetreeInitialized: true,
     };
     await fs.writeFile(
       path.join(tempPath, 'projects.json'),

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/stop-gate/stop-gate-lifecycle-setup.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/terminals/stop-gate/stop-gate-lifecycle-setup.ts
@@ -141,7 +141,6 @@ export const test = base.extend<{
             name: 'stop-gate-lifecycle-project',
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         };
         await fs.writeFile(projectsPath, JSON.stringify([savedProject], null, 2), 'utf8');
 

--- a/webapp/e2e-tests/playwright-browser/critical_for_verification/settings/project-selector-no-toggle.spec.ts
+++ b/webapp/e2e-tests/playwright-browser/critical_for_verification/settings/project-selector-no-toggle.spec.ts
@@ -78,7 +78,7 @@ async function setupMockElectronAPIWithProject(page: Page): Promise<void> {
         stopFileWatching: async () => ({ success: true }),
         getWatchStatus: async () => ({ isWatching: true, directory: '/mock/write-project' }),
         loadPreviousFolder: async () => ({ success: false }),
-        getStartupProjectHint: async () => ({ kind: 'open-folder' as const, path: '/mock/write-project' }),
+        getStartupProjectHint: async () => ({ kind: 'open-folder' as const, projectPath: '/mock/write-project' }),
         openProject: async (dir: string) => {
           const projectedGraph = mockElectronAPI.graph._projectedGraph ?? createEmptyProjectedGraph();
           setTimeout(() => {
@@ -227,13 +227,11 @@ async function setupMockElectronAPIWithProject(page: Page): Promise<void> {
           name: 'Mock Test Project',
           type: 'folder' as const,
           lastOpened: Date.now(),
-          voicetreeInitialized: true,
         }],
         saveProject: async () => {},
         removeProject: async () => {},
         getDefaultSearchDirectories: async () => [],
         scanForProjects: async () => [],
-        initializeProject: async () => '/mock/write-project/voicetree',
         showFolderPicker: async () => ({ success: false }),
 
         // Terminal state mutations

--- a/webapp/e2e-tests/playwright-browser/critical_for_verification/settings/project-selector-test-setup.ts
+++ b/webapp/e2e-tests/playwright-browser/critical_for_verification/settings/project-selector-test-setup.ts
@@ -168,7 +168,7 @@ export async function setupMockElectronAPIWithNestedFolders(page: Page): Promise
         stopFileWatching: async () => ({ success: true }),
         getWatchStatus: async () => ({ isWatching: true, directory: '/mock/watched/directory' }),
         loadPreviousFolder: async () => ({ success: false }),
-        getStartupProjectHint: async () => ({ kind: 'open-folder' as const, path: '/mock/watched/directory' }),
+        getStartupProjectHint: async () => ({ kind: 'open-folder' as const, projectPath: '/mock/watched/directory' }),
         openProject: async (dir: string) => {
           const projectedGraph = mockElectronAPI.graph._projectedGraph ?? createEmptyProjectedGraph();
           setTimeout(() => {
@@ -265,13 +265,11 @@ export async function setupMockElectronAPIWithNestedFolders(page: Page): Promise
           name: 'Mock Test Project',
           type: 'folder' as const,
           lastOpened: Date.now(),
-          voicetreeInitialized: true,
         }],
         saveProject: async () => {},
         removeProject: async () => {},
         getDefaultSearchDirectories: async () => [],
         scanForProjects: async () => [],
-        initializeProject: async () => '/mock/watched/directory/voicetree',
         showFolderPicker: async () => ({ success: false }),
         applyGraphDeltaToDBThroughMemUIAndEditorExposed: async () => ({ success: true }),
         applyGraphDeltaToDBThroughMemAndUIExposed: async () => ({ success: true }),

--- a/webapp/e2e-tests/playwright-browser/graph-delta-test-setup.ts
+++ b/webapp/e2e-tests/playwright-browser/graph-delta-test-setup.ts
@@ -139,7 +139,7 @@ function installMockElectronAPI(): void {
       },
       getWatchStatus: async () => ({ isWatching: true, directory: '/mock/watched/directory' }),
       loadPreviousFolder: async () => ({ success: false }),
-      getStartupProjectHint: async () => ({ kind: 'open-folder' as const, path: '/mock/watched/directory' }),
+      getStartupProjectHint: async () => ({ kind: 'open-folder' as const, projectPath: '/mock/watched/directory' }),
       openProject: async (dir: string) => {
         const projectedGraph = mockElectronAPI.graph._projectedGraph ?? createEmptyProjectedGraph();
         setTimeout(() => {
@@ -210,13 +210,11 @@ function installMockElectronAPI(): void {
         name: 'Mock Test Project',
         type: 'folder' as const,
         lastOpened: Date.now(),
-        voicetreeInitialized: true,
       }],
       saveProject: async () => {},
       removeProject: async () => {},
       getDefaultSearchDirectories: async () => [],
       scanForProjects: async () => [],
-      initializeProject: async () => '/mock/watched/directory/voicetree',
       showFolderPicker: async () => ({ success: false }),
     },
     onWatchingStarted: () => {},

--- a/webapp/src/shell/UI/App.projectOpen.test.tsx
+++ b/webapp/src/shell/UI/App.projectOpen.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SavedProject } from '@vt/graph-model/project'
+
+import App from './App'
+
+const selectedProject: SavedProject = {
+    id: 'project-1',
+    path: '/tmp/vt-project',
+    name: 'vt-project',
+    type: 'folder',
+    lastOpened: 1,
+}
+
+vi.mock('@/shell/UI/ProjectSelectionScreen', () => ({
+    ProjectSelectionScreen: ({ onProjectSelected }: { onProjectSelected: (project: SavedProject) => void }) => (
+        <button type="button" onClick={() => onProjectSelected(selectedProject)}>
+            Open Project
+        </button>
+    ),
+}))
+
+vi.mock('@/shell/UI/views/hooks/useFolderWatcher', () => ({
+    useFolderWatcher: () => ({
+        watchDirectory: undefined,
+        isWatching: false,
+        startWatching: async () => undefined,
+        stopWatching: async () => undefined,
+    }),
+}))
+
+vi.mock('@/shell/edge/renderer/live/useEventSubscriptionConnection', () => ({
+    useEventSubscriptionConnection: () => ({ isConnected: false }),
+}))
+
+vi.mock('@/shell/edge/UI-edge/graph/view/dotGridBackground', () => ({
+    attachDotGridBackground: () => () => undefined,
+}))
+
+vi.mock('@/shell/UI/views/renderers/voicetree-transcribe', () => ({
+    default: () => <div data-testid="transcribe" />,
+}))
+
+vi.mock('@/shell/UI/views/ui-controls/AgentStatsPanel', () => ({
+    AgentStatsPanel: () => <div data-testid="agent-stats" />,
+}))
+
+vi.mock('@/shell/UI/views/components/ProjectPathSelector', () => ({
+    ProjectPathSelector: () => <div data-testid="project-path-selector" />,
+}))
+
+vi.mock('@/shell/edge/UI-edge/components/ViewSwitcher', () => ({
+    ViewSwitcher: () => <div data-testid="view-switcher" />,
+}))
+
+vi.mock('@/shell/UI/views/graph-view/VoiceTreeGraphView', () => ({
+    VoiceTreeGraphView: class {
+        dispose(): void {}
+    },
+}))
+
+describe('App project-open lifecycle', () => {
+    let calls: string[]
+
+    beforeEach(() => {
+        calls = []
+        window.electronAPI = {
+            main: {
+                getStartupProjectHint: async () => {
+                    calls.push('getStartupProjectHint')
+                    return { kind: 'none' }
+                },
+                openProject: async (projectPath: string) => {
+                    calls.push(`openProject:${projectPath}`)
+                    return {
+                        sessionId: 'session-1',
+                        writeFolderPath: `${projectPath}/voicetree-29-5`,
+                        projectState: { projectRoot: projectPath },
+                        initialProjectedGraph: { nodes: [], edges: [] },
+                        folderState: [],
+                        activeView: { id: 'default', name: 'Default' },
+                    }
+                },
+                saveProject: async (project: SavedProject) => {
+                    calls.push(`saveProject:${project.path}`)
+                },
+                loadProjects: async () => [],
+                loadSettings: async () => ({}),
+            },
+            onProjectSwitching: () => () => undefined,
+            onProjectReady: () => () => undefined,
+            onProjectLost: () => () => undefined,
+            onViewSwitched: () => () => undefined,
+            removeAllListeners: () => undefined,
+            onBackendLog: () => undefined,
+            graph: {
+                getCurrentProjectedGraph: async () => ({ nodes: [], edges: [] }),
+                onProjectedGraphUpdate: () => () => undefined,
+                onGraphClear: () => () => undefined,
+            },
+            terminal: {},
+            events: {},
+            invoke: async () => undefined,
+            on: () => undefined,
+            off: () => undefined,
+        } as unknown as Window['electronAPI']
+    })
+
+    afterEach(() => {
+        cleanup()
+        delete window.electronAPI
+    })
+
+    it('opens a selected project through one public project-open transition', async () => {
+        render(<App />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open Project' }))
+
+        await waitFor(() => {
+            expect(calls).toContain('openProject:/tmp/vt-project')
+        })
+
+        const openIndex: number = calls.indexOf('openProject:/tmp/vt-project')
+        const saveIndex: number = calls.indexOf('saveProject:/tmp/vt-project')
+
+        expect(calls.filter((call) => call.startsWith('openProject:'))).toEqual([
+            'openProject:/tmp/vt-project',
+        ])
+        expect(saveIndex).toBeGreaterThan(openIndex)
+        expect(calls.some((call) => call.startsWith('initializeProject'))).toBe(false)
+    })
+})

--- a/webapp/src/shell/UI/App.tsx
+++ b/webapp/src/shell/UI/App.tsx
@@ -34,7 +34,6 @@ function createFallbackProject(projectPath: string): SavedProject {
         name: getProjectNameFromPath(projectPath),
         type: 'folder',
         lastOpened: Date.now(),
-        voicetreeInitialized: true,
     };
 }
 
@@ -98,16 +97,29 @@ function App(): JSX.Element {
         if (!window.electronAPI) return;
 
         const response = await window.electronAPI.main.openProject(project.path);
-        lastKnownProjectPathRef.current = project.path;
+        const projectRoot: string = response.projectState.projectRoot;
+        const openedProject: SavedProject = {
+            ...project,
+            path: projectRoot,
+            lastOpened: Date.now(),
+        };
+
+        try {
+            await window.electronAPI.main.saveProject(openedProject);
+        } catch (err) {
+            console.error('[App] Failed to save opened project metadata:', err);
+        }
+
+        lastKnownProjectPathRef.current = projectRoot;
         pendingInitialProjectedGraphRef.current = isProjectedGraph(response.initialProjectedGraph)
             ? response.initialProjectedGraph
             : null;
         setOpenedProject({
-            path: project.path,
+            path: projectRoot,
             sessionId: response.sessionId,
         });
         setProjectError(null);
-        setCurrentProject(project);
+        setCurrentProject(openedProject);
         setCurrentView('graph-view');
     }, []);
 
@@ -115,24 +127,8 @@ function App(): JSX.Element {
     const handleProjectSelected: (project: SavedProject) => Promise<void> = useCallback(async (project: SavedProject): Promise<void> => {
         if (!window.electronAPI) return;
 
-        let selectedProject: SavedProject = project;
-
-        // Initialize project if needed (creates /voicetree-{date} folder)
-        if (!project.voicetreeInitialized) {
-            try {
-                // initializeProject returns voicetree path if created, or existing path if already exists
-                await window.electronAPI.main.initializeProject(project.path);
-                // Mark as initialized regardless of whether we created it or it existed
-                const updatedProject: SavedProject = { ...project, voicetreeInitialized: true };
-                await window.electronAPI.main.saveProject(updatedProject);
-                selectedProject = updatedProject;
-            } catch (err) {
-                console.error('[App] Failed to initialize project:', err);
-            }
-        }
-
         try {
-            await openProjectForProject(selectedProject);
+            await openProjectForProject(project);
         } catch (err) {
             console.error('[App] Failed to open project:', err);
             setProjectError(err instanceof Error ? err.message : String(err));
@@ -208,7 +204,7 @@ function App(): JSX.Element {
 
                 if (cancelled) return;
                 if (startupHint.kind === 'open-folder') {
-                    const project: SavedProject = await loadProjectForDirectory(startupHint.path);
+                    const project: SavedProject = await loadProjectForDirectory(startupHint.projectPath);
                     if (!cancelled) await openProjectForProject(project);
                 }
             } catch (err) {

--- a/webapp/src/shell/UI/ProjectSelectionScreen.tsx
+++ b/webapp/src/shell/UI/ProjectSelectionScreen.tsx
@@ -137,18 +137,9 @@ export function ProjectSelectionScreen({ onProjectSelected }: ProjectSelectionSc
             name: discovered.name,
             type: discovered.type,
             lastOpened: Date.now(),
-            voicetreeInitialized: false,
         };
 
-        try {
-            await window.electronAPI.main.saveProject(newProject);
-            setSavedProjects((prev) => sortProjectsByLastOpened([...prev, newProject]));
-            setDiscoveredProjects((prev) => prev.filter((p) => p.path !== discovered.path));
-            onProjectSelected(newProject);
-        } catch (err) {
-            console.error('[ProjectSelectionScreen] Failed to add project:', err);
-            setError('Failed to add project');
-        }
+        onProjectSelected(newProject);
     };
 
     // Handle selecting a saved project
@@ -157,17 +148,7 @@ export function ProjectSelectionScreen({ onProjectSelected }: ProjectSelectionSc
     ): Promise<void> => {
         if (!window.electronAPI) return;
 
-        // Update lastOpened
-        const updated: SavedProject = { ...project, lastOpened: Date.now() };
-
-        try {
-            await window.electronAPI.main.saveProject(updated);
-            onProjectSelected(updated);
-        } catch (err) {
-            console.error('[ProjectSelectionScreen] Failed to update project:', err);
-            // Still open the project even if update fails
-            onProjectSelected(project);
-        }
+        onProjectSelected(project);
     };
 
     // Handle creating a new project — auto-creates ~/Voicetree/voicetree-{day}-{month}
@@ -183,10 +164,8 @@ export function ProjectSelectionScreen({ onProjectSelected }: ProjectSelectionSc
                 name: folderName,
                 type: 'folder',
                 lastOpened: Date.now(),
-                voicetreeInitialized: false,
             };
 
-            await window.electronAPI.main.saveProject(newProject);
             onProjectSelected(newProject);
         } catch (err) {
             console.error('[ProjectSelectionScreen] Failed to create project:', err);
@@ -217,10 +196,8 @@ export function ProjectSelectionScreen({ onProjectSelected }: ProjectSelectionSc
                 name: folderName,
                 type: 'folder',
                 lastOpened: Date.now(),
-                voicetreeInitialized: false,
             };
 
-            await window.electronAPI.main.saveProject(newProject);
             onProjectSelected(newProject);
         } catch (err) {
             console.error('[ProjectSelectionScreen] Failed to browse folder:', err);

--- a/webapp/src/shell/UI/views/graph-view/VoiceTreeGraphView.ts
+++ b/webapp/src/shell/UI/views/graph-view/VoiceTreeGraphView.ts
@@ -113,13 +113,13 @@ const createDarkModeCallbacks = ({updateGraphStyles, searchService}: DarkModeCal
     updateSearchTheme: (isDark: boolean) => searchService()?.updateTheme(isDark),
 });
 
-type StartupProjectHint = {readonly kind: 'none'} | {readonly kind: 'open-folder'; readonly path: string};
+type StartupProjectHint = {readonly kind: 'none'} | {readonly kind: 'open-folder'; readonly projectPath: string};
 
 type StartGraphUpdateSubscriptionInput = {
     hasInitialProjectedGraph: boolean;
     isDisposed: () => boolean;
     getStartupProjectHint: (() => Promise<StartupProjectHint>) | undefined;
-    openProject: ((path: string) => Promise<unknown>) | undefined;
+    openProject: ((projectPath: string) => Promise<unknown>) | undefined;
     subscribeToGraphUpdates: () => void;
 };
 
@@ -140,7 +140,7 @@ const startGraphUpdateSubscription = ({
             try {
                 const hint = await getStartupProjectHint?.();
                 if (hint && hint.kind !== 'none') {
-                    await openProject?.(hint.path);
+                    await openProject?.(hint.projectPath);
                 }
             } catch (err: unknown) {
                 console.error('[VoiceTreeGraphView] startup project open failed:', err);

--- a/webapp/src/shell/edge/main/graph/watch_folder/openProject.ts
+++ b/webapp/src/shell/edge/main/graph/watch_folder/openProject.ts
@@ -33,7 +33,7 @@ import { uiAPI } from '@/shell/edge/main/runtime/ui-api-proxy'
 import { getMainWindow } from '@/shell/edge/main/runtime/state/app-electron-state'
 
 export type StartupProjectHint =
-    | { readonly kind: 'open-folder'; readonly path: string }
+    | { readonly kind: 'open-folder'; readonly projectPath: string }
     | { readonly kind: 'none' }
 
 function pushToRenderer(
@@ -104,7 +104,7 @@ async function resolveOrCreateWriteFolderPath(projectPath: string): Promise<stri
 export async function getStartupProjectHint(): Promise<StartupProjectHint> {
     const startupFolder: string | null = getStartupFolderOverride()
     if (startupFolder !== null) {
-        return { kind: 'open-folder', path: startupFolder }
+        return { kind: 'open-folder', projectPath: startupFolder }
     }
 
     return { kind: 'none' }

--- a/webapp/src/shell/edge/main/graph/watch_folder/startupProjectHint.test.ts
+++ b/webapp/src/shell/edge/main/graph/watch_folder/startupProjectHint.test.ts
@@ -42,7 +42,28 @@ describe('getStartupProjectHint', () => {
 
         await expect(getStartupProjectHint()).resolves.toEqual({
             kind: 'open-folder',
-            path: projectPath,
+            projectPath,
         })
+    })
+
+    it('has no recent-project startup hint variant', async () => {
+        const hint = await getStartupProjectHint()
+
+        expect(['none', 'open-folder']).toContain(hint.kind)
+    })
+
+    it('does not read persisted global config while resolving startup intent', async () => {
+        const sourcePath: string = path.join(
+            process.cwd(),
+            'src/shell/edge/main/graph/watch_folder/openProject.ts',
+        )
+        const source: string = await fs.readFile(sourcePath, 'utf8')
+        const functionStart: number = source.indexOf('export async function getStartupProjectHint')
+        const functionEnd: number = source.indexOf('export async function openProject')
+        const functionSource: string = source.slice(functionStart, functionEnd)
+
+        expect(functionSource).not.toContain('lastDirectory')
+        expect(functionSource).not.toContain('getLastDirectory')
+        expect(functionSource).not.toContain('loadPersistedConfig')
     })
 })

--- a/webapp/src/shell/edge/main/observability/debug/prettySetupAppForElectronDebugging.ts
+++ b/webapp/src/shell/edge/main/observability/debug/prettySetupAppForElectronDebugging.ts
@@ -116,7 +116,6 @@ export async function prettySetupAppForElectronDebugging(): Promise<DebugSetupRe
             name: projectName,
             type: 'folder',
             lastOpened: Date.now(),
-            voicetreeInitialized: true
         };
         await saveProject(project);
         console.log('[DebugSetup] Saved project:', project.id);

--- a/webapp/src/shell/edge/main/runtime/api.ts
+++ b/webapp/src/shell/edge/main/runtime/api.ts
@@ -56,9 +56,7 @@ import {runAgentOnSelectedNodes} from '@/shell/edge/main/agent/runAgentOnSelecte
 import {listWorktrees, createWorktree as createWorktreeCore, generateWorktreeName, removeWorktree, getRemoveWorktreeCommand} from '@/shell/edge/main/workspace/worktree/gitWorktreeCommands';
 import {scanForProjects, getDefaultSearchDirectories} from '@/shell/edge/main/workspace/project-scanner';
 import {loadProjects, saveProject, removeProject} from '@/shell/edge/main/workspace/project-store';
-import {initializeProject as initializeProjectCore} from '@/shell/edge/main/workspace/project-initializer';
 import {showFolderPicker, createNewProject} from '@/shell/edge/main/workspace/show-folder-picker';
-import {getOnboardingDirectory} from './electron/startup/onboarding-setup';
 import {prettySetupAppForElectronDebugging} from '@/shell/edge/main/observability/debug/prettySetupAppForElectronDebugging';
 import {
   checkMicrophonePermission,
@@ -90,21 +88,10 @@ import {
 import { __debugLockSSE, __debugUnlockSSE } from './electron/daemon/sync/daemon-sse-subscription';
 import { stopDaemonGraphSync } from './electron/daemon/sync/daemon-watch-sync';
 import { shutdownActiveDaemonConnection as shutdownGraphDaemon } from './electron/daemon/lifecycle/graph-daemon';
-import path from 'path';
 
 async function __debugStopDaemonGraphSync(): Promise<void> {
   if (process.env.NODE_ENV !== 'test') throw new Error('Test-only API');
   await stopDaemonGraphSync();
-}
-
-/**
- * Wrapper for initializeProject that provides the onboarding source directory.
- * Copies onboarding .md files from Application Support into the project's voicetree folder.
- * Returns the path to the voicetree subfolder (existing or newly created).
- */
-async function initializeProject(projectPath: string): Promise<string | null> {
-    const onboardingSourceDir: string = path.join(getOnboardingDirectory(), 'voicetree');
-    return initializeProjectCore(projectPath, onboardingSourceDir);
 }
 
 /**
@@ -348,7 +335,6 @@ export const mainAPI = {
   loadProjects: (): Promise<SavedProject[]> => loadProjects(),
   saveProject: (project: SavedProject): Promise<void> => saveProject(project),
   removeProject: (id: string): Promise<void> => removeProject(id),
-  initializeProject,
   showFolderPicker,
   createNewProject,
 

--- a/webapp/src/shell/edge/main/workspace/show-folder-picker.test.ts
+++ b/webapp/src/shell/edge/main/workspace/show-folder-picker.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+    dialog: {
+        showOpenDialog: vi.fn(),
+    },
+}))
+
+import { getDefaultProjectsHomePath } from './show-folder-picker'
+
+describe('getDefaultProjectsHomePath', () => {
+    it('uses ~/Voicetree as the default parent for newly-created projects', () => {
+        expect(getDefaultProjectsHomePath('/home/aki')).toBe('/home/aki/Voicetree')
+    })
+})

--- a/webapp/src/shell/edge/main/workspace/show-folder-picker.ts
+++ b/webapp/src/shell/edge/main/workspace/show-folder-picker.ts
@@ -4,12 +4,16 @@ import path from 'path';
 import fs from 'fs';
 import { createDatedSubfolder } from './project-utils';
 
+export function getDefaultProjectsHomePath(homePath: string = os.homedir()): string {
+    return path.join(homePath, 'Voicetree');
+}
+
 /**
- * Creates a new dated project folder inside ~/Voicetree (e.g. ~/Voicetree/voicetree-18-2).
- * Creates the parent ~/Voicetree directory if it doesn't exist.
+ * Creates a new dated project root inside the default projects home
+ * (~/Voicetree/voicetree-{day}-{month}).
  */
 export async function createNewProject(): Promise<string> {
-    const parentDir: string = path.join(os.homedir(), 'Voicetree');
+    const parentDir: string = getDefaultProjectsHomePath();
     if (!fs.existsSync(parentDir)) {
         fs.mkdirSync(parentDir, { recursive: true });
     }


### PR DESCRIPTION
## Summary

Implements `/root/brain/mem/openspec/changes/runtime-state/explicit-project-open-and-path-entrypoints/` after PR #147 landed.

- adds the renderer-facing `openProject(projectPath)` lifecycle entrypoint
- replaces startup hint API with `getStartupProjectHint()` and `{ kind: 'open-folder', projectPath } | { kind: 'none' }`
- removes renderer-facing `openVault`, `getStartupVaultHint`, and `initializeProject`
- moves project metadata save until after successful project open
- removes stale `voicetreeInitialized` project metadata
- updates e2e helpers to use `openProject` / `writeFolderPath`
- keeps lower-level daemon/client `openVault` naming intact

## Verification

- `pnpm --filter voicetree-webapp exec vitest run src/shell/edge/main/graph/watch_folder/startupVaultHint.test.ts src/shell/UI/App.projectOpen.test.tsx src/shell/edge/main/workspace/show-folder-picker.test.ts`
- `pnpm --filter @vt/paths test`
- `pnpm --filter @vt/paths typecheck`
- `pnpm --filter voicetree-webapp exec tsc --noEmit`
