### PR TITLE
fix(folder-handle): stop chevron/eye chips bleeding over panels + seat them snug in the folder corner

### DIFF
--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-note-dom.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-note-dom.spec.ts
@@ -244,7 +244,10 @@ async function panFolderHandleIntoInteractiveViewport(appWindow: Page, folderId:
         const sidebarRight = (document.querySelector('[data-testid="folder-tree-sidebar"]') as HTMLElement | null)
             ?.getBoundingClientRect().right ?? 0;
         const containerRect = container.getBoundingClientRect();
-        const folderBbox = (folder as import('cytoscape').NodeSingular).renderedBoundingBox();
+        // Body-only bbox: the chip strip anchors to the folder body's TL corner,
+        // not the default bbox (which includes the title label floating above it).
+        const folderBbox = (folder as import('cytoscape').NodeSingular)
+            .renderedBoundingBox({includeLabels: false, includeOverlays: false});
         const chipPx = 22;
         const eyeCenterX = containerRect.left + folderBbox.x1 + chipPx + (chipPx / 2);
         const eyeCenterY = containerRect.top + folderBbox.y1 + (chipPx / 2);
@@ -281,7 +284,10 @@ async function getFolderHandleSnapshot(appWindow: Page, folderId: string): Promi
 
         const containerRect = container.getBoundingClientRect();
         const chipRect = chip.getBoundingClientRect();
-        const folderBbox = (folder as import('cytoscape').NodeSingular).renderedBoundingBox();
+        // Body-only bbox: the chip strip anchors to the folder body's TL corner,
+        // not the default bbox (which includes the title label floating above it).
+        const folderBbox = (folder as import('cytoscape').NodeSingular)
+            .renderedBoundingBox({includeLabels: false, includeOverlays: false});
         const chipOffsetX = chipRect.x - containerRect.x;
         const chipOffsetY = chipRect.y - containerRect.y;
         const toRectSnapshot = (rect: DOMRect): RectSnapshot => ({
@@ -407,6 +413,10 @@ test.describe('Folder-note DOM affordance', () => {
         });
 
         const expandedHandle = await getFolderHandleSnapshot(appWindow, authFolderId);
+        // Chip strip is snug in the folder body's top-left corner (chevron flush
+        // against the top & left edges), not floating above the box on the label.
+        expect(Math.abs(expandedHandle.chipOffsetFromFolder.dx)).toBeLessThanOrEqual(3);
+        expect(Math.abs(expandedHandle.chipOffsetFromFolder.dy)).toBeLessThanOrEqual(3);
         await expectEyeReceivesPointer(appWindow, expandedHandle.eye);
         await clickEyeAndWaitForFolderNote(appWindow, expandedHandle.eye);
         await closeHoverEditor(appWindow);

--- a/webapp/src/shell/UI/App.tsx
+++ b/webapp/src/shell/UI/App.tsx
@@ -353,8 +353,11 @@ function App(): JSX.Element {
         <div className="fixed inset-0 overflow-clip bg-background">
             {/* Layer 0: Dot-grid underlay - sits behind the transparent Cytoscape canvas */}
             <div ref={dotGridRef} className="absolute inset-0 pb-14 dot-grid pointer-events-none"/>
-            {/* Layer 1: Graph canvas - Cytoscape only, absolutely positioned so it never causes overflow */}
-            <div ref={graphContainerRef} className="absolute inset-0 pb-14 overflow-hidden"/>
+            {/* Layer 1: Graph canvas - Cytoscape only, absolutely positioned so it never causes overflow.
+                `isolate` makes this an isolated stacking context: DOM overlays appended into the cy
+                container (the folder-handle chevron/eye chips) are confined to the graph layer and can
+                never paint over Layer 2 chrome, regardless of their own z-index. */}
+            <div ref={graphContainerRef} className="absolute inset-0 pb-14 overflow-hidden isolate"/>
             {/* Layer 2: UI overlay - sidebar, overlays, title bar, tabs */}
             <div ref={uiContainerRef} className="absolute inset-0 pb-14 pointer-events-none [&>*]:pointer-events-auto"/>
 

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/folder-handle/FolderHandleService.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/folder-handle/FolderHandleService.ts
@@ -53,6 +53,19 @@ import {getHoverEditor} from '@/shell/edge/UI-edge/state/stores/EditorStore';
 
 const CHIP_PX = 22;
 
+// Measure the folder's drawn BODY box (the roundrectangle / pill), excluding the
+// title label and selection overlays. The default bounding box includes the
+// folder label, which floats *above* the compound body (text-valign:top,
+// text-margin-y:-16) and can be wider than the box — anchoring the chip strip to
+// it left the chips hovering above-and-left of the folder instead of snug in its
+// top-left corner. Same convention as the folder-handle e2e specs and
+// runLayoutAdapter. Listed as a named constant so the chip anchor and the hover
+// editor anchor stay in lock-step.
+const BODY_BBOX_OPTIONS: cytoscape.BoundingBoxOptions = {
+    includeLabels: false,
+    includeOverlays: false,
+};
+
 // Debounce duration for closing the hover editor after the cursor leaves the
 // eye chip. Long enough for the cursor to traverse from chip to editor
 // (~18px), short enough that dismissal stays responsive.
@@ -195,14 +208,15 @@ export function setupFolderHandles(cy: Core): void {
         const folderNoteId: NodeIdAndFilePath | null = await resolveFolderNoteId(folder.id());
         if (folderNoteId === null) return;
         const eyeBtn: HTMLButtonElement | undefined = chips.get(folder.id())?.eyeBtn;
-        // Anchor the editor to the chip strip (folder bbox TL), not folder.position().
+        // Anchor the editor to the chip strip (folder BODY bbox TL), not folder.position().
         // For a collapsed pill, position() ≈ bbox center ≈ strip — they coincide.
         // For an expanded compound, position() is the centroid of all descendants,
         // which floats in the middle of the folder body, far from the chip strip in
-        // the TL corner. Using bbox TL keeps the editor pinned just-below-strip in
-        // both states. Strip is 44×22 graph units (CHIP_PX=22 × two chips, scaled
-        // by zoom in CSS so size matches across zooms).
-        const bbox: cytoscape.BoundingBox12 & cytoscape.BoundingBoxWH = folder.boundingBox();
+        // the TL corner. Using the body bbox TL (same BODY_BBOX_OPTIONS as the strip
+        // itself) keeps the editor pinned just-below-strip in both states. Strip is
+        // 44×22 graph units (CHIP_PX=22 × two chips, scaled by zoom in CSS so size
+        // matches across zooms).
+        const bbox: cytoscape.BoundingBox12 & cytoscape.BoundingBoxWH = folder.boundingBox(BODY_BBOX_OPTIONS);
         const stripAnchor: cytoscape.Position = {
             x: bbox.x1 + CHIP_PX,  // strip horizontal center (half of 44 wide strip)
             y: bbox.y1 + CHIP_PX,  // strip bottom edge (22 tall)
@@ -289,10 +303,12 @@ export function setupFolderHandles(cy: Core): void {
         const node: cytoscape.CollectionReturnValue = cy.getElementById(folderId);
         if (node.length === 0) return;
 
-        const bbox: cytoscape.BoundingBox12 & cytoscape.BoundingBoxWH = (node as NodeSingular).renderedBoundingBox();
-        // Anchor strip to TL of the bbox. Container is the cy host; chip is a
-        // child of the overlay (sibling-positioned), so direct canvas coords
-        // map 1:1 onto offset coords.
+        const bbox: cytoscape.BoundingBox12 & cytoscape.BoundingBoxWH =
+            (node as NodeSingular).renderedBoundingBox(BODY_BBOX_OPTIONS);
+        // Anchor the strip to the TL corner of the folder BODY box so the chevron
+        // sits flush against the folder's top and left edges (eye snug to its
+        // right). Container is the cy host; chip is a child of the overlay
+        // (sibling-positioned), so direct canvas coords map 1:1 onto offset coords.
         entry.el.style.left = `${bbox.x1}px`;
         entry.el.style.top = `${bbox.y1}px`;
 

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/folder-handle/FolderHandleService.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/folder-handle/FolderHandleService.ts
@@ -87,7 +87,13 @@ function injectStylesheet(): void {
     position: absolute;
     inset: 0;
     pointer-events: none;
-    z-index: 1101; /* Above the macOS title-bar drag region (1099). */
+    /* Orders the chip strip above the (transparent) cy canvas within the graph
+       layer only. The graph container (App.tsx Layer 1) is an isolated stacking
+       context, so this value never competes with Layer 2 chrome — chips are
+       always occluded by side panels, terminal panes, the title bar and tabs,
+       exactly like the graph nodes they annotate. Do NOT raise this to escape
+       the graph layer (that regression put the chips on top of every panel). */
+    z-index: 5;
 }
 .${CHIP_CLASS} {
     position: absolute;


### PR DESCRIPTION
## EYE BALL bug

The folder **chevron (collapse arrow) + eye** affordance chips rendered **on top of** the terminal panes, side panels and search panel instead of behind them, and floated above the folder box rather than sitting in its corner.

### 1. Chips bleeding over panels (the reported bug)
**Root cause:** commit `1e9e890b4` raised the `.vt-folder-handle-overlay` `z-index` from `5` → `1101` ("Above the macOS title-bar drag region") so chips stay clickable under the title bar. The overlay is a child of the cy container (App.tsx *Layer 1*), which established **no stacking context**, so `1101` competed in the root stacking context and beat **every** chrome layer — floating windows (1000), sidebar (1050), title bar (1099), tabs (1100). Chips are placed at each folder's window-space `renderedBoundingBox()` with no clipping, so any folder behind a panel leaked its chip over it.

**Fix (structural, recurrence-proof):** make the graph container an isolated stacking context (`isolate`). It holds only the cy canvas + this overlay, so the chips are confined to the graph layer below all chrome **regardless of their z-index** — a future bump can't escape again. Overlay z-index dropped back to its pre-regression `5`.

**Trade-off (honest):** chips under the *transparent* title-bar drag region (top 38px) are again occluded / not click-through there — the behaviour `1e9e890b4` added. That's irreconcilable with "chips behind panels" via one global z-index (title bar 1099 > panels), and chips are graph content that should be occluded by chrome.

### 2. Snug in the folder's top-left corner (follow-up request)
The strip anchored to the folder's *default* bounding box, which includes the title label. The label floats **above** the compound body (`text-valign:top`, `text-margin-y:-16`), so the strip hovered above-and-left of the box. Now it anchors to the drawn **body box** (`renderedBoundingBox({includeLabels:false, includeOverlays:false})`) via a shared `BODY_BBOX_OPTIONS` — the same convention the e2e specs and `runLayoutAdapter` already use. Chevron is flush against the top & left edges, eye snug to its right. No-op for collapsed pills.

## Tests
- `tsc --noEmit` + eslint clean.
- `electron-folder-note-dom` now measures chip offset against the body box and asserts the **expanded** handle is snug (`|dx|,|dy| ≤ 3`), mirroring the existing collapsed-pill assertion. Click/hover assertions already use the real eye/chevron rects, so they validate reachability post-fix.

## Files
- `webapp/src/shell/UI/App.tsx`
- `webapp/src/shell/UI/cytoscape-graph-ui/services/folder-handle/FolderHandleService.ts`
- `webapp/e2e-tests/electron/.../folder_tree/electron-folder-note-dom.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)