### PR TITLE
fix(startup): kill the intermittent project-open hang (two root causes)

### DIFF
--- a/packages/systems/graph-db-client/src/client/requestCore.ts
+++ b/packages/systems/graph-db-client/src/client/requestCore.ts
@@ -7,10 +7,21 @@ import {
 } from '@opentelemetry/api'
 import {
   GraphDbClientError,
+  GraphDbRequestTimeoutError,
   ProjectNotOpenError,
   ProjectOpenFailedError,
 } from '../errors.ts'
 import type { Schema } from '../responseSchemas.ts'
+
+/**
+ * Hard ceiling for a single graphd request when the caller does not supply
+ * one. Generous enough to never abort a legitimate cold-start project parse,
+ * but bounded so a daemon that accepts the socket and then stalls converts
+ * into a thrown {@link GraphDbRequestTimeoutError} instead of an `await`
+ * that never settles. Mirrors `VtDaemonClient`'s `DEFAULT_TIMEOUT_MS` — the
+ * sibling client already had this guard; graphd's transport did not.
+ */
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 
 export type RequestOptions<T> = {
   body?: unknown
@@ -18,6 +29,13 @@ export type RequestOptions<T> = {
   headers?: Record<string, string>
   method?: 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT'
   responseSchema?: Schema<T>
+  /**
+   * Override the per-request deadline. Defaults to
+   * {@link DEFAULT_REQUEST_TIMEOUT_MS}. The timer covers the whole exchange
+   * (connect, response headers, and body read) — aborting the signal errors
+   * an in-flight body stream too.
+   */
+  timeoutMs?: number
 }
 
 export type RequestClient = <T>(
@@ -110,6 +128,9 @@ export function createRequest(baseUrl: string): RequestClient {
         },
       },
       async (span): Promise<T> => {
+        const timeoutMs = opts.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+        const controller = new AbortController()
+        const timer = setTimeout(() => controller.abort(), timeoutMs)
         try {
           const body = opts.body === undefined ? undefined : JSON.stringify(opts.body)
           const headers: Record<string, string> = {
@@ -125,6 +146,7 @@ export function createRequest(baseUrl: string): RequestClient {
             body,
             headers,
             method,
+            signal: controller.signal,
           })
           span.setAttribute('http.status_code', response.status)
           span.addEvent('graphdb.response.received')
@@ -148,13 +170,21 @@ export function createRequest(baseUrl: string): RequestClient {
           span.addEvent('graphdb.response.parsed')
           return parsed
         } catch (error) {
-          span.recordException(error instanceof Error ? error : String(error))
+          // A fetch/body-read rejection caused by our own deadline surfaces
+          // as an opaque AbortError; rewrite it to the typed timeout so the
+          // caller (e.g. openProject) can distinguish "daemon stalled" from
+          // a real protocol error and react instead of hanging.
+          const surfaced = controller.signal.aborted
+            ? new GraphDbRequestTimeoutError(method, route, timeoutMs)
+            : error
+          span.recordException(surfaced instanceof Error ? surfaced : String(surfaced))
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: error instanceof Error ? error.message : String(error),
+            message: surfaced instanceof Error ? surfaced.message : String(surfaced),
           })
-          throw error
+          throw surfaced
         } finally {
+          clearTimeout(timer)
           span.end()
         }
       },

--- a/packages/systems/graph-db-client/src/errors.ts
+++ b/packages/systems/graph-db-client/src/errors.ts
@@ -47,6 +47,25 @@ export class DaemonUnreachableError extends Error {
   }
 }
 
