### PR TITLE
feat(ci): per-base-ref budget gates so dev PRs don't wait on tier-3/4

### DIFF
--- a/.github/workflows/measures-budget-gate.generated.yml
+++ b/.github/workflows/measures-budget-gate.generated.yml
@@ -567,10 +567,10 @@ jobs:
           path: health-dashboard/reports/checks/
           retention-days: 1
 
-  budget-gate:
-    name: budget-gate
-    needs: [tier-0-pre-commit-lint, tier-0-pre-commit-policy, tier-0-pre-commit-static, tier-1-coverage, tier-1-e2e, tier-1-health, tier-1-structure, tier-1-typecheck, tier-2-contract, tier-2-e2e, tier-2-fuzz, tier-2-lint, tier-2-unit, tier-3-analyzers, tier-3-e2e, tier-4-analyzers, tier4-precheck]
-    if: "always()"
+  budget-gate-dev:
+    name: budget-gate-dev
+    needs: [tier-0-pre-commit-lint, tier-0-pre-commit-policy, tier-0-pre-commit-static, tier-1-coverage, tier-1-e2e, tier-1-health, tier-1-structure, tier-1-typecheck, tier-2-contract, tier-2-e2e, tier-2-fuzz, tier-2-lint, tier-2-unit]
+    if: "always() && github.base_ref == 'dev'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -594,7 +594,40 @@ jobs:
           GITHUB_BASE_REF: "${{ github.base_ref }}"
           MEASURES_CONDITIONAL_JOBS_BY_BASE_REF: "{\"main\":[\"tier-4-analyzers\"]}"
           MEASURES_CONDITIONAL_PRECHECK_BY_JOB_ID: "{\"tier-4-analyzers\":\"tier4-precheck\"}"
-          MEASURES_REQUIRED_JOBS_BY_BASE_REF: "{\"dev\":[\"budget-gate\",\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\"],\"main\":[\"budget-gate\",\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\",\"tier-3-analyzers\",\"tier-3-e2e\"]}"
+          MEASURES_REQUIRED_JOBS_BY_BASE_REF: "{\"dev\":[\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\"],\"main\":[\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\",\"tier-3-analyzers\",\"tier-3-e2e\"]}"
+          MEASURES_WORKFLOW_NEEDS_JSON: "${{ toJson(needs) }}"
+        run: |
+          node --no-warnings=ExperimentalWarning --experimental-strip-types \
+            packages/measures/scripts/check-tier-budgets.ts
+
+  budget-gate-main:
+    name: budget-gate-main
+    needs: [tier-0-pre-commit-lint, tier-0-pre-commit-policy, tier-0-pre-commit-static, tier-1-coverage, tier-1-e2e, tier-1-health, tier-1-structure, tier-1-typecheck, tier-2-contract, tier-2-e2e, tier-2-fuzz, tier-2-lint, tier-2-unit, tier-3-analyzers, tier-3-e2e, tier-4-analyzers, tier4-precheck]
+    if: "always() && github.base_ref == 'main'"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm ci
+      - name: Download all check reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: reports-*
+          path: health-dashboard/reports/checks/
+          merge-multiple: true
+      - name: "Run tier budget gate (max tier 4)"
+        env:
+          GITHUB_BASE_REF: "${{ github.base_ref }}"
+          MEASURES_CONDITIONAL_JOBS_BY_BASE_REF: "{\"main\":[\"tier-4-analyzers\"]}"
+          MEASURES_CONDITIONAL_PRECHECK_BY_JOB_ID: "{\"tier-4-analyzers\":\"tier4-precheck\"}"
+          MEASURES_REQUIRED_JOBS_BY_BASE_REF: "{\"dev\":[\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\"],\"main\":[\"tier-0-pre-commit-lint\",\"tier-0-pre-commit-policy\",\"tier-0-pre-commit-static\",\"tier-1-coverage\",\"tier-1-e2e\",\"tier-1-health\",\"tier-1-structure\",\"tier-1-typecheck\",\"tier-2-contract\",\"tier-2-e2e\",\"tier-2-fuzz\",\"tier-2-lint\",\"tier-2-unit\",\"tier-3-analyzers\",\"tier-3-e2e\"]}"
           MEASURES_WORKFLOW_NEEDS_JSON: "${{ toJson(needs) }}"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \

