### PR TITLE
perf(graphd): cut GET /project + SSE event-loop cost on the hot path

### DIFF
--- a/packages/measures/scripts/span-self-time.mjs
+++ b/packages/measures/scripts/span-self-time.mjs
@@ -1,0 +1,99 @@
+// Self-time aggregation over an OTLP-JSON spans NDJSON file.
+//
+// Self-time of a span = its wall duration minus the summed wall duration of its
+// direct children (same trace, parentSpanId === spanId). Aggregated by span
+// name across the whole run, this attributes blocking/CPU cost to the frame
+// that actually spent it rather than to its callees — the metric used to rank
+// the storm's worst perf offenders.
+//
+// Usage:
+//   node packages/measures/scripts/span-self-time.mjs <spans.ndjson> [nameFilter]
+//
+// With a nameFilter substring, prints the per-name self/wall percentiles for
+// matching span names; otherwise prints the top offenders by self-time sum.
+import { readFileSync } from 'node:fs'
+
+function percentile(sortedMs, p) {
+  if (sortedMs.length === 0) return 0
+  const idx = Math.min(sortedMs.length - 1, Math.ceil((p / 100) * sortedMs.length) - 1)
+  return sortedMs[Math.max(0, idx)]
+}
+
+function loadSpans(path) {
+  const spans = []
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (!line.trim()) continue
+    const batch = JSON.parse(line)
+    for (const rs of batch.resourceSpans ?? []) {
+      const service = (rs.resource?.attributes ?? []).find(a => a.key === 'service.name')?.value?.stringValue ?? '?'
+      for (const ss of rs.scopeSpans ?? []) {
+        for (const s of ss.spans ?? []) {
+          spans.push({
+            service,
+            name: s.name,
+            traceId: s.traceId,
+            spanId: s.spanId,
+            parentSpanId: s.parentSpanId,
+            durMs: (Number(BigInt(s.endTimeUnixNano) - BigInt(s.startTimeUnixNano))) / 1e6,
+          })
+        }
+      }
+    }
+  }
+  return spans
+}
+
+function selfTimes(spans) {
+  // Sum of direct-child wall durations, keyed by (traceId|parentSpanId).
+  const childDur = new Map()
+  for (const s of spans) {
+    if (!s.parentSpanId) continue
+    const key = `${s.traceId}|${s.parentSpanId}`
+    childDur.set(key, (childDur.get(key) ?? 0) + s.durMs)
+  }
+  return spans.map(s => {
+    const kids = childDur.get(`${s.traceId}|${s.spanId}`) ?? 0
+    return { ...s, selfMs: Math.max(0, s.durMs - kids) }
+  })
+}
+
+function aggregateByName(withSelf) {
+  const byName = new Map()
+  for (const s of withSelf) {
+    if (!byName.has(s.name)) byName.set(s.name, { name: s.name, service: s.service, self: [], wall: [] })
+    const e = byName.get(s.name)
+    e.self.push(s.selfMs)
+    e.wall.push(s.durMs)
+  }
+  return [...byName.values()].map(e => {
+    const self = [...e.self].sort((a, b) => a - b)
+    const wall = [...e.wall].sort((a, b) => a - b)
+    return {
+      name: e.name,
+      service: e.service,
+      count: self.length,
+      selfSumMs: self.reduce((a, b) => a + b, 0),
+      selfP50: percentile(self, 50),
+      selfP99: percentile(self, 99),
+      wallP50: percentile(wall, 50),
+      wallP99: percentile(wall, 99),
+    }
+  })
+}
+
+const [path, nameFilter] = process.argv.slice(2)
+if (!path) {
+  console.error('usage: span-self-time.mjs <spans.ndjson> [nameFilter]')
+  process.exit(1)
+}
+
+const agg = aggregateByName(selfTimes(loadSpans(path)))
+const rows = nameFilter
+  ? agg.filter(r => r.name.includes(nameFilter)).sort((a, b) => b.selfSumMs - a.selfSumMs)
+  : agg.sort((a, b) => b.selfSumMs - a.selfSumMs).slice(0, 15)
+
+const fmt = n => n.toFixed(1).padStart(8)
+console.log(`${'count'.padStart(6)} ${'selfSum'.padStart(9)} ${'selfP50'.padStart(8)} ${'selfP99'.padStart(8)} ${'wallP50'.padStart(8)} ${'wallP99'.padStart(8)}  name`)
+for (const r of rows) {
+  console.log(`${String(r.count).padStart(6)} ${fmt(r.selfSumMs)} ${fmt(r.selfP50)} ${fmt(r.selfP99)} ${fmt(r.wallP50)} ${fmt(r.wallP99)}  ${r.name}  [${r.service}]`)
+}