+/**
+ * A graphd RPC was reachable but did not answer within its deadline, so the
+ * in-flight request was aborted. Distinct from {@link DaemonUnreachableError}
+ * (connection refused / no listener): here the socket was accepted but the
+ * response stalled. Without this bound a stalled RPC hangs the caller's
+ * `await` forever — e.g. `openProject` never settling, which leaves the
+ * renderer's "loading workspace" spinner spinning until a manual refresh.
+ */
+export class GraphDbRequestTimeoutError extends Error {
+  constructor(
+    public readonly method: string,
+    public readonly route: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(`vt-graphd request ${method} ${route} exceeded ${timeoutMs}ms and was aborted`)
+    this.name = 'GraphDbRequestTimeoutError'
+  }
+}
+
 export class DaemonLockHeldError extends Error {
   constructor(
     public readonly project: string,

--- a/packages/systems/graph-db-client/tests/requestTimeout.test.ts
+++ b/packages/systems/graph-db-client/tests/requestTimeout.test.ts
@@ -1,0 +1,91 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import type { Socket } from 'node:net'
+import { afterEach, describe, expect, test } from 'vitest'
+import { createRequest } from '../src/client/requestCore.ts'
+import { GraphDbRequestTimeoutError } from '../src/errors.ts'
+import { UnknownResponseSchema } from '../src/responseSchemas.ts'
+
+/**
+ * Black-box coverage for the graphd transport deadline. The failure these
+ * guard against is a daemon that accepts the TCP connection and then never
+ * answers: before the deadline existed, the client `await` hung forever,
+ * which is exactly what froze the renderer's "loading workspace" spinner.
+ *
+ * We exercise the real {@link createRequest} against a real `node:http`
+ * server — no mocked fetch — and assert on the observable outcome (a bounded
+ * rejection vs. a resolved value), never on internal calls.
+ */
+describe('graph-db-client request deadline', () => {
+  let server: Server | null = null
+  const liveSockets = new Set<Socket>()
+
+  async function startServer(
+    handler: (req: IncomingMessage, res: ServerResponse) => void,
+  ): Promise<string> {
+    const created = createServer(handler)
+    created.on('connection', (socket: Socket) => {
+      liveSockets.add(socket)
+      socket.on('close', () => liveSockets.delete(socket))
+    })
+    await new Promise<void>((resolve) => created.listen(0, '127.0.0.1', resolve))
+    server = created
+    const address = created.address()
+    if (address === null || typeof address === 'string') {
+      throw new Error('expected a TCP address from the test server')
+    }
+    return `http://127.0.0.1:${address.port}`
+  }
+
+  afterEach(async () => {
+    // Destroy any socket the stalling handler is still holding so the server
+    // can actually close and vitest does not hang on an open handle.
+    for (const socket of liveSockets) socket.destroy()
+    liveSockets.clear()
+    const toClose = server
+    server = null
+    if (toClose !== null) {
+      await new Promise<void>((resolve) => toClose.close(() => resolve()))
+    }
+  })
+
+  test('aborts a stalled request with GraphDbRequestTimeoutError within the bound', async () => {
+    // Handler that accepts the request but never responds.
+    const baseUrl = await startServer(() => {})
+    const request = createRequest(baseUrl)
+
+    const startedAt = Date.now()
+    const error = await request('/project', {
+      method: 'GET',
+      timeoutMs: 150,
+      responseSchema: UnknownResponseSchema,
+    }).then(
+      () => {
+        throw new Error('expected the stalled request to reject, but it resolved')
+      },
+      (caught: unknown) => caught,
+    )
+    const elapsedMs = Date.now() - startedAt
+
+    expect(error).toBeInstanceOf(GraphDbRequestTimeoutError)
+    expect((error as GraphDbRequestTimeoutError).timeoutMs).toBe(150)
+    // The whole point: the call is bounded, not hung. Generous ceiling keeps
+    // CI green while still failing a regression back to an unbounded await.
+    expect(elapsedMs).toBeLessThan(2_000)
+  })
+
+  test('a prompt response resolves normally — the deadline never fires', async () => {
+    const baseUrl = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true }))
+    })
+    const request = createRequest(baseUrl)
+
+    const result = await request('/project', {
+      method: 'GET',
+      timeoutMs: 1_000,
+      responseSchema: UnknownResponseSchema,
+    })
+
+    expect(result).toEqual({ ok: true })
+  })
+})

--- a/packages/systems/vt-daemon/bin/vtd.ts
+++ b/packages/systems/vt-daemon/bin/vtd.ts
@@ -46,7 +46,6 @@
 // per-process surface, `--project` becomes optional. See
 // docs/daemon-first-architecture.md.
 
-import {existsSync} from 'node:fs'
 import {unlink} from 'node:fs/promises'
 import {dirname, join, resolve} from 'node:path'
 import {fileURLToPath} from 'node:url'
@@ -64,20 +63,17 @@ import type {McpToolBridges} from '@vt/vt-daemon/config/mcpBridges.ts'
 import {setCurrentProject} from '@vt/vt-daemon/state/currentProject.ts'
 import {buildDefaultToolCatalog} from '@vt/vt-daemon/transport/toolCatalog.ts'
 import {handleHookEventRequest} from '@vt/vt-daemon/hooks/hookEventHandler.ts'
