### PR TITLE
fix(graph): stop WebGL atlas GC from blanking still-live node labels

### DIFF
--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/animation/atlasGcFix.test.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/animation/atlasGcFix.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { Core } from 'cytoscape';
+import { correctedAtlasGc, installAtlasGcFix } from './atlasGcFix';
+
+/**
+ * A fake cytoscape WebGL `Atlas`. `canvas === null` models a locked atlas whose
+ * backing canvas was freed after buffering to the GPU (the trigger condition
+ * for the upstream bug). `disposed` records whether the faithful upstream gc
+ * deleted it (and, in the real renderer, its GPU texture).
+ */
+interface FakeAtlas {
+    canvas: object | null;
+    keyToLocation: Map<string, string>; // styleKey -> opaque location marker
+    disposed: boolean;
+}
+
+interface FakeCollection {
+    atlases: FakeAtlas[];
+    styleKeyToAtlas: Map<string, FakeAtlas>;
+    markedKeys: Set<string>;
+    gc: () => void;
+}
+
+function makeAtlas(canvas: object | null, keys: string[]): FakeAtlas {
+    const keyToLocation = new Map<string, string>();
+    for (const k of keys) keyToLocation.set(k, `loc:${k}`);
+    return { canvas, keyToLocation, disposed: false };
+}
+
+function makeCollection(atlases: FakeAtlas[], marked: string[]): FakeCollection {
+    const styleKeyToAtlas = new Map<string, FakeAtlas>();
+    for (const atlas of atlases) {
+        for (const k of atlas.keyToLocation.keys()) styleKeyToAtlas.set(k, atlas);
+    }
+    const collection: FakeCollection = {
+        atlases,
+        styleKeyToAtlas,
+        markedKeys: new Set(marked),
+        gc: () => {},
+    };
+    return collection;
+}
+
+/**
+ * Faithful re-implementation of cytoscape 3.33.4 `AtlasCollection.gc()`,
+ * INCLUDING the bug under test: surviving textures in a canvas-freed atlas are
+ * dropped (not copied, not re-registered) and the atlas is disposed. Used as
+ * the injected `upstreamGc` so the test proves the wrapper neutralizes the real
+ * upstream behavior.
+ */
+function buggyUpstreamGc(collection: FakeCollection): () => void {
+    return function gc(): void {
+        const { markedKeys } = collection;
+        if (markedKeys.size === 0) return;
+
+        const newAtlases: FakeAtlas[] = [];
+        const newStyleKeyToAtlas = new Map<string, FakeAtlas>();
+        let newAtlas: FakeAtlas | null = null;
+
+        for (const atlas of collection.atlases) {
+            const keys = new Set(atlas.keyToLocation.keys());
+            const keysToCollect = new Set([...markedKeys].filter(k => keys.has(k)));
+
+            if (keysToCollect.size === 0) {
+                newAtlases.push(atlas);
+                keys.forEach(k => newStyleKeyToAtlas.set(k, atlas));
+                continue;
+            }
+            if (!newAtlas) {
+                newAtlas = makeAtlas({}, []);
+                newAtlases.push(newAtlas);
+            }
+            for (const key of keys) {
+                if (!keysToCollect.has(key)) {
+                    if (atlas.canvas) {
+                        // repack: copy survivor onto the fresh atlas
+                        newAtlas.keyToLocation.set(key, atlas.keyToLocation.get(key) as string);
+                        newStyleKeyToAtlas.set(key, newAtlas);
+                    }
+                    // else: BUG — survivor of a canvas-freed atlas is silently dropped
+                }
+            }
+            atlas.disposed = true; // dispose() also deletes the GPU texture
+        }
+
+        collection.atlases = newAtlases;
+        collection.styleKeyToAtlas = newStyleKeyToAtlas;
+        collection.markedKeys = new Set();
+    };
+}
+
+function runCorrectedGc(collection: FakeCollection): void {
+    correctedAtlasGc(
+        collection as never,
+        buggyUpstreamGc(collection),
+    );
+}
+
+describe('correctedAtlasGc', () => {
+    test('preserves surviving textures of a canvas-freed atlas (the live bug)', () => {
+        // Mirrors the observed live state: a locked, canvas-freed atlas holding
+        // both changed (marked) and unchanged (surviving) label textures.
+        const frozen = makeAtlas(null, ['a_0', 'a_1', 'a_2', 'b_0', 'b_1']);
+        const collection = makeCollection([frozen], ['a_1']); // only a_1 actually changed
+
+        runCorrectedGc(collection);
+
+        // Every survivor still resolves to a live atlas; only the changed key is gone.
+        for (const key of ['a_0', 'a_2', 'b_0', 'b_1']) {
+            expect(collection.styleKeyToAtlas.has(key)).toBe(true);
+        }
+        expect(collection.styleKeyToAtlas.has('a_1')).toBe(false);
+        // The frozen atlas is kept (not disposed) so its valid GPU textures survive.
+        expect(frozen.disposed).toBe(false);
+        expect(collection.atlases).toContain(frozen);
+        expect(frozen.keyToLocation.has('a_1')).toBe(false);
+    });
+
+    test('without the fix, the faithful upstream gc loses the survivors', () => {
+        // Guards that the test's upstream model actually reproduces the bug,
+        // so the passing test above is meaningful.
+        const frozen = makeAtlas(null, ['a_0', 'a_1', 'a_2', 'b_0', 'b_1']);
+        const collection = makeCollection([frozen], ['a_1']);
+
+        buggyUpstreamGc(collection)();
+
+        for (const key of ['a_0', 'a_2', 'b_0', 'b_1']) {
+            expect(collection.styleKeyToAtlas.has(key)).toBe(false); // lost!
+        }
+    });
+
+    test('still repacks canvas-backed atlases (memory reclamation preserved)', () => {
+        const backed = makeAtlas({}, ['x_0', 'x_1', 'y_0']);
+        const collection = makeCollection([backed], ['x_1']);
+
+        runCorrectedGc(collection);
+
+        // survivors moved to a fresh atlas, old one disposed
+        expect(collection.styleKeyToAtlas.has('x_0')).toBe(true);
+        expect(collection.styleKeyToAtlas.has('y_0')).toBe(true);
+        expect(collection.styleKeyToAtlas.has('x_1')).toBe(false);
+        expect(backed.disposed).toBe(true);
+    });
+
+    test('disposes a fully-garbage canvas-freed atlas (no survivors to keep)', () => {
+        const allGarbage = makeAtlas(null, ['g_0', 'g_1']);
+        const collection = makeCollection([allGarbage], ['g_0', 'g_1']);
+
+        runCorrectedGc(collection);
+
+        expect(collection.styleKeyToAtlas.size).toBe(0);
+        expect(allGarbage.disposed).toBe(true);
+    });
+
+    test('keeps a canvas-freed atlas with no garbage untouched', () => {
+        const allSurvivors = makeAtlas(null, ['s_0', 's_1']);
+        const other = makeAtlas({}, ['o_0']);
+        const collection = makeCollection([allSurvivors, other], ['o_0']);
+
+        runCorrectedGc(collection);
+
+        expect(collection.styleKeyToAtlas.has('s_0')).toBe(true);
+        expect(collection.styleKeyToAtlas.has('s_1')).toBe(true);
+        expect(allSurvivors.disposed).toBe(false);
+    });
+
+    test('mixed atlases: drops only changed keys, keeps everything else live', () => {
+        const frozen = makeAtlas(null, ['f_0', 'f_1', 'f_2']);
+        const backed = makeAtlas({}, ['m_0', 'm_1']);
+        const collection = makeCollection([frozen, backed], ['f_1', 'm_0']);
+
+        runCorrectedGc(collection);
+
+        for (const key of ['f_0', 'f_2', 'm_1']) {
+            expect(collection.styleKeyToAtlas.has(key)).toBe(true);
+        }
+        expect(collection.styleKeyToAtlas.has('f_1')).toBe(false);
+        expect(collection.styleKeyToAtlas.has('m_0')).toBe(false);
+        expect(frozen.disposed).toBe(false);
+        expect(backed.disposed).toBe(true);
+    });
+
+    test('no-op when nothing is marked for collection', () => {
+        const frozen = makeAtlas(null, ['k_0', 'k_1']);
+        const collection = makeCollection([frozen], []);
+
+        runCorrectedGc(collection);
+
+        expect(collection.styleKeyToAtlas.has('k_0')).toBe(true);
+        expect(collection.styleKeyToAtlas.has('k_1')).toBe(true);
+        expect(frozen.disposed).toBe(false);
+    });
+
+    test('falls back to stock gc (never throws) if the partition pass errors', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        // An atlas whose internals don't match expectations: reading keys throws.
+        const broken = {
+            canvas: null,
+            get keyToLocation(): Map<string, string> { throw new Error('shape changed'); },
+            disposed: false,
+        } as unknown as FakeAtlas;
+        const collection = makeCollection([], ['x']);
+        collection.atlases = [broken];
+        let upstreamCalls = 0;
+
+        expect(() =>
+            correctedAtlasGc(collection as never, () => { upstreamCalls++; }),
+        ).not.toThrow();
+        expect(upstreamCalls).toBe(1); // stock gc still ran exactly once
+        warn.mockRestore();
+    });
+});
+
+describe('installAtlasGcFix', () => {
+    function cyWithCollections(collections: FakeCollection[]): Core {
+        return {
+            renderer: () => ({
+                drawing: { atlasManager: { collections: new Map(collections.map((c, i) => [String(i), c])) } },
+            }),
+        } as unknown as Core;
+    }
+
+    test('patches gc so a later collection-driven gc preserves survivors', () => {
+        const frozen = makeAtlas(null, ['a_0', 'a_1']);
+        const collection = makeCollection([frozen], ['a_1']);
+        // Install the original (buggy) gc that the fix must wrap.
+        collection.gc = buggyUpstreamGc(collection);
+
+        installAtlasGcFix(cyWithCollections([collection]));
+        collection.gc(); // now goes through the wrapper
+
+        expect(collection.styleKeyToAtlas.has('a_0')).toBe(true);
+        expect(frozen.disposed).toBe(false);
+    });
+
+    test('is idempotent — does not double-wrap gc', () => {
+        const collection = makeCollection([makeAtlas(null, ['a_0'])], []);
+        const cy = cyWithCollections([collection]);
+
+        installAtlasGcFix(cy);
+        const afterFirst = collection.gc;
+        installAtlasGcFix(cy);
+
+        expect(collection.gc).toBe(afterFirst);
+    });
+
+    test('warns and skips when atlas internals do not match expected shape', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const bogus = { atlases: 'not-an-array', gc: () => {} } as unknown as FakeCollection;
+        const original = bogus.gc;
+
+        installAtlasGcFix(cyWithCollections([bogus]));
+
+        expect(console.warn).toHaveBeenCalledOnce();
+        expect(bogus.gc).toBe(original); // unchanged
+        warn.mockRestore();
+    });
+
+    test('no-op when the renderer has no WebGL atlas manager (headless)', () => {
+        const cy = { renderer: () => ({}) } as unknown as Core;
+        expect(() => installAtlasGcFix(cy)).not.toThrow();
+    });
+});

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/animation/atlasGcFix.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/animation/atlasGcFix.ts
@@ -1,0 +1,215 @@
+/**
+ * Fixes a correctness bug in cytoscape's experimental WebGL renderer that
+ * causes node/edge labels to render blank ("cut off") until the node is
+ * hovered or the view is otherwise forced to redraw.
+ *
+ * ## The bug
+ *
+ * The WebGL renderer rasterizes every label line into a texture atlas
+ * (`AtlasCollection`). When an atlas fills up it is `lock()`-ed and a new one
+ * is started; once a locked atlas has been buffered to the GPU, its backing
+ * 2D canvas is freed to save memory (`Atlas.bufferIfNeeded` sets
+ * `this.canvas = null`). The GPU texture itself stays valid and keeps
+ * rendering.
+ *
+ * Periodically (debounced ~10s after any label change) the renderer runs
+ * `AtlasCollection.gc()` to reclaim space taken by textures whose style key
+ * changed. To repack an atlas, gc copies each *surviving* (non-collected)
+ * texture onto a fresh atlas via `canvas.drawImage`. But for a locked atlas
+ * whose canvas was already freed, that copy is impossible, and upstream's
+ * guard simply skips it:
+ *
+ *     if (atlas.canvas) {                  // false for a buffered+locked atlas
+ *       this._copyTextureToNewAtlas(...);
+ *       newStyleKeyToAtlas.set(key, ...);  // <- never runs
+ *     }
+ *     // ...later: atlas.dispose() deletes the GPU texture too
+ *
+ * So every surviving texture in a canvas-freed atlas is dropped from the
+ * cache *and* its GPU texture is deleted. Those labels then render blank.
+ * Upstream relies on "it'll be redrawn next frame", but a redraw only
+ * re-rasterizes them if something marks the elements dirty — which is exactly
+ * what hovering a node does. On an idle graph the labels stay cut off until
+ * the user hovers. Observed live: a single gc pass evicted 97 of 105 cached
+ * label textures, only 8 of which had actually changed.
+ *
+ * ## The fix
+ *
+ * Intercept only the mishandled case. Before delegating to the upstream gc,
+ * pull out any canvas-freed atlas that still holds surviving textures, forget
+ * just its collected keys, and keep the survivors in place — their GPU
+ * textures are still valid, so nothing needs re-rasterizing. Everything else
+ * (canvas-backed atlases that can be repacked, and fully-garbage atlases that
+ * should be disposed) is handed to the upstream gc unchanged, preserving its
+ * memory-reclamation behavior.
+ *
+ * ## Why a runtime override (and why it's safe)
+ *
+ * This is a *defensive vendor patch* for cytoscape's provisional WebGL
+ * renderer, in the same spirit as `installTextureCacheSkip`
+ * (largegraphPerformance.ts), which already monkey-patches the same renderer's
+ * internals. The override was chosen over the alternatives:
+ *   - No cytoscape config/flag fixes this — `webglTexRows`/`webglTexSize` only
+ *     resize the atlas (delaying locking, never preventing the gc eviction).
+ *   - Not freeing the locked atlases' canvases would fix it but regress the
+ *     renderer's core large-graph memory optimization (a 2048² canvas per
+ *     locked atlas) and isn't reachable without patching an unexported class.
+ *   - Pinning the version freezes the bug rather than fixing it.
+ * The override is surgical (it changes only the mishandled gc case and keeps
+ * upstream's repacking/reclamation for everything else) and lives in owned,
+ * unit-tested code.
+ *
+ * Safety: `installAtlasGcFix` feature-detects the exact internal shape it
+ * depends on; if a cytoscape upgrade changes it, the patch is NOT installed
+ * (a warning is logged and stock gc keeps running). `correctedAtlasGc`
+ * additionally falls back to stock gc on any unexpected runtime error, so a
+ * future upgrade degrades to original behavior rather than crashing the
+ * renderer's redraw loop.
+ *
+ * Upstream: tracking issue cytoscape/cytoscape.js#3305 (experimental WebGL
+ * renderer); related label/hover symptom in #3412. No exact-match issue for
+ * this gc eviction was found at cytoscape 3.33.4 — candidate to file/upstream.
+ */
+import type { Core } from 'cytoscape';
+
+/** Minimal structural view of a cytoscape WebGL `Atlas`. */
+interface GcAtlas {
+    /** Backing 2D canvas; null once a locked atlas has been buffered to the GPU. */
+    canvas: unknown | null;
+    /** Map of styleKey -> texture location(s) for everything drawn into this atlas. */
+    keyToLocation: Map<string, unknown>;
+}
+
+/** Minimal structural view of a cytoscape WebGL `AtlasCollection`. */
+interface GcCollection {
+    atlases: GcAtlas[];
+    styleKeyToAtlas: Map<string, GcAtlas>;
+    markedKeys: Set<string>;
+    gc: () => void;
+}
+
+type PatchedGc = (() => void) & { __vtGcFixInstalled?: boolean };
+
+/**
+ * Corrected garbage collection for one `AtlasCollection`. Preserves surviving
+ * textures of canvas-freed atlases that the upstream gc would otherwise drop,
+ * then delegates the rest to `upstreamGc`.
+ *
+ * Mutates `collection` in place (matching cytoscape's own gc contract).
+ * `upstreamGc` must be the original gc already bound to `collection`.
+ */
+export function correctedAtlasGc(collection: GcCollection, upstreamGc: () => void): void {
+    const markedKeys: Set<string> = collection.markedKeys;
+
+    const preserved: GcAtlas[] = [];
+
+    // Partition phase. If anything here throws (e.g. a future cytoscape changed
+    // the atlas internals in a way the install-time shape check didn't catch),
+    // fall back to stock gc — never crash the renderer's redraw loop. This
+    // phase reassigns collection.atlases only on full success, so the fallback
+    // runs upstream gc against the original, untouched atlas set.
+    try {
+        const remaining: GcAtlas[] = [];
+        for (const atlas of collection.atlases) {
+            const keys: string[] = [...atlas.keyToLocation.keys()];
+            let markedCount: number = 0;
+            for (const key of keys) {
+                if (markedKeys.has(key)) markedCount++;
+            }
+            const hasSurvivors: boolean = markedCount < keys.length;
+            const hasGarbage: boolean = markedCount > 0;
+
+            // Only the (canvas freed) + (mixed survivors and garbage) case is
+            // mishandled upstream. A canvas-freed atlas that is all survivors is
+            // kept correctly by upstream; one that is all garbage is disposed
+            // correctly. Canvas-backed atlases can always be repacked.
+            if (atlas.canvas === null && hasSurvivors && hasGarbage) {
+                // Forget only the collected keys; the survivors' GPU textures stay valid.
+                for (const key of keys) {
+                    if (markedKeys.has(key)) atlas.keyToLocation.delete(key);
+                }
+                preserved.push(atlas);
+            } else {
+                remaining.push(atlas);
+            }
+        }
+        // Upstream gc rebuilds collection.atlases + collection.styleKeyToAtlas
+        // and clears markedKeys. Feed it only the atlases it handles correctly.
+        collection.atlases = remaining;
+    } catch (err) {
+        console.warn('[atlasGcFix] atlas partition failed; using stock cytoscape gc', err);
+        upstreamGc();
+        return;
+    }
+
+    upstreamGc();
+
+    if (preserved.length === 0) return;
+
+    // Re-attach the preserved atlases at the FRONT — they are locked (a freed
+    // canvas implies a locked, fully-buffered atlas) so they never accept new
+    // draws; keeping them ahead of the active atlas leaves the active atlas
+    // last, where AtlasCollection.draw looks for free space. Register their
+    // survivors into the freshly-rebuilt lookup map.
+    collection.atlases = [...preserved, ...collection.atlases];
+    for (const atlas of preserved) {
+        for (const key of atlas.keyToLocation.keys()) {
+            collection.styleKeyToAtlas.set(key, atlas);
+        }
+    }
+}
+
+function isGcCollection(value: unknown): value is GcCollection {
+    if (typeof value !== 'object' || value === null) return false;
+    const c: Partial<GcCollection> = value as Partial<GcCollection>;
+    return (
+        Array.isArray(c.atlases) &&
+        c.styleKeyToAtlas instanceof Map &&
+        c.markedKeys instanceof Set &&
+        typeof c.gc === 'function' &&
+        c.atlases.every(a => a != null && a.keyToLocation instanceof Map && 'canvas' in a)
+    );
+}
+
+/** Structural view of the WebGL renderer internals (not in @types/cytoscape). */
+interface WebglRenderer {
+    drawing?: { atlasManager?: { collections?: Map<string, unknown> } };
+}
+interface CoreWithRenderer {
+    renderer?: () => WebglRenderer | undefined;
+}
+
+/** Reach the WebGL renderer's atlas collections, or [] if WebGL is inactive. */
+function getAtlasCollections(cy: Core): unknown[] {
+    const renderer: WebglRenderer | undefined = (cy as unknown as CoreWithRenderer).renderer?.();
+    const collections: Map<string, unknown> | undefined = renderer?.drawing?.atlasManager?.collections;
+    return collections ? [...collections.values()] : [];
+}
+
+/**
+ * Install the gc integrity fix on every atlas collection of `cy`'s WebGL
+ * renderer. No-op (with a warning) if the renderer is absent or its atlas
+ * internals don't match the expected shape. Idempotent per collection.
+ */
+export function installAtlasGcFix(cy: Core): void {
+    const collections: unknown[] = getAtlasCollections(cy);
+    if (collections.length === 0) return; // headless / non-WebGL: no atlases to protect
+
+    for (const collection of collections) {
+        if (!isGcCollection(collection)) {
+            console.warn(
+                '[installAtlasGcFix] cytoscape WebGL atlas internals changed; label GC integrity fix NOT applied. ' +
+                'Labels may render blank until hovered. Re-validate against the cytoscape version.'
+            );
+            continue;
+        }
+
+        const current: PatchedGc = collection.gc as PatchedGc;
+        if (current.__vtGcFixInstalled) continue; // already patched
+
+        const originalGc: () => void = current.bind(collection);
+        const patched: PatchedGc = () => correctedAtlasGc(collection, originalGc);
+        patched.__vtGcFixInstalled = true;
+        collection.gc = patched;
+    }
+}