--- a/packages/measures/scripts/check-tier-budgets.ts
+++ b/packages/measures/scripts/check-tier-budgets.ts
@@ -222,7 +222,7 @@ function evaluateCiIntegrity(
     const conditionalJobs = conditionalJobsByBase[opts.baseRef] ?? []
     const failures: EvaluationResult['ciFailures'][number][] = []
 
-    for (const jobId of requiredJobs.filter(id => id !== 'budget-gate')) {
+    for (const jobId of requiredJobs) {
         const result = needs[jobId]?.result ?? 'missing'
         if (result !== 'success') {
             failures.push({

--- a/packages/measures/scripts/gen-workflows.ts
+++ b/packages/measures/scripts/gen-workflows.ts
@@ -171,14 +171,32 @@ export function tierSpecsToWorkflow(input: TierSpecs): WorkflowYaml {
         }
     }
 
-    // Final budget-gate job: depends on every tier job, runs always.
-    jobs.push(budgetGateJob(jobs, maxTier, input))
+    // One budget-gate per protected base ref: each waits only on the jobs
+    // required (or conditional) for that base ref, so a dev-targeted PR
+    // doesn't sit on main-only tier-3/4 work.
+    for (const baseRef of protectedBaseRefs(input)) {
+        jobs.push(budgetGateJob(baseRef, input, maxTier))
+    }
 
     return {name: 'Measures (generated)', jobs}
 }
 
+export function protectedBaseRefs(input: TierSpecs): readonly string[] {
+    const set = new Set<string>()
+    for (const conc of input.concerns) {
+        for (const baseRef of conc.spec.protection?.requiredOn ?? []) set.add(baseRef)
+    }
+    return [...set].sort()
+}
+
+export function budgetGateJobId(baseRef: string): string {
+    return `budget-gate-${baseRef}`
+}
+
 export function requiredStatusContextsByBaseRef(input: TierSpecs): RequiredContextsByBaseRef {
-    return mapValuesSorted(requiredJobContextsByBaseRef(input, 'status-context'))
+    const map = requiredJobContextsByBaseRef(input, 'status-context')
+    for (const baseRef of map.keys()) addToMapSet(map, baseRef, budgetGateJobId(baseRef))
+    return mapValuesSorted(map)
 }
 
 export function requiredJobIdsByBaseRef(input: TierSpecs): RequiredContextsByBaseRef {
@@ -210,17 +228,14 @@ function requiredJobContextsByBaseRef(
     mode: 'job-id' | 'status-context',
 ): Map<string, Set<string>> {
     const out = new Map<string, Set<string>>()
-    const protectedBranches = new Set<string>()
     for (const conc of input.concerns) {
         for (const baseRef of conc.spec.protection?.requiredOn ?? []) {
-            protectedBranches.add(baseRef)
             const contexts = mode === 'job-id'
                 ? [jobIdFor(conc.tier, conc.concern)]
                 : statusContextsForConcern(conc)
             for (const context of contexts) addToMapSet(out, baseRef, context)
         }
     }
-    for (const baseRef of protectedBranches) addToMapSet(out, baseRef, 'budget-gate')
     return out
 }
 
@@ -345,17 +360,19 @@ function perCheckMatrixJob(conc: ConcernSpec, input: TierSpecs): Job {
     }
 }
 
-function budgetGateJob(upstreamJobs: readonly Job[], maxTier: number, input: TierSpecs): Job {
-    const upstreamJobIds = upstreamJobs
-        .filter(j => j.id !== 'budget-gate')
-        .map(j => j.id)
-        .sort()
+function budgetGateJob(baseRef: string, input: TierSpecs, maxTier: number): Job {
+    const required = requiredJobIdsByBaseRef(input)[baseRef] ?? []
+    const conditional = conditionalJobIdsByBaseRef(input)[baseRef] ?? []
+    const conditionalPrecheck = conditionalPrecheckByJobId(input)
+    const prechecks = [...new Set(conditional.map(j => conditionalPrecheck[j]).filter((p): p is string => !!p))]
+    const needs = [...new Set([...required, ...conditional, ...prechecks])].sort()
+    const id = budgetGateJobId(baseRef)
     return {
-        id: 'budget-gate',
-        name: 'budget-gate',
+        id,
+        name: id,
         runsOn: 'ubuntu-latest',
-        needs: upstreamJobIds,
-        ifExpr: 'always()',
+        needs,
+        ifExpr: `always() && github.base_ref == '${baseRef}'`,
         strategy: null,
         outputs: null,
         steps: [

--- a/packages/measures/src/checks/tier_4/analyzers/timing-budget-gate.test.ts
+++ b/packages/measures/src/checks/tier_4/analyzers/timing-budget-gate.test.ts
@@ -206,7 +206,7 @@ describe('runTierBudgetGate — branch-aware CI integrity', () => {
                 ...opts,
                 baseRef: 'dev',
                 needsJson: JSON.stringify({'tier-1-unit': {result: 'failure'}}),
-                requiredJobsByBaseRefJson: JSON.stringify({dev: ['tier-1-unit', 'budget-gate']}),
+                requiredJobsByBaseRefJson: JSON.stringify({dev: ['tier-1-unit']}),
             })
             expect(exitCode).toBe(1)
             expect(result.ciFailures).toEqual([{
@@ -223,7 +223,7 @@ describe('runTierBudgetGate — branch-aware CI integrity', () => {
                 ...opts,
                 baseRef: 'dev',
                 needsJson: JSON.stringify({'tier-2-unit': {result: 'success'}}),
-                requiredJobsByBaseRefJson: JSON.stringify({dev: ['tier-2-unit', 'budget-gate']}),
+                requiredJobsByBaseRefJson: JSON.stringify({dev: ['tier-2-unit']}),
             })
             expect(exitCode).toBe(1)
             expect(result.ciFailures).toEqual([{

--- a/packages/measures/src/health/meta/workflows-drift.test.ts
+++ b/packages/measures/src/health/meta/workflows-drift.test.ts
@@ -35,10 +35,10 @@ describe('workflow generator — pure transform on a synthesized fixture', () =>
     it('is deterministic: same fixture input → identical output across runs', async () => {
         const root = await mkdtemp(join(tmpdir(), 'workflow-gen-fixture-'))
         try {
-            await writeTierFixture(root, 'tier_0_pre_commit', {needs: []}, {
+            await writeTierFixture(root, 'tier_0_pre_commit', {needs: [], protection: {requiredOn: ['dev'], conditionalOn: []}}, {
                 'lint/foo.ts': checkSrc('foo-check'),
             })
-            await writeTierFixture(root, 'tier_1', {needs: []}, {
+            await writeTierFixture(root, 'tier_1', {needs: [], protection: {requiredOn: ['dev'], conditionalOn: []}}, {
                 'unit/bar.ts': checkSrc('bar-check'),
                 'unit/baz.ts': checkSrc('baz-check'),
             })
@@ -48,7 +48,7 @@ describe('workflow generator — pure transform on a synthesized fixture', () =>
             // And ensure the output is non-trivial.
             expect(a).toContain('foo-check')
             expect(a).toContain('bar-check,baz-check')
-            expect(a).toContain('budget-gate:')
+            expect(a).toContain('budget-gate-dev:')
         } finally {
             await rm(root, {recursive: true, force: true})
         }
@@ -117,14 +117,15 @@ describe('workflow generator — pure transform on a synthesized fixture', () =>
             const contexts = requiredStatusContextsByBaseRef(await discoverTiers(root))
 
             expect(contexts.dev).toEqual([
-                'budget-gate',
+                'budget-gate-dev',
                 'tier-0-pre-commit-lint',
                 'tier-1-unit',
                 'tier-2-fuzz (a-fuzz)',
                 'tier-2-fuzz (b-fuzz)',
             ])
             expect(contexts.main).toContain('tier-3-e2e')
-            expect(contexts.main).toContain('budget-gate')
+            expect(contexts.main).toContain('budget-gate-main')
+            expect(contexts.main).not.toContain('budget-gate-dev')
             expect(contexts.main).not.toContain('tier-4-analyzers')
         } finally {
             await rm(root, {recursive: true, force: true})


### PR DESCRIPTION
## Summary
Split the single CI `budget-gate` job into one `budget-gate-<baseRef>` per protected base ref, so a dev-targeted PR no longer blocks on main-only tier-3/tier-4 jobs (e.g. stryker mutation runs) that never gate its merge anyway.

## What
- `gen-workflows.ts`: generator now emits one `budget-gate-<baseRef>` per protected base ref. Each gate's `needs:` is limited to that ref's required + conditional jobs (plus their prechecks) and guards with `if: always() && github.base_ref == '<ref>'`.
- `requiredStatusContextsByBaseRef` + `sync-workflow-rulesets.ts --apply` follow through so ruleset contexts match the split gate names.
- `requiredJobIdsByBaseRef` (the env enforcement set) no longer includes the gate's own id, so the obsolete `id !== 'budget-gate'` filter in `check-tier-budgets.ts` is removed.
- `measures-budget-gate.generated.yml` regenerated to reflect the per-base-ref split.
- Tests updated: workflows-drift test, ruleset projection / per-base-ref context test, and `timing-budget-gate` fixtures now assert the split names and drop the now-absent `'budget-gate'` entry.

## Why
A single `budget-gate` job declared `needs:` on every tier — including main-only tier-3/tier-4 analyzers — and with `if: always()` a dev PR had to wait for those upstream jobs to reach a terminal state before the gate could even start, despite `check-tier-budgets` not enforcing them for dev. End-effect: dev PRs sat blocked on mutation runs that would never gate the merge. Per-base-ref gates scope `needs:` to only the jobs that actually gate that base.