### PR TITLE
docs(readme): fix stale dev start command for pnpm monorepo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,11 +121,11 @@ Capture ideas hands-free with speech-to-graph.
 
 ## Development
 
-**Prerequisites:** Node.js 18+, Python 3.13, uv
+**Prerequisites:** Node.js 18+, pnpm 10 (`corepack enable`), Python 3.13, uv
 
 ```bash
-cd webapp && npm install && npm run electron  # App
-uv sync && uv run pytest                               # Backend
+pnpm install && pnpm --filter voicetree-webapp run electron  # App (run from repo root)
+uv sync && uv run pytest                                     # Backend
 ```
 
 ## License


### PR DESCRIPTION
## What

The README's **Development** section told contributors to run:

```bash
cd webapp && npm install && npm run electron
```

This no longer works. The repo is now a **pnpm workspace** (`packageManager: pnpm@10.32.1`, `pnpm-workspace.yaml`, `pnpm-lock.yaml`):

- `cd webapp && npm install` does not set up the workspace — npm doesn't link the sibling workspace packages (`packages/libraries/*`, `packages/systems/*`).
- The `electron` dev script itself shells out to `pnpm --filter @vt/graph-db-server run build`, so the pnpm workspace must be installed from the repo root for it to run at all.

## Change

```diff
-**Prerequisites:** Node.js 18+, Python 3.13, uv
+**Prerequisites:** Node.js 18+, pnpm 10 (`corepack enable`), Python 3.13, uv

-cd webapp && npm install && npm run electron  # App
+pnpm install && pnpm --filter voicetree-webapp run electron  # App (run from repo root)
```

## Verification

- `pnpm -r ls` confirms `voicetree-webapp` (at `webapp`) and `@vt/graph-db-server` are workspace packages.
- `pnpm --filter voicetree-webapp run` lists the `electron` script, so the new command resolves.
- Did not launch Electron itself (long-running GUI process); the change is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)