### PR TITLE
refactor(recovery): env-threading + createRecoveryAPI facade + cyclomatic decomposition (BF-333/334/335)

### DIFF
--- a/packages/systems/agent-runtime/bin/vt-resume.ts
+++ b/packages/systems/agent-runtime/bin/vt-resume.ts
@@ -24,9 +24,8 @@ import {spawnSync} from 'node:child_process'
 import {DatabaseSync} from 'node:sqlite'
 
 import {
+    agentRuntime,
     configureAgentRuntime,
-    discoverRecoverableAgentSessions,
-    resumePersistedAgentSession,
     type RecoverableAgentSession,
     type CodexThreadsQuery,
     type CodexThreadsQueryResult,
@@ -267,7 +266,7 @@ function formatRow(row: RecoverableAgentSession): string {
 
 async function runList(paths: ResolvedPaths): Promise<void> {
     configureRuntime(paths)
-    const sessions: readonly RecoverableAgentSession[] = await discoverRecoverableAgentSessions()
+    const sessions: readonly RecoverableAgentSession[] = await agentRuntime.discoverRecoverableAgentSessions()
     process.stdout.write(`project_root: ${paths.projectRoot}\n`)
     process.stdout.write(`vault:        ${paths.vault}\n\n`)
     if (sessions.length === 0) {
@@ -282,7 +281,7 @@ async function runList(paths: ResolvedPaths): Promise<void> {
 
 async function runResume(paths: ResolvedPaths, terminalId: string, noAttach: boolean): Promise<void> {
     configureRuntime(paths)
-    const sessions: readonly RecoverableAgentSession[] = await discoverRecoverableAgentSessions()
+    const sessions: readonly RecoverableAgentSession[] = await agentRuntime.discoverRecoverableAgentSessions()
     const target: RecoverableAgentSession | undefined = sessions.find((s) => s.terminalId === terminalId)
     if (!target) die(`terminal '${terminalId}' is not in discovery for project_root ${paths.projectRoot}.`)
 
@@ -297,7 +296,7 @@ async function runResume(paths: ResolvedPaths, terminalId: string, noAttach: boo
     process.stdout.write(
         `resuming '${terminalId}' via ${target.resume.cliType} (native session id resolved lazily by resolveNativeSession)\n`,
     )
-    const result = await resumePersistedAgentSession(target.terminalId)
+    const result = await agentRuntime.resumePersistedAgentSession(target.terminalId)
     if (result.kind !== 'spawned') {
         die(`resume failed: ${JSON.stringify(result)}`)
     }

--- a/packages/systems/agent-runtime/bin/vt-resume.ts
+++ b/packages/systems/agent-runtime/bin/vt-resume.ts
@@ -260,7 +260,7 @@ function formatRow(row: RecoverableAgentSession): string {
     const status: string = row.isClaimed ? 'CLAIMED' : 'unclaimed'
     const capabilities: string[] = []
     if (row.attach) capabilities.push(`attach=${row.attach.session.sessionName}`)
-    if (row.resume) capabilities.push(`resume=${row.resume.cliType}:${row.resume.nativeSessionId}`)
+    if (row.resume) capabilities.push(`resume=${row.resume.cliType}`)
     if (capabilities.length === 0) capabilities.push('-')
     return `${row.terminalId.padEnd(24)}  ${(row.agentName ?? '').padEnd(20)}  ${status.padEnd(10)}  ${capabilities.join('  ')}`
 }
@@ -295,7 +295,7 @@ async function runResume(paths: ResolvedPaths, terminalId: string, noAttach: boo
     if (!target.resume) die(`terminal '${terminalId}' has neither attach nor resume capability.`)
 
     process.stdout.write(
-        `resuming '${terminalId}' via ${target.resume.cliType} (native session ${target.resume.nativeSessionId})\n`,
+        `resuming '${terminalId}' via ${target.resume.cliType} (native session id resolved lazily by resolveNativeSession)\n`,
     )
     const result = await resumePersistedAgentSession(target.terminalId)
     if (result.kind !== 'spawned') {

--- a/packages/systems/agent-runtime/bin/vt-resume.ts
+++ b/packages/systems/agent-runtime/bin/vt-resume.ts
@@ -16,7 +16,8 @@
 // The discovery + resume code paths are the same ones the Electron main
 // process uses; only the UI launch step is replaced with `tmux attach`.
 
-import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs'
+import {existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync} from 'node:fs'
+import {unlink} from 'node:fs/promises'
 import {homedir} from 'node:os'
 import {dirname, join, resolve} from 'node:path'
 import {spawnSync} from 'node:child_process'
@@ -192,8 +193,20 @@ function buildNodeRecoveryEnv(): RecoveryEnv {
                     return null
                 }
             },
+            mkdirSync: (p, opts) => {
+                mkdirSync(p, opts)
+            },
+            renameSync,
+            writeFileUtf8: (p, contents) => {
+                try {
+                    writeFileSync(p, contents, 'utf8')
+                } catch {
+                    // mirror readFileUtf8: best-effort, swallow errors
+                }
+            },
+            unlink: (p) => unlink(p),
         },
-        path: {join},
+        path: {join, resolve},
         sqlite: {queryCodexThreads: queryCodexThreadsNode},
         now: () => Date.now(),
         recoveryConfig: {
@@ -201,8 +214,15 @@ function buildNodeRecoveryEnv(): RecoveryEnv {
                 ?? join(homedir(), '.claude', 'projects'),
             codexStateDb: process.env.VOICETREE_CODEX_STATE_DB
                 ?? join(homedir(), '.codex', 'state_5.sqlite'),
+            horizonDays: parseHorizonDays(process.env.VOICETREE_RECOVERY_HORIZON_DAYS),
         },
     }
+}
+
+function parseHorizonDays(raw: string | undefined): number | undefined {
+    if (!raw) return undefined
+    const n: number = Number(raw)
+    return Number.isFinite(n) && n > 0 ? n : undefined
 }
 
 function queryCodexThreadsNode(dbPath: string, opts: CodexThreadsQuery): CodexThreadsQueryResult {

--- a/packages/systems/agent-runtime/bin/vt-resume.ts
+++ b/packages/systems/agent-runtime/bin/vt-resume.ts
@@ -16,15 +16,20 @@
 // The discovery + resume code paths are the same ones the Electron main
 // process uses; only the UI launch step is replaced with `tmux attach`.
 
-import {existsSync} from 'node:fs'
+import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs'
+import {homedir} from 'node:os'
 import {dirname, join, resolve} from 'node:path'
 import {spawnSync} from 'node:child_process'
+import {DatabaseSync} from 'node:sqlite'
 
 import {
     configureAgentRuntime,
     discoverRecoverableAgentSessions,
     resumePersistedAgentSession,
     type RecoverableAgentSession,
+    type CodexThreadsQuery,
+    type CodexThreadsQueryResult,
+    type RecoveryEnv,
 } from '../src/api/index.ts'
 import {buildTmuxSessionName} from '../src/application/terminals/tmux/tmux-session-manager.ts'
 
@@ -158,8 +163,77 @@ function configureRuntime(paths: ResolvedPaths): void {
                 writeFolder: paths.vault,
             }),
             getWriteFolder: async (): Promise<string> => paths.vault,
+            recovery: buildNodeRecoveryEnv(),
         },
     })
+}
+
+function buildNodeRecoveryEnv(): RecoveryEnv {
+    return {
+        fs: {
+            existsSync,
+            readdirSync: (p) => readdirSync(p),
+            readFileUtf8: (p) => {
+                try {
+                    return readFileSync(p, 'utf8')
+                } catch {
+                    return ''
+                }
+            },
+            statSync: (p) => {
+                try {
+                    const s = statSync(p)
+                    return {
+                        mtimeMs: s.mtimeMs,
+                        isDirectory: () => s.isDirectory(),
+                        isFile: () => s.isFile(),
+                    }
+                } catch {
+                    return null
+                }
+            },
+        },
+        path: {join},
+        sqlite: {queryCodexThreads: queryCodexThreadsNode},
+        now: () => Date.now(),
+        recoveryConfig: {
+            claudeProjectsDir: process.env.VOICETREE_CLAUDE_PROJECTS_DIR
+                ?? join(homedir(), '.claude', 'projects'),
+            codexStateDb: process.env.VOICETREE_CODEX_STATE_DB
+                ?? join(homedir(), '.codex', 'state_5.sqlite'),
+        },
+    }
+}
+
+function queryCodexThreadsNode(dbPath: string, opts: CodexThreadsQuery): CodexThreadsQueryResult {
+    let db: DatabaseSync
+    try {
+        db = new DatabaseSync(dbPath, {readOnly: true})
+    } catch {
+        return {kind: 'db-missing'}
+    }
+    try {
+        const baseColumns = 'id, first_user_message, cwd, created_at_ms, updated_at_ms, rollout_path'
+        const sql: string = opts.sinceMs !== undefined
+            ? `SELECT ${baseColumns} FROM threads WHERE updated_at_ms >= ? ORDER BY updated_at_ms DESC LIMIT ?`
+            : `SELECT ${baseColumns} FROM threads ORDER BY updated_at_ms DESC LIMIT ?`
+        let rows: readonly Record<string, unknown>[]
+        try {
+            const stmt = db.prepare(sql)
+            rows = (opts.sinceMs !== undefined
+                ? stmt.all(opts.sinceMs, opts.limit)
+                : stmt.all(opts.limit)) as readonly Record<string, unknown>[]
+        } catch {
+            return {kind: 'db-schema-mismatch'}
+        }
+        return {kind: 'rows', rows}
+    } finally {
+        try {
+            db.close()
+        } catch {
+            // ignore
+        }
+    }
 }
 
 function formatRow(row: RecoverableAgentSession): string {

--- a/packages/systems/agent-runtime/src/api/agent-runtime-api.ts
+++ b/packages/systems/agent-runtime/src/api/agent-runtime-api.ts
@@ -13,7 +13,7 @@ import { sendTextToTerminal } from '../application/inject/send-text-to-terminal'
 import { shouldFlipToActiveOnOutput } from '../application/lifecycle/output-transition'
 import { getTierTelemetrySnapshot } from '../application/lifecycle/tierTelemetry'
 import { installJsonlTelemetrySink } from '../application/lifecycle/tierTelemetryJsonlSink'
-import { configureAgentRuntime, getRuntimeEnv, getRuntimeUI } from '../application/runtime/runtime-config'
+import { configureAgentRuntime, getRecoveryEnv, getRuntimeEnv, getRuntimeUI } from '../application/runtime/runtime-config'
 import { spawnPlainTerminal, spawnPlainTerminalWithNode } from '../application/spawn/spawnPlainTerminal'
 import { spawnTerminalWithContextNode } from '../application/spawn/spawnTerminalWithContextNode'
 import { getOutput } from '../application/terminals/terminal-output-buffer'
@@ -25,11 +25,7 @@ import {
     killUnclaimedTmuxSession,
     listUnclaimedTmuxSessions,
 } from '../application/terminals/tmux/unclaimed-tmux'
-import { discoverRecoverableAgentSessions } from '../application/recovery/discovery'
-import { resumePersistedAgentSession } from '../application/recovery/resumePersistedAgentSession'
-import { forkAgentSession } from '../application/recovery/forkAgentSession'
-import { migrateLegacyTerminalDir } from '../application/recovery/migrate-legacy-terminal-dir'
-import { removePersistedAgentRecord } from '../application/recovery/removePersistedAgentRecord'
+import { createRecoveryAPI, type RecoveryAPI } from '../application/recovery'
 import {
     enqueuePendingMessage,
     getExistingAgentNames,
@@ -52,6 +48,11 @@ import {
 } from '../application/terminals/global-budget-registry'
 
 const dispatchOnNewNodeHooks = createOnNewNodeHookDispatcher()
+
+// Late-bound recovery API: callers go through `recovery()` which constructs
+// the bound facade on demand from the configured env. Avoids module-level
+// state and lets `configureAgentRuntime` swap envs between tests.
+const recovery = (): RecoveryAPI => createRecoveryAPI(getRecoveryEnv())
 
 export const agentRuntime = {
     attachUnclaimedTmuxSession,
@@ -78,11 +79,11 @@ export const agentRuntime = {
     injectNodesIntoTerminal,
     killUnclaimedTmuxSession,
     listUnclaimedTmuxSessions,
-    discoverRecoverableAgentSessions,
-    resumePersistedAgentSession,
-    forkAgentSession,
-    migrateLegacyTerminalDir,
-    removePersistedAgentRecord,
+    discoverRecoverableAgentSessions: ((opts) => recovery().discoverRecoverableAgentSessions(opts)) as RecoveryAPI['discoverRecoverableAgentSessions'],
+    resumePersistedAgentSession: ((terminalId, deps) => recovery().resumePersistedAgentSession(terminalId, deps)) as RecoveryAPI['resumePersistedAgentSession'],
+    forkAgentSession: ((sourceTerminalId, deps) => recovery().forkAgentSession(sourceTerminalId, deps)) as RecoveryAPI['forkAgentSession'],
+    migrateLegacyTerminalDir: ((args) => recovery().migrateLegacyTerminalDir(args)) as RecoveryAPI['migrateLegacyTerminalDir'],
+    removePersistedAgentRecord: ((terminalId, deps) => recovery().removePersistedAgentRecord(terminalId, deps)) as RecoveryAPI['removePersistedAgentRecord'],
     registerChild,
     reconcileTmuxHeadlessAgents,
     removeTerminalFromRegistry,

--- a/packages/systems/agent-runtime/src/api/index.ts
+++ b/packages/systems/agent-runtime/src/api/index.ts
@@ -22,20 +22,15 @@ export * from '../application/terminals/tmux/tmux-server'
 export * from '../application/terminals/tmux/unclaimed-tmux'
 
 export * from '../application/recovery/types'
-export {discoverRecoverableAgentSessions, defaultDiscoverRecoveryDeps, type DiscoverRecoveryDeps} from '../application/recovery/discovery'
-export {resumePersistedAgentSession, defaultResumePersistedDeps, type ResumePersistedDeps, type ResumePersistedResult} from '../application/recovery/resumePersistedAgentSession'
-export {forkAgentSession, defaultForkAgentDeps, type ForkAgentSessionDeps, type ForkAgentSessionResult} from '../application/recovery/forkAgentSession'
-export {
-    migrateLegacyTerminalDir,
-    type MigrateLegacyTerminalDirArgs,
-    type MigrateLegacyTerminalDirResult,
-} from '../application/recovery/migrate-legacy-terminal-dir'
-export {
-    removePersistedAgentRecord,
-    defaultRemovePersistedAgentRecordDeps,
-    type RemovePersistedAgentRecordDeps,
-    type RemovePersistedAgentRecordResult,
-} from '../application/recovery/removePersistedAgentRecord'
+export {createRecoveryAPI, type RecoveryAPI} from '../application/recovery'
+// Result-type re-exports for renderer-side `Extract<>` discrimination. These
+// stay here (api/ community, not application/) so the recovery community's
+// boundary-width stays narrow while consumers can still type-narrow the
+// facade's return values.
+export type {ResumePersistedResult} from '../application/recovery/sessions/resumePersistedAgentSession'
+export type {ForkAgentSessionResult} from '../application/recovery/sessions/forkAgentSession'
+export type {RemovePersistedAgentRecordResult} from '../application/recovery/persistence/removePersistedAgentRecord'
+export type {MigrateLegacyTerminalDirResult} from '../application/recovery/persistence/migrate-legacy-terminal-dir'
 
 export * from '../application/headless/headlessAgentManager'
 

--- a/packages/systems/agent-runtime/src/application/recovery/classifier/classifier.test-fixtures.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/classifier/classifier.test-fixtures.ts
@@ -1,9 +1,14 @@
-import type {ClassifierInput, MetadataRecord} from './classifier'
+import {classifyRecoveryCandidates, type MetadataRecord} from './classifier'
 import type {TerminalData} from '../terminals/terminal-registry/types'
 import {buildTmuxNamespaceHash} from '../terminals/tmux/tmux-session-manager'
 import type {UnclaimedTmuxSession} from '../terminals/tmux/unclaimed-tmux'
 import type {ResumeCapability} from './types'
 import * as O from 'fp-ts/lib/Option.js'
+
+// Derive the classifier's input type from its function signature so fixtures
+// don't need a separate exported type from classifier.ts (keeps the public
+// surface of the recovery community minimal).
+type ClassifierInput = Parameters<typeof classifyRecoveryCandidates>[0]
 
 // VAULT_PATH is used consistently so that computed session names (via
 // buildTmuxSessionName) match SESSION_A in tests that omit the session field.

--- a/packages/systems/agent-runtime/src/application/recovery/classifier/classifier.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/classifier/classifier.ts
@@ -5,7 +5,7 @@ import type {UnclaimedTmuxSession} from '../terminals/tmux/unclaimed-tmux'
 import {buildTmuxSessionName} from '../terminals/tmux/tmux-session-manager'
 import {parseVoicetreeTmuxSessionName} from '../terminals/tmux/unclaimed-tmux'
 import {isoToMsOrZero} from './horizon'
-import type {AttachCapability, RecoverableAgentSession, RecoveryClassification, ResumeCapability} from './types'
+import type {AttachCapability, DroppedReason, RecoverableAgentSession, RecoveryClassification, ResumeCapability} from './types'
 
 type ClassifierInput = {
     /**
@@ -143,56 +143,86 @@ function extractNamespaceHash(sessionName: string): string | null {
     return parseVoicetreeTmuxSessionName(sessionName)?.hash ?? null
 }
 
-function classifyRecord(record: MetadataRecord, input: ClassifierInput): RecoveryClassification {
+function nonEmptyString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+// Strips keys whose value is `undefined` so optional fields stay absent rather
+// than present-but-undefined on the resulting record.
+function compactDefined<T extends object>(input: T): T {
+    const result: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(input)) {
+        if (value !== undefined) result[key] = value
+    }
+    return result as T
+}
+
+type ExtractResult =
+    | {
+        readonly kind: 'extracted'
+        readonly metadata: TmuxTerminalMetadata
+        readonly terminalData: TerminalData
+        readonly sessionName: string
+        readonly terminalId: TerminalId
+    }
+    | {readonly kind: 'dropped'; readonly reason: DroppedReason}
+
+function extractValidRecord(record: MetadataRecord, currentNamespaceHash: string | null): ExtractResult {
     const metadata = validateMetadata(record.data)
-    if (!metadata) return {kind: 'dropped', reason: 'invalid', metadataPath: record.path}
+    if (!metadata) return {kind: 'dropped', reason: 'invalid'}
 
-    const terminalId = metadata.name as TerminalId
     const sessionName: string = resolveSessionName(metadata)
-
-    if (input.currentNamespaceHash !== null) {
+    if (currentNamespaceHash !== null) {
         const metadataHash: string | null = extractNamespaceHash(sessionName)
-        if (metadataHash !== null && metadataHash !== input.currentNamespaceHash) {
-            return {kind: 'dropped', reason: 'foreign-vault', metadataPath: record.path}
+        if (metadataHash !== null && metadataHash !== currentNamespaceHash) {
+            return {kind: 'dropped', reason: 'foreign-vault'}
         }
     }
 
     const terminalData: TerminalData | null = normalizeMetadataTerminalData(metadata)
-    if (!terminalData) {
-        // Without terminalData we can't surface a useful row — the UI needs it
-        // for context node, env vars, and initial command. Treat as invalid.
-        return {kind: 'dropped', reason: 'invalid', metadataPath: record.path}
-    }
+    // Without terminalData we can't surface a useful row — the UI needs it
+    // for context node, env vars, and initial command. Treat as invalid.
+    if (!terminalData) return {kind: 'dropped', reason: 'invalid'}
 
+    return {kind: 'extracted', metadata, terminalData, sessionName, terminalId: metadata.name as TerminalId}
+}
+
+function buildRecoverable(
+    extracted: Extract<ExtractResult, {kind: 'extracted'}>,
+    record: MetadataRecord,
+    input: ClassifierInput,
+): RecoverableAgentSession {
+    const {metadata, terminalData, sessionName, terminalId} = extracted
     const liveSession: UnclaimedTmuxSession | undefined = input.liveTmuxSessionsByName.get(sessionName)
     const attach: AttachCapability | undefined = liveSession ? {session: liveSession} : undefined
     const resume: ResumeCapability | undefined = input.resumeHandleByTerminalId.get(terminalId)
-
-    const worktreeName: string | undefined = terminalData.worktreeName
-    const title: string | undefined = terminalData.title && terminalData.title.length > 0 ? terminalData.title : undefined
-    const agentTypeName: string | undefined = terminalData.agentTypeName && terminalData.agentTypeName.length > 0 ? terminalData.agentTypeName : undefined
-    const killReason: string | undefined = typeof metadata.killReason === 'string' && metadata.killReason.length > 0 ? metadata.killReason : undefined
     const endedAtMs: number = isoToMsOrZero(metadata.endedAt)
 
-    const recoverable: RecoverableAgentSession = {
+    return compactDefined<RecoverableAgentSession>({
         terminalId,
         agentName: terminalData.agentName ?? metadata.name,
         metadataPath: record.path,
         terminalData,
         isClaimed: input.registryTerminalIds.has(metadata.name),
         status: metadata.status,
-        ...(attach ? {attach} : {}),
-        ...(resume ? {resume} : {}),
-        ...(worktreeName ? {worktreeName} : {}),
-        ...(title ? {title} : {}),
-        ...(agentTypeName ? {agentTypeName} : {}),
-        ...(metadata.startedAt ? {startedAt: metadata.startedAt} : {}),
-        ...(metadata.endedAt ? {endedAt: metadata.endedAt} : {}),
-        ...(endedAtMs > 0 ? {closedAt: endedAtMs} : {}),
-        ...(killReason ? {killReason} : {}),
-    }
+        attach,
+        resume,
+        worktreeName: nonEmptyString(terminalData.worktreeName),
+        title: nonEmptyString(terminalData.title),
+        agentTypeName: nonEmptyString(terminalData.agentTypeName),
+        startedAt: nonEmptyString(metadata.startedAt),
+        endedAt: nonEmptyString(metadata.endedAt),
+        closedAt: endedAtMs > 0 ? endedAtMs : undefined,
+        killReason: nonEmptyString(metadata.killReason),
+    })
+}
 
-    return {kind: 'recoverable', record: recoverable}
+function classifyRecord(record: MetadataRecord, input: ClassifierInput): RecoveryClassification {
+    const extracted = extractValidRecord(record, input.currentNamespaceHash)
+    if (extracted.kind === 'dropped') {
+        return {kind: 'dropped', reason: extracted.reason, metadataPath: record.path}
+    }
+    return {kind: 'recoverable', record: buildRecoverable(extracted, record, input)}
 }
 
 /**

--- a/packages/systems/agent-runtime/src/application/recovery/classifier/classifier.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/classifier/classifier.ts
@@ -2,13 +2,12 @@ import * as O from 'fp-ts/lib/Option.js'
 import {createTerminalData, type TerminalData, type TerminalId} from '../terminals/terminal-registry/types'
 import type {TmuxTerminalMetadata} from '../terminals/terminal-registry/terminal-metadata'
 import type {UnclaimedTmuxSession} from '../terminals/tmux/unclaimed-tmux'
-import {detectCliType} from '../spawn/headlessCli'
 import {buildTmuxSessionName} from '../terminals/tmux/tmux-session-manager'
 import {parseVoicetreeTmuxSessionName} from '../terminals/tmux/unclaimed-tmux'
 import {isoToMsOrZero} from './horizon'
 import type {AttachCapability, RecoverableAgentSession, RecoveryClassification, ResumeCapability} from './types'
 
-export type ClassifierInput = {
+type ClassifierInput = {
     /**
      * Raw parsed JSON objects (already JSON.parse'd) with their source file paths.
      * The classifier validates shape and drops malformed records.
@@ -214,15 +213,3 @@ export function classifyRecoveryCandidates(input: ClassifierInput): readonly Rec
     return input.metadataRecords.map((record) => classifyRecord(record, input))
 }
 
-/**
- * Convenience: which supported CLI does this metadata target (if any)?
- *
- * Used by discovery to decide whether to spend a resolver call on a record.
- * Returns null for unsupported CLIs, missing initialCommand, or invalid metadata.
- */
-export function detectSupportedCliFromMetadata(metadata: TmuxTerminalMetadata): 'claude' | 'codex' | null {
-    const initialCommand: string | undefined = metadata.terminalData?.initialCommand
-    if (!initialCommand) return null
-    const cliType = detectCliType(initialCommand)
-    return cliType === 'claude' || cliType === 'codex' ? cliType : null
-}

--- a/packages/systems/agent-runtime/src/application/recovery/discovery.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/discovery.ts
@@ -1,6 +1,6 @@
-import {getRecoveryEnv, getRuntimeEnv, type RecoveryEnv} from '../runtime/runtime-config'
+import {getRuntimeEnv, type RecoveryEnv} from '../runtime/runtime-config'
 import {getTerminalRecords, type TerminalRecord} from '../terminals/terminal-registry'
-import {readMetadata, type TmuxTerminalMetadata} from '../terminals/terminal-registry/terminal-metadata'
+import type {TmuxTerminalMetadata} from '../terminals/terminal-registry/terminal-metadata'
 import {createTerminalData, type TerminalId} from '../terminals/terminal-registry/types'
 import {
     getCurrentTmuxNamespaceHash,
@@ -9,16 +9,16 @@ import {
     type UnclaimedTmuxSession,
 } from '../terminals/tmux/unclaimed-tmux'
 import {buildTmuxSessionName} from '../terminals/tmux/tmux-session-manager'
+import {detectCliType} from '../spawn/headlessCli'
 import {
     classifyRecoveryCandidates,
-    detectSupportedCliFromMetadata,
     type MetadataRecord,
 } from './classifier/classifier'
 import {isoToMsOrZero, resolveRecoveryHorizonMs} from './horizon'
 import {getRecoveryMetadataDir} from './paths'
 import type {RecoverableAgentSession, RecoveryClassification, ResumeCapability} from './types'
 
-export type DiscoverRecoveryDeps = {
+type DiscoverRecoveryDeps = {
     readonly readVaultMetadataDir: () => Promise<readonly MetadataRecord[]>
     readonly listLiveUnclaimedTmuxSessions: () => Promise<readonly UnclaimedTmuxSession[]>
     readonly getRegistryTerminalIds: () => ReadonlySet<string>
@@ -103,18 +103,17 @@ function applyHorizon(
  * agent that never wrote a transcript) are dropped — there's nothing the UI
  * could do with them.
  */
-export async function discoverRecoverableAgentSessionsWithEnv(
+export async function discoverRecoverableAgentSessions(
     env: RecoveryEnv,
-    deps?: DiscoverRecoveryDeps,
     opts: DiscoverRecoveryOptions = {},
+    deps: DiscoverRecoveryDeps = defaultDiscoverRecoveryDeps(env),
 ): Promise<readonly RecoverableAgentSession[]> {
-    const resolvedDeps: DiscoverRecoveryDeps = deps ?? defaultDiscoverRecoveryDepsWithEnv(env)
     const [metadataRecords, liveUnclaimed, currentNamespaceHash] = await Promise.all([
-        resolvedDeps.readVaultMetadataDir(),
-        resolvedDeps.listLiveUnclaimedTmuxSessions(),
-        resolvedDeps.getCurrentNamespaceHash(),
+        deps.readVaultMetadataDir(),
+        deps.listLiveUnclaimedTmuxSessions(),
+        deps.getCurrentNamespaceHash(),
     ])
-    const registryTerminalIds: ReadonlySet<string> = resolvedDeps.getRegistryTerminalIds()
+    const registryTerminalIds: ReadonlySet<string> = deps.getRegistryTerminalIds()
     const liveTmuxSessionsByName: ReadonlyMap<string, UnclaimedTmuxSession> = new Map(
         liveUnclaimed.map((session) => [session.sessionName, session]),
     )
@@ -155,22 +154,6 @@ export async function discoverRecoverableAgentSessionsWithEnv(
         : opts.horizonMs
     const withinHorizon: readonly RecoverableAgentSession[] = applyHorizon(recoverable, horizonMs, env.now())
     return sortRecords(withinHorizon)
-}
-
-/**
- * Convenience binding: reads the recovery env from the configured runtime
- * registry and dispatches. Preserves the legacy zero-arg call shape consumed
- * by the api/agent-runtime-api.ts re-export surface and the sessions/* default
- * deps factories, so those callers don't need env threading yet.
- *
- * Callers that already hold a `RecoveryEnv` should call
- * `discoverRecoverableAgentSessionsWithEnv(env, ...)` directly.
- */
-export async function discoverRecoverableAgentSessions(
-    deps?: DiscoverRecoveryDeps,
-    opts: DiscoverRecoveryOptions = {},
-): Promise<readonly RecoverableAgentSession[]> {
-    return discoverRecoverableAgentSessionsWithEnv(getRecoveryEnv(), deps, opts)
 }
 
 function metadataLessAttachableRow(session: UnclaimedTmuxSession): RecoverableAgentSession {
@@ -240,6 +223,18 @@ function detectResumeCapabilitiesFromMetadata(
     return out
 }
 
+/**
+ * Which supported CLI does this metadata target (if any)? Used to gate the
+ * resolver work — only records pointing at `claude` or `codex` get a native
+ * session id at click time.
+ */
+function detectSupportedCliFromMetadata(metadata: TmuxTerminalMetadata): 'claude' | 'codex' | null {
+    const initialCommand: string | undefined = metadata.terminalData?.initialCommand
+    if (!initialCommand) return null
+    const cliType = detectCliType(initialCommand)
+    return cliType === 'claude' || cliType === 'codex' ? cliType : null
+}
+
 async function resolveCurrentVaultMetadataDir(): Promise<string | null> {
     // Canonical location is always `<projectRoot>/.voicetree/terminals/`.
     // `writeFolder` is intentionally NOT consulted: the historical
@@ -273,7 +268,7 @@ function readMetadataDir(env: RecoveryEnv, dir: string): readonly MetadataRecord
     return records
 }
 
-export function defaultDiscoverRecoveryDepsWithEnv(env: RecoveryEnv): DiscoverRecoveryDeps {
+function defaultDiscoverRecoveryDeps(env: RecoveryEnv): DiscoverRecoveryDeps {
     return {
         readVaultMetadataDir: async (): Promise<readonly MetadataRecord[]> => {
             const dir: string | null = await resolveCurrentVaultMetadataDir()
@@ -288,16 +283,3 @@ export function defaultDiscoverRecoveryDepsWithEnv(env: RecoveryEnv): DiscoverRe
     }
 }
 
-/**
- * Convenience binding for the sessions/* default deps factories: pulls the
- * recovery env from the configured runtime and dispatches. Preserves the
- * pre-Pattern-3 zero-arg call shape, so callers that haven't been env-threaded
- * yet keep compiling.
- */
-export function defaultDiscoverRecoveryDeps(): DiscoverRecoveryDeps {
-    return defaultDiscoverRecoveryDepsWithEnv(getRecoveryEnv())
-}
-
-// Re-export for convenience: callers building custom deps that still want to
-// share the on-disk metadata reader.
-export {readMetadata}

--- a/packages/systems/agent-runtime/src/application/recovery/discovery.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/discovery.ts
@@ -1,6 +1,4 @@
-import {readdirSync, readFileSync, statSync} from 'node:fs'
-import path from 'node:path'
-import {getRuntimeEnv} from '../runtime/runtime-config'
+import {getRecoveryEnv, getRuntimeEnv, type RecoveryEnv} from '../runtime/runtime-config'
 import {getTerminalRecords, type TerminalRecord} from '../terminals/terminal-registry'
 import {readMetadata, type TmuxTerminalMetadata} from '../terminals/terminal-registry/terminal-metadata'
 import {createTerminalData, type TerminalId} from '../terminals/terminal-registry/types'
@@ -15,8 +13,8 @@ import {
     classifyRecoveryCandidates,
     detectSupportedCliFromMetadata,
     type MetadataRecord,
-} from './classifier'
-import {getRecoveryHorizonMs, isoToMsOrZero} from './horizon'
+} from './classifier/classifier'
+import {isoToMsOrZero, resolveRecoveryHorizonMs} from './horizon'
 import {getRecoveryMetadataDir} from './paths'
 import type {RecoverableAgentSession, RecoveryClassification, ResumeCapability} from './types'
 
@@ -28,13 +26,13 @@ export type DiscoverRecoveryDeps = {
 }
 
 /**
- * Optional knobs for `discoverRecoverableAgentSessions`. Tests pass
- * `now` to make horizon assertions deterministic; the renderer's "show
- * older" link passes `horizonMs: null` to disable the cutoff entirely.
+ * Optional knobs for `discoverRecoverableAgentSessions`. The renderer's
+ * "show older" link passes `horizonMs: null` to disable the cutoff entirely.
+ * The clock and horizon-config defaults come from the `RecoveryEnv`; tests
+ * thread a stubbed env to make assertions deterministic.
  */
 export type DiscoverRecoveryOptions = {
     readonly horizonMs?: number | null
-    readonly now?: () => number
 }
 
 /**
@@ -105,11 +103,12 @@ function applyHorizon(
  * agent that never wrote a transcript) are dropped — there's nothing the UI
  * could do with them.
  */
-export async function discoverRecoverableAgentSessions(
+export async function discoverRecoverableAgentSessionsWithEnv(
+    env: RecoveryEnv,
     deps?: DiscoverRecoveryDeps,
     opts: DiscoverRecoveryOptions = {},
 ): Promise<readonly RecoverableAgentSession[]> {
-    const resolvedDeps: DiscoverRecoveryDeps = deps ?? defaultDiscoverRecoveryDeps()
+    const resolvedDeps: DiscoverRecoveryDeps = deps ?? defaultDiscoverRecoveryDepsWithEnv(env)
     const [metadataRecords, liveUnclaimed, currentNamespaceHash] = await Promise.all([
         resolvedDeps.readVaultMetadataDir(),
         resolvedDeps.listLiveUnclaimedTmuxSessions(),
@@ -151,10 +150,27 @@ export async function discoverRecoverableAgentSessions(
         if (surfacedTerminalIds.has(session.terminalId)) continue
         recoverable.push(metadataLessAttachableRow(session))
     }
-    const horizonMs: number | null = opts.horizonMs === undefined ? getRecoveryHorizonMs() : opts.horizonMs
-    const now: number = (opts.now ?? Date.now)()
-    const withinHorizon: readonly RecoverableAgentSession[] = applyHorizon(recoverable, horizonMs, now)
+    const horizonMs: number | null = opts.horizonMs === undefined
+        ? resolveRecoveryHorizonMs(env.recoveryConfig.horizonDays)
+        : opts.horizonMs
+    const withinHorizon: readonly RecoverableAgentSession[] = applyHorizon(recoverable, horizonMs, env.now())
     return sortRecords(withinHorizon)
+}
+
+/**
+ * Convenience binding: reads the recovery env from the configured runtime
+ * registry and dispatches. Preserves the legacy zero-arg call shape consumed
+ * by the api/agent-runtime-api.ts re-export surface and the sessions/* default
+ * deps factories, so those callers don't need env threading yet.
+ *
+ * Callers that already hold a `RecoveryEnv` should call
+ * `discoverRecoverableAgentSessionsWithEnv(env, ...)` directly.
+ */
+export async function discoverRecoverableAgentSessions(
+    deps?: DiscoverRecoveryDeps,
+    opts: DiscoverRecoveryOptions = {},
+): Promise<readonly RecoverableAgentSession[]> {
+    return discoverRecoverableAgentSessionsWithEnv(getRecoveryEnv(), deps, opts)
 }
 
 function metadataLessAttachableRow(session: UnclaimedTmuxSession): RecoverableAgentSession {
@@ -233,34 +249,35 @@ async function resolveCurrentVaultMetadataDir(): Promise<string | null> {
     return projectRoot ? getRecoveryMetadataDir(projectRoot) : null
 }
 
-function readMetadataDir(dir: string): readonly MetadataRecord[] {
+function readMetadataDir(env: RecoveryEnv, dir: string): readonly MetadataRecord[] {
     let entries: readonly string[]
     try {
-        entries = readdirSync(dir)
+        entries = env.fs.readdirSync(dir)
     } catch {
         return []
     }
     const records: MetadataRecord[] = []
     for (const entry of entries) {
         if (!entry.endsWith('.json')) continue
-        const filePath: string = path.join(dir, entry)
+        const filePath: string = env.path.join(dir, entry)
+        const stat = env.fs.statSync(filePath)
+        if (!stat || !stat.isFile()) continue
+        const raw: string = env.fs.readFileUtf8(filePath)
+        if (raw === '') continue  // env.fs.readFileUtf8 swallows read errors as ''
         try {
-            const stat = statSync(filePath)
-            if (!stat.isFile()) continue
-            const raw: string = readFileSync(filePath, 'utf8')
             records.push({path: filePath, data: JSON.parse(raw) as unknown})
         } catch {
-            // Skip files that fail to read or parse; classifier handles invalid shapes too.
+            // Skip files that fail to parse; classifier handles invalid shapes too.
         }
     }
     return records
 }
 
-export function defaultDiscoverRecoveryDeps(): DiscoverRecoveryDeps {
+export function defaultDiscoverRecoveryDepsWithEnv(env: RecoveryEnv): DiscoverRecoveryDeps {
     return {
         readVaultMetadataDir: async (): Promise<readonly MetadataRecord[]> => {
             const dir: string | null = await resolveCurrentVaultMetadataDir()
-            return dir ? readMetadataDir(dir) : []
+            return dir ? readMetadataDir(env, dir) : []
         },
         listLiveUnclaimedTmuxSessions: (): Promise<readonly UnclaimedTmuxSession[]> => listUnclaimedTmuxSessions(),
         getRegistryTerminalIds: (): ReadonlySet<string> => {
@@ -269,6 +286,16 @@ export function defaultDiscoverRecoveryDeps(): DiscoverRecoveryDeps {
         },
         getCurrentNamespaceHash: (): Promise<string | null> => getCurrentTmuxNamespaceHash(),
     }
+}
+
+/**
+ * Convenience binding for the sessions/* default deps factories: pulls the
+ * recovery env from the configured runtime and dispatches. Preserves the
+ * pre-Pattern-3 zero-arg call shape, so callers that haven't been env-threaded
+ * yet keep compiling.
+ */
+export function defaultDiscoverRecoveryDeps(): DiscoverRecoveryDeps {
+    return defaultDiscoverRecoveryDepsWithEnv(getRecoveryEnv())
 }
 
 // Re-export for convenience: callers building custom deps that still want to

--- a/packages/systems/agent-runtime/src/application/recovery/discovery.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/discovery.ts
@@ -182,6 +182,42 @@ function metadataLessAttachableRow(session: UnclaimedTmuxSession): RecoverableAg
     }
 }
 
+function toValidatedMetadata(data: unknown): TmuxTerminalMetadata | null {
+    if (typeof data !== 'object' || data === null) return null
+    const obj = data as Record<string, unknown>
+    if (typeof obj.name !== 'string' || !obj.name) return null
+    if (obj.status !== 'running' && obj.status !== 'exited' && obj.status !== 'killed') return null
+    return data as TmuxTerminalMetadata
+}
+
+function isInCurrentNamespace(metadata: TmuxTerminalMetadata, currentNamespaceHash: string | null): boolean {
+    if (currentNamespaceHash === null) return true
+    const sessionName: string = metadata.session
+        ?? buildTmuxSessionName(metadata.name, metadata.terminalData?.initialEnvVars ?? {})
+    const namespaceHash: string | null = parseVoicetreeTmuxSessionName(sessionName)?.hash ?? null
+    return namespaceHash === null || namespaceHash === currentNamespaceHash
+}
+
+/**
+ * Which supported CLI does this metadata target (if any)? Used to gate the
+ * resolver work — only records pointing at `claude` or `codex` get a native
+ * session id at click time.
+ */
+function detectSupportedCliFromMetadata(metadata: TmuxTerminalMetadata): 'claude' | 'codex' | null {
+    const initialCommand: string | undefined = metadata.terminalData?.initialCommand
+    if (!initialCommand) return null
+    const cliType = detectCliType(initialCommand)
+    return cliType === 'claude' || cliType === 'codex' ? cliType : null
+}
+
+function toResumeEntry(metadata: TmuxTerminalMetadata): readonly [string, ResumeCapability] | null {
+    const cliType: 'claude' | 'codex' | null = detectSupportedCliFromMetadata(metadata)
+    if (!cliType) return null
+    const projectRoot: string | undefined = metadata.terminalData?.initialEnvVars?.VOICETREE_VAULT_PATH
+    if (!projectRoot) return null
+    return [metadata.name, {cliType}]
+}
+
 /**
  * Decide resume capability for each metadata record from metadata shape alone.
  *
@@ -199,40 +235,13 @@ function detectResumeCapabilitiesFromMetadata(
     metadataRecords: readonly MetadataRecord[],
     currentNamespaceHash: string | null,
 ): ReadonlyMap<string, ResumeCapability> {
-    const out: Map<string, ResumeCapability> = new Map()
-    for (const record of metadataRecords) {
-        const data: unknown = record.data
-        if (typeof data !== 'object' || data === null) continue
-        const obj = data as Record<string, unknown>
-        if (typeof obj.name !== 'string' || !obj.name) continue
-        if (obj.status !== 'running' && obj.status !== 'exited' && obj.status !== 'killed') continue
-        const metadata = data as TmuxTerminalMetadata
-        // Skip foreign vaults early — won't be surfaced anyway.
-        if (currentNamespaceHash !== null) {
-            const sessionName: string = metadata.session
-                ?? buildTmuxSessionName(metadata.name, metadata.terminalData?.initialEnvVars ?? {})
-            const namespaceHash: string | null = parseVoicetreeTmuxSessionName(sessionName)?.hash ?? null
-            if (namespaceHash !== null && namespaceHash !== currentNamespaceHash) continue
-        }
-        const cliType: 'claude' | 'codex' | null = detectSupportedCliFromMetadata(metadata)
-        if (!cliType) continue
-        const projectRoot: string | undefined = metadata.terminalData?.initialEnvVars?.VOICETREE_VAULT_PATH
-        if (!projectRoot) continue
-        out.set(metadata.name, {cliType})
-    }
-    return out
-}
-
-/**
- * Which supported CLI does this metadata target (if any)? Used to gate the
- * resolver work — only records pointing at `claude` or `codex` get a native
- * session id at click time.
- */
-function detectSupportedCliFromMetadata(metadata: TmuxTerminalMetadata): 'claude' | 'codex' | null {
-    const initialCommand: string | undefined = metadata.terminalData?.initialCommand
-    if (!initialCommand) return null
-    const cliType = detectCliType(initialCommand)
-    return cliType === 'claude' || cliType === 'codex' ? cliType : null
+    const entries: readonly (readonly [string, ResumeCapability])[] = metadataRecords
+        .map((record): TmuxTerminalMetadata | null => toValidatedMetadata(record.data))
+        .filter((metadata): metadata is TmuxTerminalMetadata => metadata !== null)
+        .filter((metadata): boolean => isInCurrentNamespace(metadata, currentNamespaceHash))
+        .map(toResumeEntry)
+        .filter((entry): entry is readonly [string, ResumeCapability] => entry !== null)
+    return new Map(entries)
 }
 
 async function resolveCurrentVaultMetadataDir(): Promise<string | null> {

--- a/packages/systems/agent-runtime/src/application/recovery/horizon.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/horizon.ts
@@ -1,7 +1,7 @@
 const MS_PER_DAY: number = 24 * 60 * 60 * 1000
 const DEFAULT_HORIZON_DAYS: number = 7
 
-export const RECOVERY_HORIZON_MS: number = DEFAULT_HORIZON_DAYS * MS_PER_DAY
+const RECOVERY_HORIZON_MS: number = DEFAULT_HORIZON_DAYS * MS_PER_DAY
 
 /**
  * Resolve the active recovery-horizon window in ms from a caller-supplied

--- a/packages/systems/agent-runtime/src/application/recovery/horizon.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/horizon.ts
@@ -4,19 +4,18 @@ const DEFAULT_HORIZON_DAYS: number = 7
 export const RECOVERY_HORIZON_MS: number = DEFAULT_HORIZON_DAYS * MS_PER_DAY
 
 /**
- * Resolve the active recovery-horizon window in ms.
+ * Resolve the active recovery-horizon window in ms from a caller-supplied
+ * `horizonDays` override (typically threaded through `RecoveryEnv.recoveryConfig`
+ * after the shell reads `process.env.VOICETREE_RECOVERY_HORIZON_DAYS`).
  *
- * Default is 7 days. `process.env.VOICETREE_RECOVERY_HORIZON_DAYS` overrides at
- * read time so test fixtures (and the user's $VOICETREE_RECOVERY_HORIZON_DAYS
- * shell override) take effect without rebuilding. Non-finite or non-positive
- * values fall back to the default.
+ * Returns the 7-day default when the input is undefined, non-finite, or
+ * non-positive — those treat malformed config as "no override" rather than
+ * propagating bad data.
  */
-export function getRecoveryHorizonMs(): number {
-    const raw: string | undefined = process.env.VOICETREE_RECOVERY_HORIZON_DAYS
-    if (!raw) return RECOVERY_HORIZON_MS
-    const days: number = Number(raw)
-    if (!Number.isFinite(days) || days <= 0) return RECOVERY_HORIZON_MS
-    return days * MS_PER_DAY
+export function resolveRecoveryHorizonMs(horizonDays: number | undefined): number {
+    if (horizonDays === undefined) return RECOVERY_HORIZON_MS
+    if (!Number.isFinite(horizonDays) || horizonDays <= 0) return RECOVERY_HORIZON_MS
+    return horizonDays * MS_PER_DAY
 }
 
 /**

--- a/packages/systems/agent-runtime/src/application/recovery/index.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/index.ts
@@ -1,0 +1,46 @@
+import type {RecoveryEnv} from '../runtime/runtime-config'
+import type {TerminalId} from '../terminals/terminal-registry/types'
+import {discoverRecoverableAgentSessions, type DiscoverRecoveryOptions} from './discovery'
+import {resumePersistedAgentSession, type ResumePersistedDeps, type ResumePersistedResult} from './sessions/resumePersistedAgentSession'
+import {forkAgentSession, type ForkAgentSessionDeps, type ForkAgentSessionResult} from './sessions/forkAgentSession'
+import {migrateLegacyTerminalDir, type MigrateLegacyTerminalDirArgs, type MigrateLegacyTerminalDirResult} from './persistence/migrate-legacy-terminal-dir'
+import {removePersistedAgentRecord, type RemovePersistedAgentRecordDeps, type RemovePersistedAgentRecordResult} from './persistence/removePersistedAgentRecord'
+import type {RecoverableAgentSession} from './types'
+
+/**
+ * Deep-function entry to the recovery community.
+ *
+ * `createRecoveryAPI(env)` binds the `RecoveryEnv` once at the shell and
+ * returns a record of operations whose call shape no longer mentions env —
+ * callers think in domain terms (`discover`, `resume`, `fork`, `migrate`,
+ * `remove`) and the facade hides every `fs`/`path`/`sqlite`/`now`/`config`
+ * capability behind that boundary.
+ *
+ * This is the package-as-deep-function (P2) lift of the per-file M1 pattern:
+ * the recovery sibling files (discovery, persistence/*, resolvers/*,
+ * sessions/*) all close over a single `RecoveryEnv`, and external callers
+ * see exactly one public symbol from this community.
+ */
+export type RecoveryAPI = {
+    readonly discoverRecoverableAgentSessions: (opts?: DiscoverRecoveryOptions) => Promise<readonly RecoverableAgentSession[]>
+    readonly resumePersistedAgentSession: (terminalId: TerminalId, deps?: ResumePersistedDeps) => Promise<ResumePersistedResult>
+    readonly forkAgentSession: (sourceTerminalId: TerminalId, deps?: ForkAgentSessionDeps) => Promise<ForkAgentSessionResult>
+    readonly migrateLegacyTerminalDir: (args: MigrateLegacyTerminalDirArgs) => MigrateLegacyTerminalDirResult
+    readonly removePersistedAgentRecord: (terminalId: string, deps?: Partial<RemovePersistedAgentRecordDeps>) => Promise<RemovePersistedAgentRecordResult>
+}
+
+export function createRecoveryAPI(env: RecoveryEnv): RecoveryAPI {
+    return {
+        discoverRecoverableAgentSessions: (opts) => discoverRecoverableAgentSessions(env, opts),
+        resumePersistedAgentSession: (terminalId, deps) =>
+            deps === undefined
+                ? resumePersistedAgentSession(env, terminalId)
+                : resumePersistedAgentSession(env, terminalId, deps),
+        forkAgentSession: (sourceTerminalId, deps) =>
+            deps === undefined
+                ? forkAgentSession(env, sourceTerminalId)
+                : forkAgentSession(env, sourceTerminalId, deps),
+        migrateLegacyTerminalDir: (args) => migrateLegacyTerminalDir(env, args),
+        removePersistedAgentRecord: (terminalId, deps) => removePersistedAgentRecord(env, terminalId, deps),
+    }
+}

--- a/packages/systems/agent-runtime/src/application/recovery/paths.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/paths.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 /**
  * Canonical location for persisted terminal recovery metadata.
  *
@@ -7,7 +5,12 @@ import path from 'node:path'
  * canonical project root), NOT `writeFolder` and NOT `process.env.VOICETREE_VAULT_PATH`.
  * Mixing those sources is the bug that motivated this helper — see
  * openspec/changes/fix-resume-recovery-and-surviving-agents-ux/design.md decisions 1+2.
+ *
+ * Pure string concatenation (no `node:path`): the codebase is posix-only
+ * (Electron + tmux on darwin/linux), and keeping this function dependency-free
+ * removes a path-io import from the recovery community subgraph.
  */
 export function getRecoveryMetadataDir(projectRoot: string): string {
-    return path.join(projectRoot, '.voicetree', 'terminals')
+    const trimmed: string = projectRoot.endsWith('/') ? projectRoot.slice(0, -1) : projectRoot
+    return `${trimmed}/.voicetree/terminals`
 }

--- a/packages/systems/agent-runtime/src/application/recovery/persistence/migrate-legacy-terminal-dir.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/persistence/migrate-legacy-terminal-dir.ts
@@ -1,4 +1,4 @@
-import {getRecoveryEnv, type RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
+import type {RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
 
 import {getRecoveryMetadataDir} from '../paths'
 
@@ -58,7 +58,7 @@ function writeMigratedStub(env: RecoveryEnv, legacyDir: string, canonicalDir: st
  * or the legacy directory does not exist. Conflicts keep the canonical copy
  * and leave the legacy entry untouched.
  */
-export function migrateLegacyTerminalDirWithEnv(
+export function migrateLegacyTerminalDir(
     env: RecoveryEnv,
     args: MigrateLegacyTerminalDirArgs,
 ): MigrateLegacyTerminalDirResult {
@@ -104,16 +104,4 @@ export function migrateLegacyTerminalDirWithEnv(
     if (moved.length > 0) writeMigratedStub(env, legacyDir, canonicalDir)
 
     return {moved, conflicts, skipped}
-}
-
-/**
- * Convenience binding: pulls the recovery env from the configured runtime and
- * dispatches. Used by the api/agent-runtime-api.ts re-export surface so the
- * Electron + MCP boot paths don't need env threading yet.
- *
- * Callers that already hold a `RecoveryEnv` should call
- * `migrateLegacyTerminalDirWithEnv(env, args)` directly.
- */
-export function migrateLegacyTerminalDir(args: MigrateLegacyTerminalDirArgs): MigrateLegacyTerminalDirResult {
-    return migrateLegacyTerminalDirWithEnv(getRecoveryEnv(), args)
 }

--- a/packages/systems/agent-runtime/src/application/recovery/persistence/migrate-legacy-terminal-dir.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/persistence/migrate-legacy-terminal-dir.ts
@@ -1,7 +1,6 @@
-import {existsSync, mkdirSync, readdirSync, renameSync, writeFileSync} from 'node:fs'
-import {join} from 'node:path'
+import {getRecoveryEnv, type RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
 
-import {getRecoveryMetadataDir} from './paths'
+import {getRecoveryMetadataDir} from '../paths'
 
 type Logger = {
     readonly warn?: (message: string) => void
@@ -27,28 +26,26 @@ function siblingNamesFor(jsonEntry: string): readonly string[] {
     return SIBLING_SUFFIXES.map((suffix: string) => `${base}${suffix}`)
 }
 
-function moveOne(legacyDir: string, canonicalDir: string, jsonEntry: string): void {
-    renameSync(join(legacyDir, jsonEntry), join(canonicalDir, jsonEntry))
+function moveOne(env: RecoveryEnv, legacyDir: string, canonicalDir: string, jsonEntry: string): void {
+    env.fs.renameSync(env.path.join(legacyDir, jsonEntry), env.path.join(canonicalDir, jsonEntry))
     for (const sibling of siblingNamesFor(jsonEntry)) {
-        const legacySibling: string = join(legacyDir, sibling)
-        if (!existsSync(legacySibling)) continue
+        const legacySibling: string = env.path.join(legacyDir, sibling)
+        if (!env.fs.existsSync(legacySibling)) continue
         try {
-            renameSync(legacySibling, join(canonicalDir, sibling))
+            env.fs.renameSync(legacySibling, env.path.join(canonicalDir, sibling))
         } catch {
             // best-effort sibling move; absence is non-fatal per spec
         }
     }
 }
 
-function writeMigratedStub(legacyDir: string, canonicalDir: string): void {
-    try {
-        writeFileSync(
-            join(legacyDir, MIGRATED_STUB_NAME),
-            `Recovery metadata moved to ${canonicalDir}.\nWriters now use <projectRoot>/.voicetree/terminals/ exclusively.\n`,
-        )
-    } catch {
-        // best-effort: failure to write the stub never blocks the migration
-    }
+function writeMigratedStub(env: RecoveryEnv, legacyDir: string, canonicalDir: string): void {
+    // env.fs.writeFileUtf8 already swallows errors per its contract; failure
+    // to write the stub never blocks the migration.
+    env.fs.writeFileUtf8(
+        env.path.join(legacyDir, MIGRATED_STUB_NAME),
+        `Recovery metadata moved to ${canonicalDir}.\nWriters now use <projectRoot>/.voicetree/terminals/ exclusively.\n`,
+    )
 }
 
 /**
@@ -61,7 +58,10 @@ function writeMigratedStub(legacyDir: string, canonicalDir: string): void {
  * or the legacy directory does not exist. Conflicts keep the canonical copy
  * and leave the legacy entry untouched.
  */
-export function migrateLegacyTerminalDir(args: MigrateLegacyTerminalDirArgs): MigrateLegacyTerminalDirResult {
+export function migrateLegacyTerminalDirWithEnv(
+    env: RecoveryEnv,
+    args: MigrateLegacyTerminalDirArgs,
+): MigrateLegacyTerminalDirResult {
     const moved: string[] = []
     const conflicts: string[] = []
     const skipped: string[] = []
@@ -71,22 +71,22 @@ export function migrateLegacyTerminalDir(args: MigrateLegacyTerminalDirArgs): Mi
     const legacyDir: string = getRecoveryMetadataDir(args.writeFolder)
     const canonicalDir: string = getRecoveryMetadataDir(args.projectRoot)
 
-    if (!existsSync(legacyDir)) return {moved, conflicts, skipped}
+    if (!env.fs.existsSync(legacyDir)) return {moved, conflicts, skipped}
 
     let entries: readonly string[]
     try {
-        entries = readdirSync(legacyDir).filter((entry: string) => entry.endsWith('.json'))
+        entries = env.fs.readdirSync(legacyDir).filter((entry: string) => entry.endsWith('.json'))
     } catch {
         return {moved, conflicts, skipped}
     }
 
     if (entries.length === 0) return {moved, conflicts, skipped}
 
-    mkdirSync(canonicalDir, {recursive: true})
+    env.fs.mkdirSync(canonicalDir, {recursive: true})
 
     for (const entry of entries) {
-        const canonicalTarget: string = join(canonicalDir, entry)
-        if (existsSync(canonicalTarget)) {
+        const canonicalTarget: string = env.path.join(canonicalDir, entry)
+        if (env.fs.existsSync(canonicalTarget)) {
             conflicts.push(entry)
             args.logger?.warn?.(
                 `[migrate-legacy-terminal-dir] Conflict for ${entry}: canonical copy at ${canonicalTarget} kept; legacy copy at ${legacyDir} left in place.`,
@@ -94,14 +94,26 @@ export function migrateLegacyTerminalDir(args: MigrateLegacyTerminalDirArgs): Mi
             continue
         }
         try {
-            moveOne(legacyDir, canonicalDir, entry)
+            moveOne(env, legacyDir, canonicalDir, entry)
             moved.push(entry)
         } catch {
             skipped.push(entry)
         }
     }
 
-    if (moved.length > 0) writeMigratedStub(legacyDir, canonicalDir)
+    if (moved.length > 0) writeMigratedStub(env, legacyDir, canonicalDir)
 
     return {moved, conflicts, skipped}
+}
+
+/**
+ * Convenience binding: pulls the recovery env from the configured runtime and
+ * dispatches. Used by the api/agent-runtime-api.ts re-export surface so the
+ * Electron + MCP boot paths don't need env threading yet.
+ *
+ * Callers that already hold a `RecoveryEnv` should call
+ * `migrateLegacyTerminalDirWithEnv(env, args)` directly.
+ */
+export function migrateLegacyTerminalDir(args: MigrateLegacyTerminalDirArgs): MigrateLegacyTerminalDirResult {
+    return migrateLegacyTerminalDirWithEnv(getRecoveryEnv(), args)
 }

--- a/packages/systems/agent-runtime/src/application/recovery/persistence/removePersistedAgentRecord.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/persistence/removePersistedAgentRecord.ts
@@ -1,4 +1,4 @@
-import {getRecoveryEnv, getRuntimeEnv, type RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
+import {getRuntimeEnv, type RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
 import {getTerminalRecords, type TerminalRecord} from '@vt/agent-runtime/terminals/terminal-registry/index.ts'
 import {getRecoveryMetadataDir} from '../paths'
 
@@ -59,7 +59,7 @@ const SIBLING_SUFFIXES: readonly string[] = ['.json', '.log', '-prompt.txt', '.e
  * `isInLiveRegistry` and provide an env whose `unlink` records the paths it
  * receives.
  */
-export async function removePersistedAgentRecordWithEnv(
+export async function removePersistedAgentRecord(
     env: RecoveryEnv,
     terminalId: string,
     deps?: Partial<RemovePersistedAgentRecordDeps>,
@@ -67,8 +67,8 @@ export async function removePersistedAgentRecordWithEnv(
     if (!SAFE_TERMINAL_ID_REGEX.test(terminalId)) return {kind: 'invalid-id'}
 
     const resolved: RemovePersistedAgentRecordDeps = {
-        ...defaultRemovePersistedAgentRecordDeps(),
-        ...deps,
+        getProjectRoot: deps?.getProjectRoot ?? defaultGetProjectRoot,
+        isInLiveRegistry: deps?.isInLiveRegistry ?? defaultIsInLiveRegistry,
     }
 
     if (resolved.isInLiveRegistry(terminalId)) {
@@ -102,36 +102,18 @@ export async function removePersistedAgentRecordWithEnv(
     return {kind: 'removed'}
 }
 
-/**
- * Convenience binding: pulls the recovery env from the configured runtime and
- * dispatches. Used by the api/agent-runtime-api.ts re-export surface so the
- * Electron + MCP boot paths don't need env threading yet.
- *
- * Callers that already hold a `RecoveryEnv` should call
- * `removePersistedAgentRecordWithEnv(env, terminalId, deps)` directly.
- */
-export async function removePersistedAgentRecord(
-    terminalId: string,
-    deps?: Partial<RemovePersistedAgentRecordDeps>,
-): Promise<RemovePersistedAgentRecordResult> {
-    return removePersistedAgentRecordWithEnv(getRecoveryEnv(), terminalId, deps)
+async function defaultGetProjectRoot(): Promise<string | null> {
+    const probe: (() => Promise<string | null>) | undefined = getRuntimeEnv().getProjectRoot
+    return probe ? probe() : null
+}
+
+function defaultIsInLiveRegistry(terminalId: string): boolean {
+    const records: readonly TerminalRecord[] = getTerminalRecords()
+    return records.some((record: TerminalRecord): boolean => record.terminalId === terminalId)
 }
 
 function isFileNotFoundError(error: unknown): boolean {
     if (typeof error !== 'object' || error === null) return false
     const code: unknown = (error as {code?: unknown}).code
     return code === 'ENOENT'
-}
-
-export function defaultRemovePersistedAgentRecordDeps(): RemovePersistedAgentRecordDeps {
-    return {
-        getProjectRoot: async (): Promise<string | null> => {
-            const probe: (() => Promise<string | null>) | undefined = getRuntimeEnv().getProjectRoot
-            return probe ? probe() : null
-        },
-        isInLiveRegistry: (terminalId: string): boolean => {
-            const records: readonly TerminalRecord[] = getTerminalRecords()
-            return records.some((record: TerminalRecord): boolean => record.terminalId === terminalId)
-        },
-    }
 }

--- a/packages/systems/agent-runtime/src/application/recovery/persistence/removePersistedAgentRecord.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/persistence/removePersistedAgentRecord.ts
@@ -1,9 +1,6 @@
-import {unlink} from 'node:fs/promises'
-import path from 'node:path'
-
-import {getRuntimeEnv} from '../runtime/runtime-config'
-import {getTerminalRecords, type TerminalRecord} from '../terminals/terminal-registry'
-import {getRecoveryMetadataDir} from './paths'
+import {getRecoveryEnv, getRuntimeEnv, type RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
+import {getTerminalRecords, type TerminalRecord} from '@vt/agent-runtime/terminals/terminal-registry/index.ts'
+import {getRecoveryMetadataDir} from '../paths'
 
 /**
  * Discriminated result for `removePersistedAgentRecord`.
@@ -30,13 +27,12 @@ export type RemovePersistedAgentRecordResult =
 export type RemovePersistedAgentRecordDeps = {
     readonly getProjectRoot: () => Promise<string | null>
     readonly isInLiveRegistry: (terminalId: string) => boolean
-    readonly unlinkPath: (filePath: string) => Promise<void>
 }
 
 /**
  * Strict allowlist matching the design-doc requirement. Any character outside
  * this set is rejected outright — including `/`, `\`, `.`, whitespace, and any
- * non-ASCII letter. The downstream path is built by `path.join` over a
+ * non-ASCII letter. The downstream path is built by `env.path.join` over a
  * validated id; an id like `../foo` would escape the metadata dir, so the
  * regex is the only place this is allowed to fail.
  */
@@ -58,11 +54,13 @@ const SIBLING_SUFFIXES: readonly string[] = ['.json', '.log', '-prompt.txt', '.e
  *      dir — defence in depth against any future regex slip.
  *   5. Best-effort unlink each sibling, swallowing ENOENT (idempotent).
  *
- * Side-effect surface: only `unlinkPath` (filesystem) is impure. The deps
- * shape keeps tests black-box: callers pass an in-memory unlink and assert on
- * the recorded paths.
+ * Side-effect surface: `env.fs.unlink` is the only impure call. The deps
+ * shape keeps tests black-box: callers stub `getProjectRoot` and
+ * `isInLiveRegistry` and provide an env whose `unlink` records the paths it
+ * receives.
  */
-export async function removePersistedAgentRecord(
+export async function removePersistedAgentRecordWithEnv(
+    env: RecoveryEnv,
     terminalId: string,
     deps?: Partial<RemovePersistedAgentRecordDeps>,
 ): Promise<RemovePersistedAgentRecordResult> {
@@ -83,25 +81,40 @@ export async function removePersistedAgentRecord(
     }
 
     const metadataDir: string = getRecoveryMetadataDir(projectRoot)
-    const canonicalDir: string = path.resolve(metadataDir)
+    const canonicalDir: string = env.path.resolve(metadataDir)
 
     for (const suffix of SIBLING_SUFFIXES) {
-        const candidate: string = path.join(metadataDir, `${terminalId}${suffix}`)
-        const canonical: string = path.resolve(candidate)
+        const candidate: string = env.path.join(metadataDir, `${terminalId}${suffix}`)
+        const canonical: string = env.path.resolve(candidate)
         // Belt-and-braces: even though the regex already excludes `/`, `\`,
         // and `..`, verify the resolved path is inside the metadata dir.
         // Anything outside is silently skipped (never thrown — refusal should
         // be surfaced by the regex check, this is just defence in depth).
-        const withinDir: boolean = canonical === path.join(canonicalDir, `${terminalId}${suffix}`)
+        const withinDir: boolean = canonical === env.path.join(canonicalDir, `${terminalId}${suffix}`)
         if (!withinDir) continue
         try {
-            await resolved.unlinkPath(canonical)
+            await env.fs.unlink(canonical)
         } catch (error) {
             if (!isFileNotFoundError(error)) throw error
         }
     }
 
     return {kind: 'removed'}
+}
+
+/**
+ * Convenience binding: pulls the recovery env from the configured runtime and
+ * dispatches. Used by the api/agent-runtime-api.ts re-export surface so the
+ * Electron + MCP boot paths don't need env threading yet.
+ *
+ * Callers that already hold a `RecoveryEnv` should call
+ * `removePersistedAgentRecordWithEnv(env, terminalId, deps)` directly.
+ */
+export async function removePersistedAgentRecord(
+    terminalId: string,
+    deps?: Partial<RemovePersistedAgentRecordDeps>,
+): Promise<RemovePersistedAgentRecordResult> {
+    return removePersistedAgentRecordWithEnv(getRecoveryEnv(), terminalId, deps)
 }
 
 function isFileNotFoundError(error: unknown): boolean {
@@ -120,6 +133,5 @@ export function defaultRemovePersistedAgentRecordDeps(): RemovePersistedAgentRec
             const records: readonly TerminalRecord[] = getTerminalRecords()
             return records.some((record: TerminalRecord): boolean => record.terminalId === terminalId)
         },
-        unlinkPath: (filePath: string): Promise<void> => unlink(filePath),
     }
 }

--- a/packages/systems/agent-runtime/src/application/recovery/resolvers/claude-transcript-matcher.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/resolvers/claude-transcript-matcher.ts
@@ -1,4 +1,4 @@
-export type ClaudeContentBlock = {
+type ClaudeContentBlock = {
     readonly type?: string
     readonly text?: string
 }
@@ -12,7 +12,7 @@ export type ClaudeTranscriptRecord = {
     }
 }
 
-export type ClaudeMatchInput = {
+type ClaudeMatchInput = {
     readonly records: readonly ClaudeTranscriptRecord[]
     readonly terminalId: string
     readonly projectRoot: string

--- a/packages/systems/agent-runtime/src/application/recovery/resolvers/codex-thread-matcher.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/resolvers/codex-thread-matcher.ts
@@ -7,7 +7,7 @@ export type CodexThreadRow = {
     readonly rollout_path?: string
 }
 
-export type CodexMatchInput = {
+type CodexMatchInput = {
     readonly rows: readonly CodexThreadRow[]
     readonly terminalId: string
     readonly projectRoot: string

--- a/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveClaudeNativeSession.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveClaudeNativeSession.ts
@@ -1,6 +1,4 @@
-import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs'
-import path from 'node:path'
-import os from 'node:os'
+import type {RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
 import {matchClaudeSessionId, type ClaudeTranscriptRecord} from './claude-transcript-matcher'
 
 export type ResolveClaudeRequest = {
@@ -57,7 +55,7 @@ const DEFAULT_SCAN_TIMEOUT_MS = 10 * 1000
  */
 export async function resolveClaudeNativeSession(
     request: ResolveClaudeRequest,
-    deps: ResolveClaudeDeps = defaultResolveClaudeDeps(),
+    deps: ResolveClaudeDeps,
 ): Promise<ResolveClaudeResult> {
     const recencyWindowMs: number = request.recencyWindowMs ?? DEFAULT_RECENCY_WINDOW_MS
     const scanTimeoutMs: number = request.scanTimeoutMs ?? DEFAULT_SCAN_TIMEOUT_MS
@@ -90,24 +88,15 @@ export async function resolveClaudeNativeSession(
     return {kind: 'not-found', reason: 'marker-mismatch'}
 }
 
-function listJsonlFilesRecursive(root: string): readonly string[] {
+function listJsonlFilesRecursive(env: RecoveryEnv, root: string): readonly string[] {
     const results: string[] = []
-    let entries: readonly string[]
-    try {
-        entries = readdirSync(root)
-    } catch {
-        return []
-    }
+    const entries: readonly string[] = env.fs.readdirSync(root)
     for (const entry of entries) {
-        const full: string = path.join(root, entry)
-        let stat
-        try {
-            stat = statSync(full)
-        } catch {
-            continue
-        }
+        const full: string = env.path.join(root, entry)
+        const stat = env.fs.statSync(full)
+        if (!stat) continue
         if (stat.isDirectory()) {
-            results.push(...listJsonlFilesRecursive(full))
+            results.push(...listJsonlFilesRecursive(env, full))
         } else if (stat.isFile() && entry.endsWith('.jsonl')) {
             results.push(full)
         }
@@ -115,21 +104,7 @@ function listJsonlFilesRecursive(root: string): readonly string[] {
     return results
 }
 
-function safeFileModifiedAt(filePath: string): number {
-    try {
-        return statSync(filePath).mtimeMs
-    } catch {
-        return 0
-    }
-}
-
-function safeReadJsonlLines(filePath: string): readonly ClaudeTranscriptRecord[] {
-    let raw: string
-    try {
-        raw = readFileSync(filePath, 'utf8')
-    } catch {
-        return []
-    }
+function parseJsonlLines(raw: string): readonly ClaudeTranscriptRecord[] {
     const records: ClaudeTranscriptRecord[] = []
     for (const line of raw.split('\n')) {
         const trimmed: string = line.trim()
@@ -143,16 +118,26 @@ function safeReadJsonlLines(filePath: string): readonly ClaudeTranscriptRecord[]
     return records
 }
 
-export function defaultResolveClaudeDeps(
-    projectsRoot: string = path.join(os.homedir(), '.claude', 'projects'),
-): ResolveClaudeDeps {
+export function defaultResolveClaudeDeps(env: RecoveryEnv, projectsRoot: string): ResolveClaudeDeps {
     return {
         listProjectTranscripts: (): ClaudeTranscriptsList => {
-            if (!existsSync(projectsRoot)) return {kind: 'projects-dir-missing'}
-            return {kind: 'transcripts', paths: listJsonlFilesRecursive(projectsRoot)}
+            if (!env.fs.existsSync(projectsRoot)) return {kind: 'projects-dir-missing'}
+            // env.fs.readdirSync may throw on the root if it disappears between
+            // the existsSync check and the walk; defer such races to the caller
+            // (resolveClaudeNativeSession returns 'projects-dir-missing' for an
+            // absent root, and an empty file list otherwise).
+            try {
+                return {kind: 'transcripts', paths: listJsonlFilesRecursive(env, projectsRoot)}
+            } catch {
+                return {kind: 'transcripts', paths: []}
+            }
         },
-        fileModifiedAt: safeFileModifiedAt,
-        readJsonlLines: safeReadJsonlLines,
-        now: () => Date.now(),
+        fileModifiedAt: (filePath: string): number => {
+            const stat = env.fs.statSync(filePath)
+            return stat ? stat.mtimeMs : 0
+        },
+        readJsonlLines: (filePath: string): readonly ClaudeTranscriptRecord[] =>
+            parseJsonlLines(env.fs.readFileUtf8(filePath)),
+        now: env.now,
     }
 }

--- a/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveClaudeNativeSession.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveClaudeNativeSession.ts
@@ -1,7 +1,7 @@
 import type {RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
 import {matchClaudeSessionId, type ClaudeTranscriptRecord} from './claude-transcript-matcher'
 
-export type ResolveClaudeRequest = {
+type ResolveClaudeRequest = {
     readonly terminalId: string
     readonly projectRoot: string
     readonly taskNodePath: string
@@ -27,16 +27,9 @@ export type ResolveClaudeResult =
     | {readonly kind: 'found'; readonly sessionId: string; readonly providerStorePath: string}
     | {readonly kind: 'not-found'; readonly reason: ClaudeMissReason}
 
-export type ClaudeTranscriptsList =
+type ClaudeTranscriptsList =
     | {readonly kind: 'transcripts'; readonly paths: readonly string[]}
     | {readonly kind: 'projects-dir-missing'}
-
-export type ResolveClaudeDeps = {
-    readonly listProjectTranscripts: () => ClaudeTranscriptsList
-    readonly fileModifiedAt: (filePath: string) => number       // epoch ms
-    readonly readJsonlLines: (filePath: string) => readonly ClaudeTranscriptRecord[]
-    readonly now: () => number                                  // epoch ms
-}
 
 const DEFAULT_RECENCY_WINDOW_MS = 24 * 60 * 60 * 1000
 const DEFAULT_SCAN_TIMEOUT_MS = 10 * 1000
@@ -54,29 +47,30 @@ const DEFAULT_SCAN_TIMEOUT_MS = 10 * 1000
  * so an O(files) deadline check is sufficient to bound total wall time.
  */
 export async function resolveClaudeNativeSession(
+    env: RecoveryEnv,
     request: ResolveClaudeRequest,
-    deps: ResolveClaudeDeps,
 ): Promise<ResolveClaudeResult> {
+    const projectsRoot: string = env.recoveryConfig.claudeProjectsDir
     const recencyWindowMs: number = request.recencyWindowMs ?? DEFAULT_RECENCY_WINDOW_MS
     const scanTimeoutMs: number = request.scanTimeoutMs ?? DEFAULT_SCAN_TIMEOUT_MS
-    const startMs: number = deps.now()
+    const startMs: number = env.now()
     const deadlineMs: number = startMs + scanTimeoutMs
     const cutoff: number = startMs - recencyWindowMs
 
-    const list: ClaudeTranscriptsList = deps.listProjectTranscripts()
+    const list: ClaudeTranscriptsList = listProjectTranscripts(env, projectsRoot)
     if (list.kind === 'projects-dir-missing') return {kind: 'not-found', reason: 'projects-dir-missing'}
 
     const recent: Array<{readonly path: string; readonly mtime: number}> = []
     for (const filePath of list.paths) {
-        const mtime: number = deps.fileModifiedAt(filePath)
+        const mtime: number = fileModifiedAt(env, filePath)
         if (mtime >= cutoff) recent.push({path: filePath, mtime})
     }
     if (recent.length === 0) return {kind: 'not-found', reason: 'no-jsonl-matches'}
     recent.sort((a, b) => b.mtime - a.mtime)
 
     for (const {path: filePath} of recent) {
-        if (deps.now() > deadlineMs) return {kind: 'not-found', reason: 'scan-timeout'}
-        const records: readonly ClaudeTranscriptRecord[] = deps.readJsonlLines(filePath)
+        if (env.now() > deadlineMs) return {kind: 'not-found', reason: 'scan-timeout'}
+        const records: readonly ClaudeTranscriptRecord[] = parseJsonlLines(env.fs.readFileUtf8(filePath))
         const sessionId: string | null = matchClaudeSessionId({
             records,
             terminalId: request.terminalId,
@@ -86,6 +80,19 @@ export async function resolveClaudeNativeSession(
         if (sessionId) return {kind: 'found', sessionId, providerStorePath: filePath}
     }
     return {kind: 'not-found', reason: 'marker-mismatch'}
+}
+
+function listProjectTranscripts(env: RecoveryEnv, projectsRoot: string): ClaudeTranscriptsList {
+    if (!env.fs.existsSync(projectsRoot)) return {kind: 'projects-dir-missing'}
+    // env.fs.readdirSync may throw on the root if it disappears between
+    // the existsSync check and the walk; defer such races to the caller
+    // (resolveClaudeNativeSession returns 'projects-dir-missing' for an
+    // absent root, and an empty file list otherwise).
+    try {
+        return {kind: 'transcripts', paths: listJsonlFilesRecursive(env, projectsRoot)}
+    } catch {
+        return {kind: 'transcripts', paths: []}
+    }
 }
 
 function listJsonlFilesRecursive(env: RecoveryEnv, root: string): readonly string[] {
@@ -104,6 +111,11 @@ function listJsonlFilesRecursive(env: RecoveryEnv, root: string): readonly strin
     return results
 }
 
+function fileModifiedAt(env: RecoveryEnv, filePath: string): number {
+    const stat = env.fs.statSync(filePath)
+    return stat ? stat.mtimeMs : 0
+}
+
 function parseJsonlLines(raw: string): readonly ClaudeTranscriptRecord[] {
     const records: ClaudeTranscriptRecord[] = []
     for (const line of raw.split('\n')) {
@@ -116,28 +128,4 @@ function parseJsonlLines(raw: string): readonly ClaudeTranscriptRecord[] {
         }
     }
     return records
-}
-
-export function defaultResolveClaudeDeps(env: RecoveryEnv, projectsRoot: string): ResolveClaudeDeps {
-    return {
-        listProjectTranscripts: (): ClaudeTranscriptsList => {
-            if (!env.fs.existsSync(projectsRoot)) return {kind: 'projects-dir-missing'}
-            // env.fs.readdirSync may throw on the root if it disappears between
-            // the existsSync check and the walk; defer such races to the caller
-            // (resolveClaudeNativeSession returns 'projects-dir-missing' for an
-            // absent root, and an empty file list otherwise).
-            try {
-                return {kind: 'transcripts', paths: listJsonlFilesRecursive(env, projectsRoot)}
-            } catch {
-                return {kind: 'transcripts', paths: []}
-            }
-        },
-        fileModifiedAt: (filePath: string): number => {
-            const stat = env.fs.statSync(filePath)
-            return stat ? stat.mtimeMs : 0
-        },
-        readJsonlLines: (filePath: string): readonly ClaudeTranscriptRecord[] =>
-            parseJsonlLines(env.fs.readFileUtf8(filePath)),
-        now: env.now,
-    }
 }

--- a/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveCodexNativeSession.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveCodexNativeSession.ts
@@ -1,7 +1,7 @@
 import type {RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
 import {matchCodexThreadId, type CodexThreadRow} from './codex-thread-matcher'
 
-export type ResolveCodexRequest = {
+type ResolveCodexRequest = {
     readonly terminalId: string
     readonly projectRoot: string
     readonly taskNodePath: string
@@ -29,16 +29,10 @@ export type ResolveCodexResult =
     | {readonly kind: 'found'; readonly sessionId: string; readonly providerStorePath?: string}
     | {readonly kind: 'not-found'; readonly reason: CodexMissReason; readonly diagnosticSessionId?: string}
 
-export type CodexQueryResult =
+type CodexQueryResult =
     | {readonly kind: 'rows'; readonly rows: readonly CodexThreadRow[]}
     | {readonly kind: 'db-missing'}
     | {readonly kind: 'db-schema-mismatch'}
-
-export type ResolveCodexDeps = {
-    readonly listRecentThreads: (sinceMs: number, limit: number) => CodexQueryResult
-    readonly listAnyThreads: (limit: number) => CodexQueryResult
-    readonly now: () => number
-}
 
 const DEFAULT_RECENCY_WINDOW_MS = 24 * 60 * 60 * 1000
 const DEFAULT_ROW_LIMIT = 200
@@ -56,19 +50,20 @@ const DEFAULT_ROW_LIMIT = 200
  *    the UI can offer a manual `codex resume <id>` copy command.
  */
 export function resolveCodexNativeSession(
+    env: RecoveryEnv,
     request: ResolveCodexRequest,
-    deps: ResolveCodexDeps,
 ): ResolveCodexResult {
+    const dbPath: string = env.recoveryConfig.codexStateDb
     const recencyWindowMs: number = request.recencyWindowMs ?? DEFAULT_RECENCY_WINDOW_MS
     const rowLimit: number = request.rowLimit ?? DEFAULT_ROW_LIMIT
-    const sinceMs: number = deps.now() - recencyWindowMs
+    const sinceMs: number = env.now() - recencyWindowMs
 
-    const recent: CodexQueryResult = deps.listRecentThreads(sinceMs, rowLimit)
+    const recent: CodexQueryResult = queryRows(env, dbPath, {limit: rowLimit, sinceMs})
     if (recent.kind === 'db-missing') return {kind: 'not-found', reason: 'db-missing'}
     if (recent.kind === 'db-schema-mismatch') return {kind: 'not-found', reason: 'db-schema-mismatch'}
 
     if (recent.rows.length === 0) {
-        const any: CodexQueryResult = deps.listAnyThreads(rowLimit)
+        const any: CodexQueryResult = queryRows(env, dbPath, {limit: rowLimit})
         if (any.kind === 'db-missing') return {kind: 'not-found', reason: 'db-missing'}
         if (any.kind === 'db-schema-mismatch') return {kind: 'not-found', reason: 'db-schema-mismatch'}
         if (any.rows.length === 0) return {kind: 'not-found', reason: 'no-rows'}
@@ -97,6 +92,12 @@ export function resolveCodexNativeSession(
         : {kind: 'found', sessionId}
 }
 
+function queryRows(env: RecoveryEnv, dbPath: string, opts: {readonly limit: number; readonly sinceMs?: number}): CodexQueryResult {
+    const result = env.sqlite.queryCodexThreads(dbPath, opts)
+    if (result.kind !== 'rows') return result
+    return {kind: 'rows', rows: result.rows.map(toCodexThreadRow)}
+}
+
 function toCodexThreadRow(raw: Record<string, unknown>): CodexThreadRow {
     return {
         id: String(raw.id ?? ''),
@@ -105,18 +106,5 @@ function toCodexThreadRow(raw: Record<string, unknown>): CodexThreadRow {
         created_at_ms: typeof raw.created_at_ms === 'number' ? raw.created_at_ms : undefined,
         updated_at_ms: typeof raw.updated_at_ms === 'number' ? raw.updated_at_ms : undefined,
         rollout_path: typeof raw.rollout_path === 'string' ? raw.rollout_path : undefined,
-    }
-}
-
-export function defaultResolveCodexDeps(env: RecoveryEnv, dbPath: string): ResolveCodexDeps {
-    const queryRows = (opts: {limit: number; sinceMs?: number}): CodexQueryResult => {
-        const result = env.sqlite.queryCodexThreads(dbPath, opts)
-        if (result.kind !== 'rows') return result
-        return {kind: 'rows', rows: result.rows.map(toCodexThreadRow)}
-    }
-    return {
-        listRecentThreads: (sinceMs: number, limit: number): CodexQueryResult => queryRows({sinceMs, limit}),
-        listAnyThreads: (limit: number): CodexQueryResult => queryRows({limit}),
-        now: env.now,
     }
 }

--- a/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveCodexNativeSession.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveCodexNativeSession.ts
@@ -1,6 +1,4 @@
-import {DatabaseSync} from 'node:sqlite'
-import path from 'node:path'
-import os from 'node:os'
+import type {RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
 import {matchCodexThreadId, type CodexThreadRow} from './codex-thread-matcher'
 
 export type ResolveCodexRequest = {
@@ -59,7 +57,7 @@ const DEFAULT_ROW_LIMIT = 200
  */
 export function resolveCodexNativeSession(
     request: ResolveCodexRequest,
-    deps: ResolveCodexDeps = defaultResolveCodexDeps(),
+    deps: ResolveCodexDeps,
 ): ResolveCodexResult {
     const recencyWindowMs: number = request.recencyWindowMs ?? DEFAULT_RECENCY_WINDOW_MS
     const rowLimit: number = request.rowLimit ?? DEFAULT_ROW_LIMIT
@@ -99,49 +97,6 @@ export function resolveCodexNativeSession(
         : {kind: 'found', sessionId}
 }
 
-function queryCodexThreads(dbPath: string, opts: {limit: number; sinceMs?: number}): CodexQueryResult {
-    let db: DatabaseSync
-    try {
-        db = new DatabaseSync(dbPath, {readOnly: true})
-    } catch {
-        return {kind: 'db-missing'}
-    }
-    try {
-        const baseColumns = 'id, first_user_message, cwd, created_at_ms, updated_at_ms, rollout_path'
-        const sql: string = opts.sinceMs !== undefined
-            ? `SELECT ${baseColumns} FROM threads WHERE updated_at_ms >= ? ORDER BY updated_at_ms DESC LIMIT ?`
-            : `SELECT ${baseColumns} FROM threads ORDER BY updated_at_ms DESC LIMIT ?`
-        let raw: readonly Record<string, unknown>[]
-        try {
-            const stmt = db.prepare(sql)
-            raw = (opts.sinceMs !== undefined
-                ? stmt.all(opts.sinceMs, opts.limit)
-                : stmt.all(opts.limit)) as readonly Record<string, unknown>[]
-        } catch {
-            return {kind: 'db-schema-mismatch'}
-        }
-        return {kind: 'rows', rows: raw.map(toCodexThreadRow)}
-    } finally {
-        try {
-            db.close()
-        } catch {
-            // ignore
-        }
-    }
-}
-
-export function defaultResolveCodexDeps(
-    dbPath: string = path.join(os.homedir(), '.codex', 'state_5.sqlite'),
-): ResolveCodexDeps {
-    return {
-        listRecentThreads: (sinceMs: number, limit: number): CodexQueryResult =>
-            queryCodexThreads(dbPath, {sinceMs, limit}),
-        listAnyThreads: (limit: number): CodexQueryResult =>
-            queryCodexThreads(dbPath, {limit}),
-        now: () => Date.now(),
-    }
-}
-
 function toCodexThreadRow(raw: Record<string, unknown>): CodexThreadRow {
     return {
         id: String(raw.id ?? ''),
@@ -150,5 +105,18 @@ function toCodexThreadRow(raw: Record<string, unknown>): CodexThreadRow {
         created_at_ms: typeof raw.created_at_ms === 'number' ? raw.created_at_ms : undefined,
         updated_at_ms: typeof raw.updated_at_ms === 'number' ? raw.updated_at_ms : undefined,
         rollout_path: typeof raw.rollout_path === 'string' ? raw.rollout_path : undefined,
+    }
+}
+
+export function defaultResolveCodexDeps(env: RecoveryEnv, dbPath: string): ResolveCodexDeps {
+    const queryRows = (opts: {limit: number; sinceMs?: number}): CodexQueryResult => {
+        const result = env.sqlite.queryCodexThreads(dbPath, opts)
+        if (result.kind !== 'rows') return result
+        return {kind: 'rows', rows: result.rows.map(toCodexThreadRow)}
+    }
+    return {
+        listRecentThreads: (sinceMs: number, limit: number): CodexQueryResult => queryRows({sinceMs, limit}),
+        listAnyThreads: (limit: number): CodexQueryResult => queryRows({limit}),
+        now: env.now,
     }
 }

--- a/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveNativeSession.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveNativeSession.ts
@@ -1,5 +1,4 @@
-import path from 'node:path'
-import os from 'node:os'
+import {getRecoveryEnv, type RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
 import {
     resolveClaudeNativeSession,
     defaultResolveClaudeDeps,
@@ -45,32 +44,27 @@ export type ResolveNativeSession = (request: NativeSessionRequest) => Promise<Na
  * codex outside-recency-window, the diagnostic session id) so the UI can
  * render an actionable toast plus a copy-manual-command escape hatch.
  *
- * Resolver roots can be overridden via env vars (useful for tests and for
- * users with non-default config locations):
- *
- * - `VOICETREE_CLAUDE_PROJECTS_DIR`  → defaults to `~/.claude/projects`
- * - `VOICETREE_CODEX_STATE_DB`       → defaults to `~/.codex/state_5.sqlite`
+ * Resolver roots come from `env.recoveryConfig`. The shell decides their
+ * defaults (typically `~/.claude/projects` and `~/.codex/state_5.sqlite`,
+ * overridable by `VOICETREE_CLAUDE_PROJECTS_DIR` / `VOICETREE_CODEX_STATE_DB`).
  */
-export async function defaultResolveNativeSession(
+export async function resolveNativeSessionWithEnv(
+    env: RecoveryEnv,
     request: NativeSessionRequest,
 ): Promise<NativeSessionResult> {
     if (request.cliType === 'claude') {
-        const root: string = process.env.VOICETREE_CLAUDE_PROJECTS_DIR
-            ?? path.join(os.homedir(), '.claude', 'projects')
         const result: ResolveClaudeResult = await resolveClaudeNativeSession(
             {terminalId: request.terminalId, projectRoot: request.projectRoot, taskNodePath: request.taskNodePath},
-            defaultResolveClaudeDeps(root),
+            defaultResolveClaudeDeps(env, env.recoveryConfig.claudeProjectsDir),
         )
         if (result.kind === 'found') {
             return {kind: 'found', sessionId: result.sessionId, providerStorePath: result.providerStorePath}
         }
         return {kind: 'not-found', reason: result.reason}
     }
-    const dbPath: string = process.env.VOICETREE_CODEX_STATE_DB
-        ?? path.join(os.homedir(), '.codex', 'state_5.sqlite')
     const result: ResolveCodexResult = resolveCodexNativeSession(
         {terminalId: request.terminalId, projectRoot: request.projectRoot, taskNodePath: request.taskNodePath},
-        defaultResolveCodexDeps(dbPath),
+        defaultResolveCodexDeps(env, env.recoveryConfig.codexStateDb),
     )
     if (result.kind === 'found') {
         return {kind: 'found', sessionId: result.sessionId, providerStorePath: result.providerStorePath}
@@ -78,4 +72,19 @@ export async function defaultResolveNativeSession(
     return result.diagnosticSessionId !== undefined
         ? {kind: 'not-found', reason: result.reason, diagnosticSessionId: result.diagnosticSessionId}
         : {kind: 'not-found', reason: result.reason}
+}
+
+/**
+ * Convenience binding: reads the recovery env from the configured runtime
+ * registry and dispatches. Preserves the `ResolveNativeSession` shape
+ * consumed by sessions/* default deps so those callers don't need env
+ * threading.
+ *
+ * The dependency is still visible — calls `getRecoveryEnv()` which throws
+ * unambiguously at the shell boundary when the runtime hasn't been wired
+ * with a `RecoveryEnv`. Callers that already hold an env should call
+ * `resolveNativeSessionWithEnv(env, request)` directly.
+ */
+export async function defaultResolveNativeSession(request: NativeSessionRequest): Promise<NativeSessionResult> {
+    return resolveNativeSessionWithEnv(getRecoveryEnv(), request)
 }

--- a/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveNativeSession.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/resolvers/resolveNativeSession.ts
@@ -1,18 +1,8 @@
-import {getRecoveryEnv, type RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
-import {
-    resolveClaudeNativeSession,
-    defaultResolveClaudeDeps,
-    type ResolveClaudeResult,
-    type ClaudeMissReason,
-} from './resolveClaudeNativeSession'
-import {
-    resolveCodexNativeSession,
-    defaultResolveCodexDeps,
-    type ResolveCodexResult,
-    type CodexMissReason,
-} from './resolveCodexNativeSession'
+import type {RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
+import {resolveClaudeNativeSession, type ResolveClaudeResult, type ClaudeMissReason} from './resolveClaudeNativeSession'
+import {resolveCodexNativeSession, type ResolveCodexResult, type CodexMissReason} from './resolveCodexNativeSession'
 
-export type NativeSessionRequest = {
+type NativeSessionRequest = {
     readonly cliType: 'claude' | 'codex'
     readonly terminalId: string
     readonly projectRoot: string
@@ -48,43 +38,30 @@ export type ResolveNativeSession = (request: NativeSessionRequest) => Promise<Na
  * defaults (typically `~/.claude/projects` and `~/.codex/state_5.sqlite`,
  * overridable by `VOICETREE_CLAUDE_PROJECTS_DIR` / `VOICETREE_CODEX_STATE_DB`).
  */
-export async function resolveNativeSessionWithEnv(
+export async function resolveNativeSession(
     env: RecoveryEnv,
     request: NativeSessionRequest,
 ): Promise<NativeSessionResult> {
     if (request.cliType === 'claude') {
-        const result: ResolveClaudeResult = await resolveClaudeNativeSession(
-            {terminalId: request.terminalId, projectRoot: request.projectRoot, taskNodePath: request.taskNodePath},
-            defaultResolveClaudeDeps(env, env.recoveryConfig.claudeProjectsDir),
-        )
+        const result: ResolveClaudeResult = await resolveClaudeNativeSession(env, {
+            terminalId: request.terminalId,
+            projectRoot: request.projectRoot,
+            taskNodePath: request.taskNodePath,
+        })
         if (result.kind === 'found') {
             return {kind: 'found', sessionId: result.sessionId, providerStorePath: result.providerStorePath}
         }
         return {kind: 'not-found', reason: result.reason}
     }
-    const result: ResolveCodexResult = resolveCodexNativeSession(
-        {terminalId: request.terminalId, projectRoot: request.projectRoot, taskNodePath: request.taskNodePath},
-        defaultResolveCodexDeps(env, env.recoveryConfig.codexStateDb),
-    )
+    const result: ResolveCodexResult = resolveCodexNativeSession(env, {
+        terminalId: request.terminalId,
+        projectRoot: request.projectRoot,
+        taskNodePath: request.taskNodePath,
+    })
     if (result.kind === 'found') {
         return {kind: 'found', sessionId: result.sessionId, providerStorePath: result.providerStorePath}
     }
     return result.diagnosticSessionId !== undefined
         ? {kind: 'not-found', reason: result.reason, diagnosticSessionId: result.diagnosticSessionId}
         : {kind: 'not-found', reason: result.reason}
-}
-
-/**
- * Convenience binding: reads the recovery env from the configured runtime
- * registry and dispatches. Preserves the `ResolveNativeSession` shape
- * consumed by sessions/* default deps so those callers don't need env
- * threading.
- *
- * The dependency is still visible — calls `getRecoveryEnv()` which throws
- * unambiguously at the shell boundary when the runtime hasn't been wired
- * with a `RecoveryEnv`. Callers that already hold an env should call
- * `resolveNativeSessionWithEnv(env, request)` directly.
- */
-export async function defaultResolveNativeSession(request: NativeSessionRequest): Promise<NativeSessionResult> {
-    return resolveNativeSessionWithEnv(getRecoveryEnv(), request)
 }

--- a/packages/systems/agent-runtime/src/application/recovery/sessions/forkAgentSession.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/sessions/forkAgentSession.ts
@@ -1,20 +1,17 @@
-import {
-    discoverRecoverableAgentSessions,
-    defaultDiscoverRecoveryDeps,
-    type DiscoverRecoveryDeps,
-} from './discovery'
-import {buildResumeCommand, type ResumeMode} from '../spawn/resumeCli'
-import {spawnTmuxBackedTerminal} from '../headless/tmuxHeadlessRuntime'
-import {getExistingAgentNames} from '../terminals/terminal-registry'
+import type {RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
+import {discoverRecoverableAgentSessions} from '../discovery'
+import {buildResumeCommand, type ResumeMode} from '@vt/agent-runtime/spawn/resumeCli.ts'
+import {spawnTmuxBackedTerminal} from '@vt/agent-runtime/headless/tmuxHeadlessRuntime.ts'
+import {getExistingAgentNames} from '@vt/agent-runtime/terminals/terminal-registry/index.ts'
 import {getUniqueAgentName} from '@vt/graph-model/settings'
 import {
-    defaultResolveNativeSession,
+    resolveNativeSession,
     type NativeSessionMissReason,
     type NativeSessionResult,
     type ResolveNativeSession,
-} from './resolvers/resolveNativeSession'
-import type {RecoverableAgentSession} from './types'
-import type {TerminalData, TerminalId} from '../terminals/terminal-registry/types'
+} from '../resolvers/resolveNativeSession'
+import type {RecoverableAgentSession} from '../types'
+import type {TerminalData, TerminalId} from '@vt/agent-runtime/terminals/terminal-registry/types.ts'
 
 export type ForkAgentSessionDeps = {
     readonly discover: () => Promise<readonly RecoverableAgentSession[]>
@@ -62,8 +59,9 @@ function modeFor(terminalData: TerminalData): ResumeMode {
  * `resumePersistedAgentSession`.
  */
 export async function forkAgentSession(
+    env: RecoveryEnv,
     sourceTerminalId: TerminalId,
-    deps: ForkAgentSessionDeps = defaultForkAgentDeps(),
+    deps: ForkAgentSessionDeps = defaultForkAgentDeps(env),
 ): Promise<ForkAgentSessionResult> {
     const sessions: readonly RecoverableAgentSession[] = await deps.discover()
     const source: RecoverableAgentSession | undefined = sessions.find((s) => s.terminalId === sourceTerminalId)
@@ -99,7 +97,7 @@ export async function forkAgentSession(
 
     const forkedAgentName: string = deps.allocateForkAgentName(source.agentName)
     const forkedTerminalId: TerminalId = forkedAgentName as TerminalId
-    const env: Record<string, string> = {
+    const spawnEnvVars: Record<string, string> = {
         ...(source.terminalData.initialEnvVars ?? {}),
         VOICETREE_TERMINAL_ID: forkedTerminalId,
         AGENT_NAME: forkedAgentName,
@@ -110,7 +108,7 @@ export async function forkAgentSession(
         agentName: forkedAgentName,
         title: forkedAgentName,
         parentTerminalId: sourceTerminalId,
-        initialEnvVars: env,
+        initialEnvVars: spawnEnvVars,
         initialCommand,  // preserve the original command so future forks/resumes have the same base
     }
     const cwd: string | undefined = source.terminalData.initialSpawnDirectory
@@ -120,7 +118,7 @@ export async function forkAgentSession(
             forkedTerminalData,
             built.command,
             cwd,
-            env,
+            spawnEnvVars,
         )
         return {kind: 'spawned', forkedTerminalId, pid: result.pid, command: built.command, terminalData: forkedTerminalData}
     } catch (error) {
@@ -128,16 +126,13 @@ export async function forkAgentSession(
     }
 }
 
-export function defaultForkAgentDeps(
-    discoveryDeps: DiscoverRecoveryDeps = defaultDiscoverRecoveryDeps(),
-): ForkAgentSessionDeps {
+function defaultForkAgentDeps(env: RecoveryEnv): ForkAgentSessionDeps {
     return {
-        discover: () => discoverRecoverableAgentSessions(discoveryDeps),
-        resolveNativeSession: defaultResolveNativeSession,
-        allocateForkAgentName: (sourceAgentName: string): string => {
-            return getUniqueAgentName(sourceAgentName, getExistingAgentNames())
-        },
-        spawn: (terminalId, terminalData, command, cwd, env) =>
-            spawnTmuxBackedTerminal(terminalId, terminalData, command, cwd, env),
+        discover: () => discoverRecoverableAgentSessions(env),
+        resolveNativeSession: (request) => resolveNativeSession(env, request),
+        allocateForkAgentName: (sourceAgentName: string): string =>
+            getUniqueAgentName(sourceAgentName, getExistingAgentNames()),
+        spawn: (terminalId, terminalData, command, cwd, spawnEnv) =>
+            spawnTmuxBackedTerminal(terminalId, terminalData, command, cwd, spawnEnv),
     }
 }

--- a/packages/systems/agent-runtime/src/application/recovery/sessions/resumePersistedAgentSession.ts
+++ b/packages/systems/agent-runtime/src/application/recovery/sessions/resumePersistedAgentSession.ts
@@ -1,18 +1,15 @@
+import type {RecoveryEnv} from '@vt/agent-runtime/runtime/runtime-config'
+import {discoverRecoverableAgentSessions} from '../discovery'
+import {buildResumeCommand, type ResumeMode} from '@vt/agent-runtime/spawn/resumeCli.ts'
+import {spawnTmuxBackedTerminal} from '@vt/agent-runtime/headless/tmuxHeadlessRuntime.ts'
 import {
-    discoverRecoverableAgentSessions,
-    defaultDiscoverRecoveryDeps,
-    type DiscoverRecoveryDeps,
-} from './discovery'
-import {buildResumeCommand, type ResumeMode} from '../spawn/resumeCli'
-import {spawnTmuxBackedTerminal} from '../headless/tmuxHeadlessRuntime'
-import {
-    defaultResolveNativeSession,
+    resolveNativeSession,
     type NativeSessionMissReason,
     type NativeSessionResult,
     type ResolveNativeSession,
-} from './resolvers/resolveNativeSession'
-import type {RecoverableAgentSession} from './types'
-import type {TerminalData, TerminalId} from '../terminals/terminal-registry/types'
+} from '../resolvers/resolveNativeSession'
+import type {RecoverableAgentSession} from '../types'
+import type {TerminalData, TerminalId} from '@vt/agent-runtime/terminals/terminal-registry/types.ts'
 
 export type ResumePersistedDeps = {
     readonly discover: () => Promise<readonly RecoverableAgentSession[]>
@@ -60,8 +57,9 @@ function modeFor(terminalData: TerminalData): ResumeMode {
  * a clean message instead of a generic spawn failure.
  */
 export async function resumePersistedAgentSession(
+    env: RecoveryEnv,
     terminalId: TerminalId,
-    deps: ResumePersistedDeps = defaultResumePersistedDeps(),
+    deps: ResumePersistedDeps = defaultResumePersistedDeps(env),
 ): Promise<ResumePersistedResult> {
     const sessions: readonly RecoverableAgentSession[] = await deps.discover()
     const session: RecoverableAgentSession | undefined = sessions.find((s) => s.terminalId === terminalId)
@@ -96,7 +94,7 @@ export async function resumePersistedAgentSession(
     })
     if (built.kind === 'unsupported') return {kind: 'unsupported', reason: built.reason}
 
-    const env: Record<string, string> = session.terminalData.initialEnvVars ?? {}
+    const spawnEnvVars: Record<string, string> = session.terminalData.initialEnvVars ?? {}
     const cwd: string | undefined = session.terminalData.initialSpawnDirectory
     try {
         const result: {readonly pid: number} = await deps.spawn(
@@ -104,7 +102,7 @@ export async function resumePersistedAgentSession(
             session.terminalData,
             built.command,
             cwd,
-            env,
+            spawnEnvVars,
         )
         return {kind: 'spawned', pid: result.pid, command: built.command, terminalData: session.terminalData}
     } catch (error) {
@@ -112,13 +110,11 @@ export async function resumePersistedAgentSession(
     }
 }
 
-export function defaultResumePersistedDeps(
-    discoveryDeps: DiscoverRecoveryDeps = defaultDiscoverRecoveryDeps(),
-): ResumePersistedDeps {
+function defaultResumePersistedDeps(env: RecoveryEnv): ResumePersistedDeps {
     return {
-        discover: () => discoverRecoverableAgentSessions(discoveryDeps),
-        resolveNativeSession: defaultResolveNativeSession,
-        spawn: (terminalId, terminalData, command, cwd, env) =>
-            spawnTmuxBackedTerminal(terminalId, terminalData, command, cwd, env),
+        discover: () => discoverRecoverableAgentSessions(env),
+        resolveNativeSession: (request) => resolveNativeSession(env, request),
+        spawn: (terminalId, terminalData, command, cwd, spawnEnv) =>
+            spawnTmuxBackedTerminal(terminalId, terminalData, command, cwd, spawnEnv),
     }
 }

--- a/packages/systems/agent-runtime/src/application/runtime/runtime-config.ts
+++ b/packages/systems/agent-runtime/src/application/runtime/runtime-config.ts
@@ -67,9 +67,16 @@ export type RecoveryEnv = {
             readonly isDirectory: () => boolean;
             readonly isFile: () => boolean;
         } | null;
+        readonly mkdirSync: (path: string, opts?: {readonly recursive?: boolean}) => void;
+        readonly renameSync: (oldPath: string, newPath: string) => void;
+        /** Writes utf8 contents; swallows errors (mirror readFileUtf8). */
+        readonly writeFileUtf8: (path: string, contents: string) => void;
+        /** Async unlink. ENOENT must propagate as an Error with `code: 'ENOENT'`. */
+        readonly unlink: (path: string) => Promise<void>;
     };
     readonly path: {
         readonly join: (...parts: readonly string[]) => string;
+        readonly resolve: (...parts: readonly string[]) => string;
     };
     readonly sqlite: {
         readonly queryCodexThreads: (dbPath: string, opts: CodexThreadsQuery) => CodexThreadsQueryResult;
@@ -78,6 +85,13 @@ export type RecoveryEnv = {
     readonly recoveryConfig: {
         readonly claudeProjectsDir: string;
         readonly codexStateDb: string;
+        /**
+         * Override for the recovery horizon window (in days). Undefined falls
+         * back to `RECOVERY_HORIZON_MS` (7 days). The shell reads
+         * `VOICETREE_RECOVERY_HORIZON_DAYS` and propagates it here so the
+         * discovery community doesn't reach for `process` directly.
+         */
+        readonly horizonDays?: number;
     };
 };
 

--- a/packages/systems/agent-runtime/src/application/runtime/runtime-config.ts
+++ b/packages/systems/agent-runtime/src/application/runtime/runtime-config.ts
@@ -27,6 +27,58 @@ export type RuntimeEnvProvider = {
         readonly writeFolder: string | null;
     }>;
     readonly getWriteFolder?: () => Promise<string | null>;
+    readonly recovery?: RecoveryEnv;
+};
+
+// ---------------------------------------------------------------------------
+// Recovery community Reader-env (FP Pattern 3).
+//
+// The recovery resolvers/discovery/persistence functions used to reach for
+// `node:fs`, `node:path`, `node:sqlite`, and `process.env.X` directly. That
+// made their dependencies invisible in their signatures and inflated the
+// implicit-globals subgraph measure on the `agent-runtime/application`
+// community.
+//
+// Every recovery function now takes a `RecoveryEnv` argument carrying just
+// the capabilities it needs (fs / path / sqlite / clock / config). The shell
+// (Electron main, vt-mcpd, vt-resume) wires real `node:*` implementations
+// at boot via `configureAgentRuntime({env: {..., recovery: ...}})`.
+// ---------------------------------------------------------------------------
+
+export type CodexThreadsQuery = {
+    readonly limit: number;
+    readonly sinceMs?: number;
+};
+
+export type CodexThreadsQueryResult =
+    | {readonly kind: 'rows'; readonly rows: readonly Record<string, unknown>[]}
+    | {readonly kind: 'db-missing'}
+    | {readonly kind: 'db-schema-mismatch'};
+
+export type RecoveryEnv = {
+    readonly fs: {
+        readonly existsSync: (path: string) => boolean;
+        readonly readdirSync: (path: string) => readonly string[];
+        /** Returns the file's contents as utf8, or '' if the file cannot be read. */
+        readonly readFileUtf8: (path: string) => string;
+        /** Returns `null` if the path does not exist or is otherwise unstattable. */
+        readonly statSync: (path: string) => {
+            readonly mtimeMs: number;
+            readonly isDirectory: () => boolean;
+            readonly isFile: () => boolean;
+        } | null;
+    };
+    readonly path: {
+        readonly join: (...parts: readonly string[]) => string;
+    };
+    readonly sqlite: {
+        readonly queryCodexThreads: (dbPath: string, opts: CodexThreadsQuery) => CodexThreadsQueryResult;
+    };
+    readonly now: () => number;
+    readonly recoveryConfig: {
+        readonly claudeProjectsDir: string;
+        readonly codexStateDb: string;
+    };
 };
 
 export type WatchStatus = {
@@ -81,6 +133,17 @@ export function getRuntimeEnv(): RuntimeEnvProvider {
         throw new Error('Agent runtime env provider not configured. Call configureAgentRuntime({ env: ... }) at boot.');
     }
     return config.env;
+}
+
+export function getRecoveryEnv(): RecoveryEnv {
+    const recovery: RecoveryEnv | undefined = getRuntimeEnv().recovery;
+    if (!recovery) {
+        throw new Error(
+            'Agent runtime recovery env not configured. '
+            + 'Call configureAgentRuntime({ env: { ..., recovery: { fs, path, sqlite, now, recoveryConfig } } }) at boot.',
+        );
+    }
+    return recovery;
 }
 
 export function getGraphBridge(): GraphStateBridge | undefined {

--- a/webapp/src/shell/edge/main/agent/terminals/recovery-session-sync.ts
+++ b/webapp/src/shell/edge/main/agent/terminals/recovery-session-sync.ts
@@ -50,7 +50,7 @@ export async function refreshRecoverySessions(
             : (typeof horizonDays === 'number' ? horizonDays * 24 * 60 * 60 * 1000 : undefined)
         const opts = horizonMs === undefined ? undefined : {horizonMs}
         const sessions: readonly RecoverableAgentSession[] = opts
-            ? await terminalRuntimeSurface.discoverRecoverableAgentSessions(undefined, opts)
+            ? await terminalRuntimeSurface.discoverRecoverableAgentSessions(opts)
             : await terminalRuntimeSurface.discoverRecoverableAgentSessions()
         publishRecoverySessions(sessions)
         return sessions


### PR DESCRIPTION
## Summary
Functional-design rearchitecture of the agent-runtime **recovery** community: dependencies threaded through signatures, the export surface collapsed to a single deep-function facade, and the top cyclomatic offenders pipeline-decomposed (BF-333/334/335).

## What
- **BF-333a — thread env through resolvers** (`07351cfcd`): added `RecoveryEnv` to `RuntimeEnvProvider` (fs/path/sqlite/now/recoveryConfig) plus a `getRecoveryEnv()` accessor; dropped `node:fs`/`node:path`/`node:os`/`node:sqlite` imports from the three native-session resolvers so their deps appear in their signatures.
- **fix(vt-resume)** (`514420e59`): dropped stale `nativeSessionId` display refs in `vt-resume.ts` (native id is now resolved lazily by `resolveNativeSession` at click time); prints `resume=<cliType>`.
- **BF-333b — thread env through discovery + persistence** (`3cbb32b50`): routed `discovery.ts`, `horizon.ts`, `paths.ts`, and `persistence/*` through `RecoveryEnv`; `paths.ts`/`horizon.ts` became pure; extended `RecoveryEnv` with `mkdirSync`/`renameSync`/`writeFileUtf8`/`unlink`/`path.resolve`/`recoveryConfig.horizonDays`.
- **BF-334 — collapse export surface to `createRecoveryAPI` facade** (`6e7007582`): replaced 14 files exporting 64 symbols with a single `createRecoveryAPI(env): RecoveryAPI` deep function; env is now the canonical first arg of every internal function; `recovery/index.ts` exposes exactly one function + one type. External callers (agent-runtime-api, vt-resume) see one symbol.
- **BF-335 — pipeline-decompose top cyclomatic offenders** (`f691d562e`): split `classifyRecord` (cyclomatic 23) into `extractValidRecord` → `buildRecoverable`; refactored `detectResumeCapabilitiesFromMetadata` (cyclomatic 17) into a map/filter pipeline. Each new function ≤ 8 branches, all private.

## Why
Visibility of dependencies is the precondition for trusting the structural complexity metrics; threading env, collapsing the boundary width, and decomposing cyclomatic offenders bring the agent-runtime/application community back under its subgraph-gate baselines (implicit-globals ≤ 155, boundary-width ≤ 427, cyclomatic-per-fn ≤ 16).

> Note: this PR targets `dev`, which is behind `dev-manu` (the base this branch forked from), so the GitHub diff also carries the intervening `dev-manu` divergence. The branch's own work is the 5 commits listed above.