-import {registerChildIfMonitored} from '@vt/vt-daemon/agent-runtime/agent-control/agent-completion-monitor.ts'
 import {startOtlpReceiver, stopOtlpReceiver} from '@vt/vt-daemon/observability/otlpReceiver.ts'
 import {terminalRuntimeSurface as agentRuntime} from '@vt/vt-daemon/agent-runtime/agent-control/terminalRuntimeSurface.ts'
-import {configureAgentRuntime} from '@vt/vt-daemon/agent-runtime/runtime/runtime-config.ts'
-import {resolveVtBinDir} from '@vt/vt-daemon/agent-runtime/spawn/injection/vtPathInjection.ts'
 import {ensureHomePrompts} from '@vt/vt-daemon/agent-runtime/spawn/ensureHomePrompts.ts'
 import {reconcileTmuxHeadlessAgents} from '@vt/vt-daemon/agent-runtime/headless/headlessAgentManager.ts'
 import {buildGdbGraphBridge} from '../src/config/gdbGraphBridge.ts'
 import {buildGdbAgentRuntimeGraphBridge} from '../src/config/gdbAgentRuntimeBridge.ts'
-import type {GraphStateBridge} from '@vt/vt-daemon/agent-runtime/runtime/runtime-config.ts'
 import {
-    TERMINAL_REGISTRY_TOPIC,
-    type TerminalRegistryEvent,
-} from '@vt/vt-daemon-protocol'
+    buildPublishTerminalRegistryEvent,
+    configureAgentRuntimeForVtd,
+} from '../src/config/vtdAgentRuntimeWiring.ts'
+import {TERMINAL_REGISTRY_TOPIC} from '@vt/vt-daemon-protocol'
 import {generateAuthToken, rpcPortFilePath, writeAuthTokenFile, writeRpcPortFile} from '@vt/vt-rpc'
 import {VTD_CONTRACT_VERSION, type VtDaemonHealthResponse} from '../src/contract.ts'
 import {buildVtDaemonHealthResponse} from '../src/lifecycle/buildHealthResponse.ts'
@@ -181,57 +177,6 @@ function resolveVoicetreeCliPackageDir(): string {
     return join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'voicetree-cli')
 }
 
