### PR TITLE
fix(graph-ui): reliable terminal→progress blue edge (create on update deltas)

### DIFF
--- a/webapp/src/shell/edge/UI-edge/graph/actions/applyGraphDeltaToUI.ts
+++ b/webapp/src/shell/edge/UI-edge/graph/actions/applyGraphDeltaToUI.ts
@@ -216,7 +216,11 @@ export function applyGraphDeltaToUI(cy: Core, graph: ProjectedGraph): ApplyGraph
 
     const newNodeIds: string[] = []
     const nodesWithoutPositions: string[] = []
-    const agentNameByNewNodeId: Map<string, string> = new Map()
+    // agent_name → node, collected across BOTH new and updated file nodes. `vt graph
+    // create` often injects agent_name via frontmatter-completion AFTER the node first
+    // appears, so the delta carrying agent_name is an UPDATE, not a create. Collecting
+    // on both branches lets the (idempotent) indicator-edge reconcile fire either way.
+    const agentNameByNodeId: Map<string, string> = new Map()
 
     cy.batch(() => {
         // PASS 1 — remove cy nodes no longer in spec
@@ -263,7 +267,7 @@ export function applyGraphDeltaToUI(cy: Core, graph: ProjectedGraph): ApplyGraph
                 // file-node
                 newNodeIds.push(specNode.id)
                 const agentName: string | undefined = getAgentNameFromNode(specNode)
-                if (agentName) agentNameByNewNodeId.set(specNode.id, agentName)
+                if (agentName) agentNameByNodeId.set(specNode.id, agentName)
 
                 const color: string | undefined = colorForNode(specNode)
                 const position: { x: number; y: number } = specNode.position
@@ -310,6 +314,10 @@ export function applyGraphDeltaToUI(cy: Core, graph: ProjectedGraph): ApplyGraph
                 existing.data('color', nextColor)
             }
             existing.data('isContextNode', false)
+            // agent_name may arrive on an update delta (frontmatter-completion after the
+            // node first appeared) — collect it here too so the indicator edge can form.
+            const updatedAgentName: string | undefined = getAgentNameFromNode(specNode)
+            if (updatedAgentName) agentNameByNodeId.set(specNode.id, updatedAgentName)
             if (hasActualContentChanged(previousContent, nextContent)) {
                 existing.emit('content-changed')
             }
@@ -369,8 +377,10 @@ export function applyGraphDeltaToUI(cy: Core, graph: ProjectedGraph): ApplyGraph
         repairTerminalAnchorsForNode(cy, nodeId)
     }
 