--- a/packages/systems/graph-db-server/src/application/workflows/sessionEvents.ts
+++ b/packages/systems/graph-db-server/src/application/workflows/sessionEvents.ts
@@ -182,28 +182,49 @@ export async function runSessionEventsWorkflow(input: {
 
   let pendingLiveEvents: SequencedDeltaEvent[] = []
   let liveFlushScheduled = false
-  const flushLiveDeltaProjection = async (): Promise<void> => {
-    liveFlushScheduled = false
-    const events = pendingLiveEvents
-    pendingLiveEvents = []
-    const useCache = canUseProjectionCache()
-    let freshCache: ProjectionCache | null = null
-    for (const batched of batchProjectDeltaEvents(events)) {
-      const cache = await sendDeltaProjection(batched, useCache ? 'cached' : 'fresh')
-      if (!useCache && cache) freshCache = cache
-    }
-    if (!useCache && freshCache) projectionCache.replace(freshCache)
-    if (pendingLiveEvents.length > 0 && !liveFlushScheduled) {
-      liveFlushScheduled = true
-      queueMicrotask(() => void flushLiveDeltaProjection())
+  let liveFlushActive = false
+
+  // Project+stringify the whole graph at most ONCE per drained burst, never
+  // concurrently. All deltas that arrive while a drain is in flight (or queued
+  // for the same event-loop turn) accumulate and collapse into the next
+  // `batchProjectDeltaEvents` pass, so a storm of N single-delta publishes
+  // costs far fewer than N whole-graph serializations. Correctness is
+  // preserved: every delta is still applied in seq order and the final send
+  // always reflects the complete, consistent graph — only intermediate frames
+  // are coalesced.
+  const drainLiveDeltaProjections = async (): Promise<void> => {
+    if (liveFlushActive) return
+    liveFlushActive = true
+    try {
+      while (pendingLiveEvents.length > 0) {
+        const events = pendingLiveEvents
+        pendingLiveEvents = []
+        const useCache = canUseProjectionCache()
+        let freshCache: ProjectionCache | null = null
+        for (const batched of batchProjectDeltaEvents(events)) {
+          const cache = await sendDeltaProjection(batched, useCache ? 'cached' : 'fresh')
+          if (!useCache && cache) freshCache = cache
+        }
+        if (!useCache && freshCache) projectionCache.replace(freshCache)
+      }
+    } finally {
+      liveFlushActive = false
     }
   }
 
+  // Schedule the drain on a macrotask (setImmediate) rather than a microtask:
+  // microtasks drain between each I/O callback, so under a storm every publish
+  // lands in its own flush and nothing coalesces. setImmediate fires once after
+  // the current poll phase, collapsing every delta published in that event-loop
+  // turn into a single projection+stringify.
   const enqueueLiveDeltaProjection = (event: SequencedDeltaEvent): void => {
     pendingLiveEvents.push(event)
-    if (liveFlushScheduled) return
+    if (liveFlushScheduled || liveFlushActive) return
     liveFlushScheduled = true
-    queueMicrotask(() => void flushLiveDeltaProjection())
+    setImmediate(() => {
+      liveFlushScheduled = false
+      void drainLiveDeltaProjections()
+    })
   }
 
   const sendReplayResetSnapshot = async (

--- a/packages/systems/graph-db-server/src/data/watch-folder/folder-visibility-active-view.ts
+++ b/packages/systems/graph-db-server/src/data/watch-folder/folder-visibility-active-view.ts
@@ -40,15 +40,45 @@ async function loadStoreWithDerivation(): Promise<FolderVisibilityStoreAndDeriva
     return (await import('@vt/graph-state')) as unknown as FolderVisibilityStoreAndDerivation
 }
 
+async function loadFolderVisibilityResource(): Promise<typeof import('../views/folderVisibilityResource')> {
+    return await import('../views/folderVisibilityResource')
+}
+
+/** Pure: the expanded folder paths from a folder-state listing. */
+function expandedFolderPaths(
+    folderState: readonly (readonly [path: string, state: string])[],
+): readonly FilePath[] {
+    return folderState
+        .filter(([, state]) => state === 'expanded')
+        .map(([folderPath]) => folderPath as FilePath)
+}
+
 export async function getExpandedFolderPathsForProject(projectRoot: FilePath): Promise<readonly FilePath[]> {
-    let dbModule: Awaited<ReturnType<typeof loadFolderVisibilityDbModule>>
+    let resource: Awaited<ReturnType<typeof loadFolderVisibilityResource>>
     try {
-        dbModule = await loadFolderVisibilityDbModule()
+        resource = await loadFolderVisibilityResource()
     } catch {
-        // node:sqlite is unavailable in this runtime — safe to
-        // return empty because the daemon manages folder visibility in that mode.
+        // node:sqlite (and the resource's sqlite-backed deps) are unavailable in
+        // this runtime — safe to return empty because the daemon manages folder
+        // visibility in that mode.
         return []
     }
+    // Hot path: once the project's long-lived folder-visibility db handle is
+    // open (everything after `openResources`), reuse it. The read runs a live
+    // SELECT against the same on-disk db, so this returns data identical to a
+    // fresh open while avoiding the per-call sqlite open + schema-migration +
+    // close that otherwise blocks the graphd event loop on every GET /project.
+    if (resource.isFolderVisibilityOpen()) {
+        return expandedFolderPaths(resource.readCurrentFolderState().folderState)
+    }
+    // Open-sequence window: `bindProject` reads expanded paths (via
+    // `setWriteFolderPath`) before `openResources` installs the long-lived
+    // handle. Fall back to a one-shot open against the on-disk db.
+    return await readExpandedFolderPathsByOneShotOpen(projectRoot)
+}
+
+async function readExpandedFolderPathsByOneShotOpen(projectRoot: FilePath): Promise<readonly FilePath[]> {
+    const dbModule = await loadFolderVisibilityDbModule()
     const store = await loadFolderVisibilityStore()
     const { ensureDefaultView, getActiveViewId } = await loadViewsRepository()
     const db: FolderVisibilityDatabase = dbModule.openFolderVisibilityDb(projectRoot, dbModule.defaultFolderVisibilityDbDeps)
@@ -56,9 +86,7 @@ export async function getExpandedFolderPathsForProject(projectRoot: FilePath): P
         ensureDefaultView(db)
         store.configureFolderVisibilityStore(db)
         const activeViewId: string = getActiveViewId(db)
-        return [...store.getFolderVisibility(activeViewId)]
-            .filter(([, state]) => state === 'expanded')
-            .map(([folderPath]) => folderPath)
+        return expandedFolderPaths([...store.getFolderVisibility(activeViewId)])
     } finally {
         store.clearFolderVisibilityStoreForTests()
         dbModule.closeFolderVisibilityDb(db)


### PR DESCRIPTION
## What

Two graphd event-loop hot-path perf wins, surfaced and validated under the 50x8 e2e-storm + LGTM stack. Each was independently reviewed and accepted by a separate agent (the user requires every perf improvement be verified by a non-author).

### 1. Coalesce per-delta SSE projection across the event-loop turn (`sessionEvents.ts`)
Per-delta whole-graph SSE stringify was re-projecting on every delta; now coalesced across the event-loop turn. Independently reviewed and **ACCEPTED** (agent Gus, exp #1). Modest, real win.

### 2. Serve `GET /project` folder-visibility from the long-lived db handle (`folder-visibility-active-view.ts`)
`getExpandedFolderPathsForProject()` did a full synchronous sqlite open + WAL pragma + `CREATE TABLE IF NOT EXISTS` migrations + close on **every** `GET /project` (~258x on the graphd loop per storm). It now reuses the daemon's already-open long-lived `folderVisibilityResource` handle, falling back to a one-shot open only during the open-sequence window and in sqlite-unavailable runtimes. A shared pure helper (`expandedFolderPaths`) backs both paths.

**Measured (3 reps each, same Linux box, independently re-derived):**
- `GET /project` self-sum **−24%**, with **complete rep separation** (max treatment 4701ms < min baseline 5720ms) — the signature of removing a fixed per-call cost from all 258 calls.
- p50 −29%; p99 improves on median but is tail-noisy (loop-starvation from writeFile/projection — a different lever).
- Call count 258–261 unchanged (no dropped calls); 400/400 nodes on all 6 storm runs.

**No stale reads (correctness crux):** `getFolderVisibility` runs a live `SELECT` on every read with no in-memory cache, and the reused handle is the same connection that performs all daemon mutations — so reads are if anything *fresher* than a fresh open, never staler. Both handles hit the same on-disk file.

Independently reviewed and **ACCEPTED**, reward-hack audit **PASS** (agent Ian, exp #2).

## Also included
`packages/measures/scripts/span-self-time.mjs` — re-derivable self-time aggregator over the otelcol spans NDJSON (reproduces the baseline offenders table exactly), so these numbers can be re-checked.

## Notes
- Rebased onto current `origin/dev-manu` (`01151c7`). The experiments' third commit — exp #1's "gate blocking heap snapshots behind opt-in env" — was **dropped as superseded**: dev-manu's BF-434 perf-probe tier split already gates heap snapshots (`heapSnapshots` only in the `deep` tier).
- No product-behavior or schema change: `GET /project` response is byte-identical; `readProjectState`/zod untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
