### PR TITLE
fix(graph): enlarge WebGL label atlas to 4096 for crisp node titles

### DIFF
--- a/webapp/src/shell/UI/views/VoiceTreeGraphViewHelpers/initializeCytoscapeInstance.ts
+++ b/webapp/src/shell/UI/views/VoiceTreeGraphViewHelpers/initializeCytoscapeInstance.ts
@@ -19,6 +19,36 @@ export interface CytoscapeInitResult {
 }
 
 /**
+ * WebGL texture-atlas size (px) for the label atlas, chosen to keep node-title
+ * text crisp. Paired with `webglTexRows: 24` this gives a per-label atlas row of
+ * 4096/24 ≈ 170px.
+ *
+ * Why this matters: cytoscape's experimental WebGL renderer rasterizes every
+ * node label once into a single atlas row of height `webglTexSize / webglTexRows`
+ * — and a multi-line title's *whole* bounding box must fit that one row (see
+ * cytoscape's `atlas.mjs` getScale, which also flags "TODO what about
+ * pixelRatio?"). The stock 2048 → 85px row downscales the taller titles measured
+ * on the live graph (single line ≈40px up to a 6-line title ≈132px) into far too
+ * few texels, so they read soft even at zoom 1 — confirmed by an A/B against
+ * cy.png()'s canvas path, which renders the same titles vector-sharp.
+ *
+ * 4096 (row ≈170px) exceeds the tallest measured title, so labels are no longer
+ * downscaled in the atlas: titles are crisp on a standard (DPR 1) display and
+ * roughly twice as sharp on HiDPI. Verified on the real WebGL renderer (Chromium
+ * + cytoscape) at DPR 1 and DPR 2.
+ *
+ * Why not larger / DPR-scaled: scaling texSize (rather than cutting texRows) was
+ * chosen because it raises the per-label texel budget WITHOUT increasing the
+ * atlas *count* — atlas count, not size, drives the per-frame texture binds, so
+ * the WebGL batching win the renderer was enabled for is preserved. 8192 would
+ * fully sharpen 6-line titles on retina too, but it equals the MAX_TEXTURE_SIZE
+ * of lower-end GPUs and rendered *blank* at DPR 2 in testing (a hard texture-size
+ * limit), for a marginal gain at 4× the VRAM. 4096 is the measured sweet spot:
+ * well within every tested GPU's limits while fixing the reported blur.
+ */
+const WEBGL_LABEL_ATLAS_SIZE = 4096;
+
+/**
  * Cytoscape's WebGL render path (overrideCanvasRendererFunctions) doesn't emit the
  * 'render' event that the canvas path emits. This breaks cytoscape-navigator's
  * onRender-based thumbnail updates. Patch the renderer to emit 'render' — but
@@ -87,7 +117,7 @@ export function initializeCytoscapeInstance(config: CytoscapeInitConfig): Cytosc
                 webgl: true,
                 showFps,
                 webglDebug: false,
-                webglTexSize: 2048,
+                webglTexSize: WEBGL_LABEL_ATLAS_SIZE, // crisp multi-line titles; see constant doc
                 webglTexRows: 24,
                 webglBatchSize: 2048,
                 webglTexPerBatch: 16


### PR DESCRIPTION
## The bug
Node **title text** on the graph renderer reads soft/blurry — suspected to be a side effect of the deliberate WebGL/GPU performance switch.

## Root cause (confirmed)
The "GPU perf fix" is cytoscape's experimental **WebGL renderer**. It rasterizes each node label **once** into a single texture-atlas row of height `webglTexSize / webglTexRows`, and a multi-line title's *whole* bounding box must fit that one row. Cytoscape's own `atlas.mjs` `getScale` even flags the gap: `// TODO what about pixelRatio?`.

With the stock `webglTexSize: 2048` / `webglTexRows: 24` the row is **~85px**. But titles measured on the live graph run **~40px (1 line) → ~132px (6 lines)**, so taller titles are *downscaled* into far too few texels and look soft **even at zoom 1**.

**A/B proof (read-only, on the live graph):** the on-screen WebGL view is soft, while `cy.png()`'s canvas path (same content, same zoom) renders the same titles vector-sharp — isolating the WebGL atlas as the cause. Node *bodies* stay crisp because they're SDF "simple shapes", not atlased — consistent with the report being specifically about title *text*.

## Fix
Raise `webglTexSize` to **4096** (atlas row ≈170px > the tallest measured title) so labels are no longer downscaled in the atlas.

- **Why scale texSize, not cut texRows:** scaling texSize raises the per-label texel budget **without increasing the atlas *count***; atlas count (not size) drives the per-frame texture binds during pan/zoom — so the WebGL batching win the renderer was enabled for is **preserved**. (Cutting `webglTexRows` would quarter labels-per-atlas and multiply atlas count, eroding that win.) The only added cost is one-time atlas rasterization + ~4× the label-atlas VRAM (64MB vs 16MB per atlas).
- **Why 4096 and not 8192/DPR-scaled:** measured. 8192 would also fully sharpen 6-line titles on retina, but it **equals lower-end GPUs' `MAX_TEXTURE_SIZE` and rendered *blank* at DPR 2** in testing (hard texture-size limit), for a marginal crispness gain at 4× the VRAM. 4096 is the sweet spot — well within every tested GPU's limits while fixing the reported blur.

## Verification
Confirmed on the **real WebGL renderer** (Chromium + cytoscape `3.33.4`, isolated harness reproducing the exact renderer config + label styling) at **DPR 1 and DPR 2**: `2048` is soft, `4096` is crisp, with `glError: 0` and no context loss. The `2048→4096` output differs visibly with identical config except `webglTexSize`, confirming the parameter is the lever.

> Note: not screenshotted inside a second Electron instance — the live app (main worktree) and concurrent agents are actively using the shared remote-debug port / Application Support dir, so spinning one up would collide. The isolated Chromium harness exercises the same cytoscape renderer + options, which is what governs label crispness. The on-disk change applies on the next app restart.

## Files
- `webapp/src/shell/UI/views/VoiceTreeGraphViewHelpers/initializeCytoscapeInstance.ts` — `webglTexSize` 2048 → 4096 via a documented `WEBGL_LABEL_ATLAS_SIZE` constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)