-    // Terminal→node indicator edges driven by agent_name YAML on new nodes.
-    for (const [nodeId, agentName] of agentNameByNewNodeId) {
+    // Terminal→node indicator edges driven by agent_name YAML (new + updated nodes).
+    // createTerminalIndicatorEdge is idempotent, so re-running it for already-edged
+    // nodes is a no-op.
+    for (const [nodeId, agentName] of agentNameByNodeId) {
         createTerminalIndicatorEdge(cy, nodeId, agentName)
     }
 

--- a/webapp/src/shell/edge/UI-edge/graph/integration-tests/applyGraphDeltaToUI-terminal-indicator.test.ts
+++ b/webapp/src/shell/edge/UI-edge/graph/integration-tests/applyGraphDeltaToUI-terminal-indicator.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { Core } from 'cytoscape'
+import cytoscape from 'cytoscape'
+import type { GraphDelta, GraphNode } from '@vt/graph-model/graph'
+import { syncProjectStateFromMain } from '@/shell/edge/UI-edge/state/stores/ProjectPathStore'
+import { resetTestProjectionState, setTestCollapseSet } from '@/shell/edge/UI-edge/graph/integration-tests/projectGraphDelta'
+import { addTerminal, clearTerminals } from '@/shell/edge/UI-edge/state/stores/TerminalStore'
+import { createTerminalData, getShadowNodeId } from '@/shell/edge/UI-edge/floating-windows/anchoring/types'
+import type { TerminalId, NodeIdAndFilePath } from '@/shell/edge/UI-edge/floating-windows/anchoring/types'
+import { O, upsert, applyDeltaToUI } from './applyGraphDeltaToUI.test-utils'
+
+vi.mock('@/shell/edge/UI-edge/graph/popups/userEngagementPrompts', () => ({
+    checkEngagementPrompts: vi.fn()
+}))
+
+const AGENT: string = 'Amy_1'
+const NODE_ID: string = '/project/progress-node.md'
+
+function makeNode(agentName?: string): GraphNode {
+    return {
+        absoluteFilePathIsID: NODE_ID,
+        contentWithoutYamlOrLinks: '# Progress Node',
+        outgoingEdges: [],
+        nodeUIMetadata: {
+            color: O.none,
+            position: O.some({ x: 0, y: 0 }),
+            additionalYAMLProps: agentName ? { agent_name: agentName } : {},
+            isContextNode: false,
+        },
+    }
+}
+
+function deltaWith(node: GraphNode): GraphDelta {
+    return [upsert(node)]
+}
+
+/**
+ * Reproduces the "blue terminal→progress edge is unreliable" bug.
+ *
+ * The indicator edge (class `terminal-progres-nodes-indicator`) connects a live
+ * terminal's shadow node to progress nodes that terminal authored, matched by the
+ * node's `agent_name` YAML against `terminal.agentName`.
+ *
+ * `vt graph create` frequently injects `agent_name` via frontmatter-completion AFTER
+ * the node first appears — so the renderer's first ("new node") delta lacks agent_name
+ * and the later delta that carries it is an UPDATE. Before the fix the edge was only
+ * ever created on the new-node branch, so update-delivered agent_name never produced
+ * an edge.
+ */
+describe('applyGraphDeltaToUI — terminal→progress indicator edge', () => {
+    let cy: Core
+
+    beforeEach(() => {
+        resetTestProjectionState()
+        clearTerminals()
+        cy = cytoscape({ headless: true, elements: [] })
+        // A live terminal whose agentName matches the node's agent_name, plus its
+        // shadow node present in the graph (the edge endpoint).
+        addTerminal(createTerminalData({
+            terminalId: AGENT as TerminalId,
+            attachedToNodeId: '/project/task.md' as NodeIdAndFilePath,
+            terminalCount: 0,
+            title: AGENT,
+            agentName: AGENT,
+        }))
+        cy.add({
+            group: 'nodes',
+            data: { id: getShadowNodeId(AGENT as TerminalId), isShadowNode: true },
+        })
+    })
+
+    afterEach(() => {
+        cy.destroy()
+        clearTerminals()
+        setTestCollapseSet(new Set())
+        syncProjectStateFromMain({ readPaths: [], writeFolderPath: null, starredFolders: [] })
+    })
+
+    function indicatorEdgeCount(): number {
+        return cy.edges('.terminal-progres-nodes-indicator').length
+    }
+
+    it('creates the edge when agent_name is present on the first (new-node) delta', () => {
+        applyDeltaToUI(cy, deltaWith(makeNode(AGENT)))
+        expect(indicatorEdgeCount()).toBe(1)
+    })
+
+    it('creates the edge when agent_name arrives on a later UPDATE delta (regression)', () => {
+        // First delta: node appears WITHOUT agent_name (frontmatter not yet completed).
+        applyDeltaToUI(cy, deltaWith(makeNode(undefined)))
+        expect(cy.getElementById(NODE_ID).length).toBe(1)
+        expect(indicatorEdgeCount()).toBe(0)
+
+        // Second delta: same node, now WITH agent_name (frontmatter completion). This is
+        // an update path because the node already exists in cy.
+        applyDeltaToUI(cy, deltaWith(makeNode(AGENT)))
+        expect(indicatorEdgeCount()).toBe(1)
+    })
+
+    it('does not duplicate the edge across repeated update deltas (idempotent)', () => {
+        applyDeltaToUI(cy, deltaWith(makeNode(AGENT)))
+        applyDeltaToUI(cy, deltaWith(makeNode(AGENT)))
+        applyDeltaToUI(cy, deltaWith(makeNode(AGENT)))
+        expect(indicatorEdgeCount()).toBe(1)
+    })
+})


### PR DESCRIPTION
## Problem

The blue `terminal-progres-nodes-indicator` edge — drawn from a live terminal's shadow node to the progress nodes that terminal authored — shows up **unreliably**. Same node, same `agent_name`, same live terminal: sometimes an edge, sometimes none.

## Root cause (diagnosed live via `vt debug`)

The edge is only ever created in the **new-node branch** of `applyGraphDeltaToUI`, which reads `agent_name` from the projected node's YAML.

But `vt graph create` frequently injects `agent_name` via **frontmatter-completion *after*** the node first appears (`completed_frontmatter (agent_name, isContextNode)`). So:

1. First delta — node appears **without** `agent_name` → new-node branch runs, finds nothing → no edge.
2. Second delta — same node, now **with** `agent_name` → this is an **update** (node already in cy) → the update branch never attempted edge creation.

So the edge only formed when `agent_name` happened to ride in the very first delta (e.g. the agent hand-wrote it in frontmatter). Hence "unreliable".

Confirmed empirically against the running app:
- shadow node + live terminal present, `agent_name` matches → **still no edge**
- re-saving an existing node (forces an update delta) → **still no edge**
- creating a fresh node with `agent_name` in the **first** delta → **edge appears instantly**

## Fix

Collect `agent_name` across **both** the new-node and update branches into a single map, then run the already-idempotent `createTerminalIndicatorEdge` reconcile over all of them. `createTerminalIndicatorEdge` bails if the edge id already exists, so re-running on already-edged nodes is a no-op.

**No new imports** — the import graph is unchanged.

## Tests (TDD)

New `applyGraphDeltaToUI-terminal-indicator.test.ts`:
- ✅ creates the edge when `agent_name` is on the first (new-node) delta
- ✅ **regression**: creates the edge when `agent_name` arrives on a later UPDATE delta (this was the failing red test)
- ✅ idempotent across repeated update deltas (no duplicate edges)

Full `applyGraphDeltaToUI-*` suite passes (38 passed, 1 skipped).

## Notes
- Does not address **headless** agents (no shadow node exists to draw from — separate concern).
- A fuller fix could also reconcile on terminal-registration events to cover the "terminal arrives after the node" race; this PR closes the dominant `vt graph create` two-write case with a minimal change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)