--- a/webapp/src/shell/UI/views/VoiceTreeGraphViewHelpers/initializeCytoscapeInstance.ts
+++ b/webapp/src/shell/UI/views/VoiceTreeGraphViewHelpers/initializeCytoscapeInstance.ts
@@ -5,6 +5,7 @@
 import cytoscape, {type Core, type CytoscapeOptions, type StylesheetCSS} from 'cytoscape';
 import {MIN_ZOOM, MAX_ZOOM} from '@/shell/UI/cytoscape-graph-ui/constants';
 import {installCollectionCache, installTextureCacheSkip} from '@/shell/UI/cytoscape-graph-ui/services/animation/largegraphPerformance';
+import {installAtlasGcFix} from '@/shell/UI/cytoscape-graph-ui/services/animation/atlasGcFix';
 
 export interface CytoscapeInitConfig {
     container: HTMLElement;
@@ -96,6 +97,9 @@ export function initializeCytoscapeInstance(config: CytoscapeInitConfig): Cytosc
         patchWebglRenderEvent(cy);
         installCollectionCache(cy);
         installTextureCacheSkip(cy);
+        // Prevent the WebGL atlas garbage collector from evicting still-live
+        // label textures (causes labels to render blank until hovered).
+        installAtlasGcFix(cy);
         return {cy, isHeadless: false};
     } catch (_error) {
         // Fallback to headless mode (e.g., JSDOM without proper layout)


### PR DESCRIPTION
## The bug

Node/edge titles intermittently render **blank ("cut off")** until the node is hovered — on an idle graph they stay cut off.

## Root cause (confirmed live via CDP on the running app)

Cytoscape's experimental WebGL renderer rasterizes each label line into a texture atlas (`AtlasCollection`). When an atlas fills it is `lock()`-ed and, once buffered to the GPU, its backing 2D canvas is freed (`Atlas.bufferIfNeeded` → `this.canvas = null`); the GPU texture stays valid.

Periodically (debounced ~10s after any label change) `AtlasCollection.gc()` repacks surviving textures by copying them **via that canvas**. For a canvas-freed atlas the copy is skipped by the `if (atlas.canvas)` guard, so every *surviving* texture is silently dropped from the cache **and** its GPU texture is deleted when the atlas is disposed. Upstream relies on "redrawn next frame", which only fires when an element is marked dirty — i.e. **on hover**.

Measured on the live app: a single gc pass evicted **97 of 105** cached label textures; only 8 had actually changed. Independently re-validated: the label collection currently has 1 canvas-freed atlas with 19 marked of 51 textures.

## The fix

A **defensive vendor patch** for the provisional WebGL renderer (`services/animation/atlasGcFix.ts`), wired into `initializeCytoscapeInstance` alongside the existing `installTextureCacheSkip`.

`installAtlasGcFix()` overrides each `AtlasCollection.gc` to intercept **only** the mishandled case — a canvas-freed atlas holding both changed and surviving textures — keeping the survivors (their GPU textures are still valid; nothing is re-rasterized) and delegating canvas-backed repacking and fully-garbage disposal to the upstream gc unchanged, so memory reclamation is preserved.

### Why a runtime override (vs alternatives)
- No cytoscape config/flag fixes this — `webglTexRows`/`webglTexSize` only resize the atlas (delay locking, never prevent the eviction).
- Not freeing locked canvases would fix it but regress the renderer's core large-graph memory optimization (a 2048² canvas per locked atlas) and isn't reachable without patching an unexported class.
- Pinning the version freezes the bug rather than fixing it.

### Safety (degrades, never crashes)
- Feature-detects the exact internal shape (`isGcCollection`); on a cytoscape bump that changes it, the patch is **not installed** (warns; stock gc keeps running).
- `correctedAtlasGc` falls back to stock gc on any unexpected runtime error — degrades to original behavior, never throws inside the redraw loop.

## Tests
12 black-box tests against a faithful re-implementation of cytoscape 3.33.4's buggy gc, including guard tests proving (a) upstream loses the survivors without the fix and (b) the fallback never throws. `tsc` + `eslint` clean.

## Upstream
Tracking issue cytoscape/cytoscape.js#3305 (experimental WebGL); related label/hover symptom #3412. No exact-match issue found at 3.33.4 — candidate to file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)