-function configureAgentRuntimeForVtd(
-    publishTerminalRegistryEvent: (event: TerminalRegistryEvent) => void,
-    graph: GraphStateBridge,
-): void {
-    // The `vt` binary is shipped inside @voicetree/cli. The CLI manual is
-    // rendered live from @vt/vt-daemon-protocol's TOOL_SPECS — no longer
-    // file-based — so vtd no longer needs to register a manual path.
-    const voicetreeCliPackageDir: string = resolveVoicetreeCliPackageDir()
-    // `vt` lives at <voicetree-cli>/bin/vt. resolveVtBinDir verifies the
-    // script exists and returns null otherwise — the spawn pipeline's
-    // PATH injection then no-ops gracefully.
-    const vtBinDir: string | null = resolveVtBinDir(voicetreeCliPackageDir, existsSync)
-
-    configureAgentRuntime({
-        env: {
-            getVtBinDir: (): string | null => vtBinDir,
-        },
-        publishTerminalRegistryEvent,
-        graph,
-    })
-}
-
-/**
- * Build the publish sink injected into agent-runtime. Two concerns fan out
- * from a single event:
- *
- *   1. Wire publish onto the new `terminal-registry` SSE topic so renderer
- *      clients learn about registry mutations and the imperative UI-launch
- *      instructions that used to fire as in-process UI callbacks.
- *   2. In-process side effect for `terminal-ui-child-registered`: VTD owns
- *      the agent-completion monitor (`@vt/vt-daemon`'s
- *      `registerChildIfMonitored`); when a spawn announces a new child of a
- *      monitored parent, the monitor's terminal-id table must learn about
- *      it before the child's first poll. Pre-S2-R this happened through an
- *      in-process callback; that callback is gone, so we route the same
- *      data through the publish sink instead.
- *
- * The sink is the canonical place to do both because it sits at the boundary
- * where every event passes through exactly once.
- */
-function buildPublishTerminalRegistryEvent(
-    publishOnTopic: (event: string, data: unknown) => void,
-): (event: TerminalRegistryEvent) => void {
-    return (event: TerminalRegistryEvent): void => {
-        publishOnTopic(event.type, event)
-        if (event.type === 'terminal-ui-child-registered') {
-            registerChildIfMonitored(event.parentTerminalId, event.childTerminalId)
-        }
-    }
-}
-
 async function main(): Promise<void> {
     tracing.init('vtd')
     const args: Args = parseArgs(process.argv.slice(2))
@@ -270,10 +215,17 @@ async function main(): Promise<void> {
     // `VT_GRAPHD_BIN` is honored as an override (used by tests pointing at a
     // fake vt-graphd; also useful in dev to point at a freshly built binary).
     // Mirrors `ensureDaemon` in @vt/graph-db-client.
+    // Budget parity (startup-hang fix): electron waits up to 30s for THIS VTD to
+    // report healthy, and VTD reports healthy only after this graphd-ensure
+    // resolves. Graphd's 5s default here is a budget inversion — a slow-but-
+    // healthy graphd would `die()` VTD at 5s while electron would have waited,
+    // leaving the renderer spinning on "loading workspace". Match electron's 30s.
+    const GRAPHD_ENSURE_TIMEOUT_MS = 30_000
     let gdb: EnsureGraphDaemonResult
     try {
         gdb = await ensureGraphDaemonForProject(args.project, 'vtd', {
             bin: process.env.VT_GRAPHD_BIN,
+            timeoutMs: GRAPHD_ENSURE_TIMEOUT_MS,
         })
     } catch (err) {
         await ownerHandle.release().catch(() => undefined)
@@ -392,6 +344,7 @@ async function main(): Promise<void> {
     // Both must be wired or the spawn pipeline throws "graph bridge not configured"
     // on the first Run-Agent click.
     configureAgentRuntimeForVtd(
+        resolveVoicetreeCliPackageDir(),
         buildPublishTerminalRegistryEvent(
             (event: string, data: unknown): void =>
                 httpHandle.hub.publish(TERMINAL_REGISTRY_TOPIC, event, data),

--- a/packages/systems/vt-daemon/src/config/vtdAgentRuntimeWiring.ts
+++ b/packages/systems/vt-daemon/src/config/vtdAgentRuntimeWiring.ts
@@ -1,0 +1,69 @@
+// vtd's agent-runtime wiring helpers, extracted from `bin/vtd.ts` to keep the
+// daemon entrypoint within the file-size budget. Two cohesive concerns:
+//   - configureAgentRuntimeForVtd: resolve the `vt` bin dir from the CLI
+//     package dir and hand the agent-runtime its env + publish + graph wiring.
+//   - buildPublishTerminalRegistryEvent: the single publish sink that fans a
+//     terminal-registry event onto the SSE topic AND the in-process
+//     completion-monitor side channel.
+//
+// `resolveVoicetreeCliPackageDir` deliberately stays in `bin/vtd.ts`: it is
+// `import.meta.url`-relative and must resolve against the binary's on-disk
+// location, so the caller passes the already-resolved dir in here.
+
+import {existsSync} from 'node:fs'
+import type {TerminalRegistryEvent} from '@vt/vt-daemon-protocol'
+import {registerChildIfMonitored} from '../agent-runtime/agent-control/agent-completion-monitor.ts'
+import {configureAgentRuntime, type GraphStateBridge} from '../agent-runtime/runtime/runtime-config.ts'
+import {resolveVtBinDir} from '../agent-runtime/spawn/injection/vtPathInjection.ts'
+
+/**
+ * Configure the agent-runtime for a VTD process. `voicetreeCliPackageDir` is
+ * the resolved `@voicetree/cli` package dir; `vt` lives at
+ * `<voicetree-cli>/bin/vt`. `resolveVtBinDir` verifies the script exists and
+ * returns null otherwise — the spawn pipeline's PATH injection then no-ops
+ * gracefully. The CLI manual is rendered live from @vt/vt-daemon-protocol's
+ * TOOL_SPECS, so vtd no longer needs to register a manual path.
+ */
+export function configureAgentRuntimeForVtd(
+    voicetreeCliPackageDir: string,
+    publishTerminalRegistryEvent: (event: TerminalRegistryEvent) => void,
+    graph: GraphStateBridge,
+): void {
+    const vtBinDir: string | null = resolveVtBinDir(voicetreeCliPackageDir, existsSync)
+
+    configureAgentRuntime({
+        env: {
+            getVtBinDir: (): string | null => vtBinDir,
+        },
+        publishTerminalRegistryEvent,
+        graph,
+    })
+}
+
+/**
+ * Build the publish sink injected into agent-runtime. Two concerns fan out
+ * from a single event:
+ *
+ *   1. Wire publish onto the new `terminal-registry` SSE topic so renderer
+ *      clients learn about registry mutations and the imperative UI-launch
+ *      instructions that used to fire as in-process UI callbacks.
+ *   2. In-process side effect for `terminal-ui-child-registered`: VTD owns
+ *      the agent-completion monitor (`registerChildIfMonitored`); when a spawn
+ *      announces a new child of a monitored parent, the monitor's terminal-id
+ *      table must learn about it before the child's first poll. Pre-S2-R this
+ *      happened through an in-process callback; that callback is gone, so we
+ *      route the same data through the publish sink instead.
+ *
+ * The sink is the canonical place to do both because it sits at the boundary
+ * where every event passes through exactly once.
+ */
+export function buildPublishTerminalRegistryEvent(
+    publishOnTopic: (event: string, data: unknown) => void,
+): (event: TerminalRegistryEvent) => void {
+    return (event: TerminalRegistryEvent): void => {
+        publishOnTopic(event.type, event)
+        if (event.type === 'terminal-ui-child-registered') {
+            registerChildIfMonitored(event.parentTerminalId, event.childTerminalId)
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -121,11 +121,11 @@ Capture ideas hands-free with speech-to-graph.
 
 ## Development
 
-**Prerequisites:** Node.js 18+, Python 3.13, uv
+**Prerequisites:** Node.js 18+, pnpm 10 (`corepack enable`), Python 3.13, uv
 
 ```bash
-cd webapp && npm install && npm run electron  # App
-uv sync && uv run pytest                               # Backend
+pnpm install && pnpm --filter voicetree-webapp run electron  # App (run from repo root)
+uv sync && uv run pytest                                     # Backend
 ```
 
 ## License


### PR DESCRIPTION
Investigates the two reported startup problems on the home-screen project-open path (task `node_yipu3o`): (1) it's slow the first time, and (2) it occasionally hangs forever on "loading workspace".

## Concern #2 — the intermittent hang (FIXED — two independent root causes)

| Mechanism | Severity | Fix |
|---|---|---|
| A graphd RPC accepted at the socket but never answered → `GraphDbClient` had **no request timeout** → the `await` hangs **forever** | truly infinite ("never works, must refresh") | `1accd2542` — `AbortController` timeout on every graphd request → bounded `GraphDbRequestTimeoutError` |
| VTD ensures its graphd sibling with a **5s** budget but electron waits **30s** for VTD — a budget inversion; a slow-but-healthy graphd kills VTD at 5s → electron spins on a dead VTD | bounded ~30s then error | `e87ee1524` — give VTD's graphd-ensure a 30s budget |

A is the truly-infinite match for the reported symptom; B is a related fragility hardened by construction. Could not reproduce the rare hang live → root-cause-by-analysis. Both fixes type-check clean; A is covered by a new black-box test.

## Concern #1 — cold open is slow (root-caused; quick fix attempted then **reverted**)

Root cause (measured): cold open serializes **two** daemon boots — `bindVtDaemonForProject` spawns VTD, and VTD adopts-or-spawns vt-graphd *inside its own startup*, so graphd's ~378ms cold boot stacks **after** VTD's ~0.6s tsx boot. (~1.0s of the ~1.78s is inherent dev-mode tsx process startup, paid twice; the markdown parse is negligible — project size is not the cause.)

A concurrent-graphd-prewarm (electron pre-spawns graphd during the VTD bind, ~21% win) was implemented and **reverted in this PR**: CI's electron cold-open smoke test caught that **electron-main can't reliably spawn graphd** (the `build-config.ts:149` Electron-PATH limitation), and the prewarm **inverts a dependency** — VTD's health would then wait on electron's graphd spawn instead of spawning its own. That's a structural fragility increase in the critical open path, not worth ~21%. The robust lever is **precompiling the daemons** (attacks the ~1.0s inherent tsx boot, paid in both GUI *and* headless) — left as a separate follow-up.

## What's in this PR
Just the two hang fixes (`1accd2542`, `e87ee1524`) — clean, orthogonal, and they fix the painful symptom. The prewarm investigation + reasoning is recorded in the progress graph.

## Verification
- `tsc --noEmit`: 0 errors.
- `vitest` daemon-lifecycle dir: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)