### PR TITLE
perf: low-hanging-fruit runtime wins across 5 subsystems (12 no-downside fixes)

### DIFF
--- a/backend/markdown_tree_manager/markdown_to_tree/comprehensive_parser.py
+++ b/backend/markdown_tree_manager/markdown_to_tree/comprehensive_parser.py
@@ -16,16 +16,9 @@ from backend.types import (
     ParsedNode,
     ParsedNodeKeys,
     ParsedRelationships,
-    ParentRelationship,
     RelationshipKeys,
 )
 
-from backend.markdown_tree_manager.markdown_to_tree.file_operations import (
-    read_markdown_file,
-)
-from backend.markdown_tree_manager.markdown_to_tree.link_extraction import (
-    extract_markdown_links,
-)
 from backend.markdown_tree_manager.markdown_to_tree.metadata_extraction import (
     extract_node_id,
 )
@@ -35,20 +28,22 @@ from backend.markdown_tree_manager.markdown_to_tree.yaml_parser import (
 from backend.markdown_tree_manager.markdown_to_tree.yaml_parser import extract_tags
 
 
-def parse_markdown_file_complete(filepath: Path) -> Optional[ParsedNode]:
+def parse_markdown_file_complete(filepath: Path, content: str) -> Optional[ParsedNode]:
     """
-    Completely parse a markdown file extracting all metadata and content.
+    Completely parse already-read markdown content extracting all metadata.
+
+    Content is supplied by the caller (read once) rather than read here, so the
+    same content can be reused for relationship parsing without a second disk read.
 
     Args:
-        filepath: Path to the markdown file
+        filepath: Path to the markdown file (used for filename and mtime/ctime fallback)
+        content: Raw markdown file content
 
     Returns:
         Dictionary with all parsed data including:
         - node_id, title, summary, content
         - tags, created_at, modified_at, color
-        - links, parent_info
     """
-    content = read_markdown_file(filepath)
     if not content:
         return None
 
@@ -90,12 +85,6 @@ def parse_markdown_file_complete(filepath: Path) -> Optional[ParsedNode]:
     if isinstance(modified_at, str):
         modified_at = datetime.fromisoformat(modified_at)
 
-    # Extract links
-    links = extract_markdown_links(content)
-
-    # Parse parent relationship from Links section
-    parent_info = extract_parent_relationship(content) # DEPRECATED
-
     return {
         ParsedNodeKeys.NODE_ID: node_id,
         ParsedNodeKeys.TITLE: title,
@@ -105,8 +94,6 @@ def parse_markdown_file_complete(filepath: Path) -> Optional[ParsedNode]:
         ParsedNodeKeys.CREATED_AT: created_at,
         ParsedNodeKeys.MODIFIED_AT: modified_at,
         ParsedNodeKeys.COLOR: metadata.get('color'),
-        ParsedNodeKeys.LINKS: links,
-        ParsedNodeKeys.PARENT_INFO: parent_info,
         ParsedNodeKeys.FILENAME: filepath.name
     }
 
@@ -156,35 +143,6 @@ def extract_title_summary_and_content(markdown_content: str) -> tuple[str, str, 
     content = '\n'.join(content_lines).strip()
 
     return title, summary, content
-
-
-def extract_parent_relationship(content: str) -> Optional[ParentRelationship]:
-    """
-    Extract parent relationship from the Links section.
-
-    Args:
-        content: Full markdown content
-
-    Returns:
-        Dictionary with parent_filename and relationship_type, or None
-    """
-    links_match = re.search(r'_Links:_\s*\n(.*?)(?:\n\n|$)', content, re.DOTALL)
-    if not links_match:
-        return None
-
-    links_content = links_match.group(1)
-
-    # Parse parent relationship
-    parent_match = re.search(r'Parent:\s*\n.*?-\s*(.+?)\s*\[\[(.*?)\]\]', links_content)
-    if parent_match:
-        relationship_type = parent_match.group(1).strip()
-        parent_filename = parent_match.group(2).strip()
-        return {
-            RelationshipKeys.PARENT_FILENAME: parent_filename,
-            RelationshipKeys.RELATIONSHIP_TYPE: relationship_type.replace('_', ' ')
-        }
-
-    return None
 
 
 def parse_relationships_from_links(content: str) -> ParsedRelationships:

--- a/backend/markdown_tree_manager/markdown_to_tree/markdown_to_tree.py
+++ b/backend/markdown_tree_manager/markdown_to_tree/markdown_to_tree.py
@@ -9,9 +9,12 @@ from backend.markdown_tree_manager.markdown_to_tree.comprehensive_parser import 
 from backend.markdown_tree_manager.markdown_to_tree.comprehensive_parser import (
     parse_relationships_from_links,
 )
+from backend.markdown_tree_manager.markdown_to_tree.file_operations import (
+    read_markdown_file,
+)
 from backend.markdown_tree_manager.markdown_tree_ds import MarkdownTree
 from backend.markdown_tree_manager.markdown_tree_ds import Node
-from backend.types import ParsedNodeKeys, RelationshipKeys
+from backend.types import ParsedNodeKeys, ParsedRelationships, RelationshipKeys
 
 
 class MarkdownToTreeConverter:
@@ -64,26 +67,25 @@ class MarkdownToTreeConverter:
         if not os.path.exists(markdown_dir):
             raise ValueError(f"Markdown directory does not exist: {markdown_dir}")
 
-        # First pass: Load all nodes and build filename mapping (recursively scan subfolders)
+        # First pass: Load all nodes and build filename mapping (recursively scan subfolders).
+        # Each file is read from disk exactly once; its content is reused for both node
+        # parsing and relationship parsing (resolved in the second pass below).
         markdown_dir_path = Path(markdown_dir)
         all_md_files = list(markdown_dir_path.rglob('*.md'))
         # Filter out excluded directories
         markdown_files = [f for f in all_md_files if not self._should_exclude_path(f, markdown_dir_path)]
 
+        relationships_by_path: dict[str, ParsedRelationships] = {}
         next_generated_id = 1
         for filepath in markdown_files:
             # Use relative path from markdown_dir as the filename
             relative_path = str(filepath.relative_to(markdown_dir_path))
             try:
-                node = self._parse_markdown_file(str(filepath), relative_path)
+                content = read_markdown_file(filepath)
+                node = self._build_node_from_content(filepath, relative_path, content)
                 if node:
-                    # Assign integer ID if node has None ID (no node_id in frontmatter)
-                    # if node.id is None:
                     node.id = next_generated_id
                     next_generated_id += 1
-                    # elif isinstance(node.id, int):
-                    #     Track max to avoid collisions with generated IDs
-                        # next_generated_id = max(next_generated_id, node.id + 1)
 
                     self.tree_data[node.id] = node
                     self.filename_to_node_id[relative_path] = node.id
@@ -91,14 +93,15 @@ class MarkdownToTreeConverter:
                     basename = filepath.name
                     if basename not in self._basename_to_relative_path:
                         self._basename_to_relative_path[basename] = relative_path
+                    # Parse relationships from the same content (resolved in second pass)
+                    relationships_by_path[relative_path] = parse_relationships_from_links(content)
             except Exception as e:
                 logging.error(f"Error parsing file {relative_path}: {e}")
 
-        # Second pass: Resolve relationships
-        for filepath in markdown_files:
-            relative_path = str(filepath.relative_to(markdown_dir_path))
+        # Second pass: Resolve relationships using the already-parsed link data
+        for relative_path, relationships in relationships_by_path.items():
             try:
-                self._parse_relationships(str(filepath), relative_path)
+                self._apply_relationships(relative_path, relationships)
             except Exception as e:
                 logging.error(f"Error parsing relationships in {relative_path}: {e}")
 
@@ -107,8 +110,7 @@ class MarkdownToTreeConverter:
 
     def _parse_markdown_file(self, filepath: str, filename: str) -> Optional[Node]:
         """
-        Parse a single markdown file to extract node data.
-        This is now a thin wrapper around the comprehensive parser.
+        Parse a single markdown file to extract node data (reads the file once).
 
         Args:
             filepath: Full path to the markdown file
@@ -117,8 +119,22 @@ class MarkdownToTreeConverter:
         Returns:
             Node object or None if parsing fails
         """
-        # Use the comprehensive parser from the module
-        parsed_data = parse_markdown_file_complete(Path(filepath))
+        path = Path(filepath)
+        return self._build_node_from_content(path, filename, read_markdown_file(path))
+
+    def _build_node_from_content(self, filepath: Path, filename: str, content: str) -> Optional[Node]:
+        """
+        Build a Node from already-read markdown content (no disk read).
+
+        Args:
+            filepath: Path to the markdown file (used for filename/mtime fallback)
+            filename: Relative filename to assign to the node
+            content: Raw markdown content
+
+        Returns:
+            Node object or None if parsing fails
+        """
+        parsed_data = parse_markdown_file_complete(filepath, content)
         if not parsed_data:
             logging.warning(f"Could not parse file {filename}")
             return None
@@ -145,30 +161,22 @@ class MarkdownToTreeConverter:
         return node
 
 
-    def _parse_relationships(self, filepath: str, filename: str) -> None:
-
-        # this new method looks super sus. can't we just set
-
+    def _apply_relationships(self, filename: str, relationships: ParsedRelationships) -> None:
         """
-        Parse relationships from the Links section of markdown file.
-        This is now a thin wrapper around the module's relationship parser.
+        Wire up parent/child relationships parsed from a node's Links section.
+
+        Relationships are parsed once (from the content read in the first pass) and
+        applied here, after all nodes and the filename->id mapping are built.
 
         Args:
-            filepath: Full path to the markdown file
-            filename: Name of the file
+            filename: Relative filename of the node whose relationships to apply
+            relationships: Parsed relationships from the node's Links section
         """
         if filename not in self.filename_to_node_id:
             return
 
         node_id = self.filename_to_node_id[filename]
         node = self.tree_data[node_id]
-
-        # Read the file content
-        with open(filepath, encoding='utf-8') as f:
-            content = f.read()
-
-        # Use the module's relationship parser
-        relationships = parse_relationships_from_links(content)
 
         # Process parent relationship
         if relationships[RelationshipKeys.PARENT]:

--- a/backend/types.py
+++ b/backend/types.py
@@ -119,8 +119,6 @@ class ParsedNode(TypedDict):
     created_at: datetime
     modified_at: datetime
     color: Optional[str]
-    links: List[str]
-    parent_info: Optional[ParentRelationship]
     filename: str
 
 
@@ -140,8 +138,6 @@ class ParsedNodeKeys:
     CREATED_AT = "created_at"
     MODIFIED_AT = "modified_at"
     COLOR = "color"
-    LINKS = "links"
-    PARENT_INFO = "parent_info"
     FILENAME = "filename"
 
 

--- a/packages/libraries/graph-model/src/pure/graph/graph-operations/indexes/incomingEdgesIndex.test.ts
+++ b/packages/libraries/graph-model/src/pure/graph/graph-operations/indexes/incomingEdgesIndex.test.ts
@@ -145,6 +145,23 @@ describe('incomingEdgesIndex', () => {
       // 'd' should have 'a' as incomer
       expect(newIndex.get('d')).toEqual(['a'])
     })
+
+    it('should not mutate the input index (returns an independent copy)', () => {
+      // Initial: a -> c, b -> c
+      const cIncomers: readonly NodeIdAndFilePath[] = ['a', 'b']
+      const index: IncomingEdgesIndex = new Map([['c', cIncomers]])
+
+      const previousNode: GraphNode = createTestNode('a', [{ targetId: 'c', label: '' }])
+      // Updated: a -> d (a no longer points to c)
+      const newNode: GraphNode = createTestNode('a', [{ targetId: 'd', label: '' }])
+
+      updateIndexForUpsert(index, newNode, O.some(previousNode))
+
+      // The original index and its value arrays must be untouched (shallow-copy correctness).
+      expect(index.get('c')).toEqual(['a', 'b'])
+      expect(cIncomers).toEqual(['a', 'b'])
+      expect(index.has('d')).toBe(false)
+    })
   })
 
   describe('updateIndexForDelete', () => {

--- a/packages/libraries/graph-model/src/pure/graph/graph-operations/indexes/incomingEdgesIndex.ts
+++ b/packages/libraries/graph-model/src/pure/graph/graph-operations/indexes/incomingEdgesIndex.ts
@@ -50,9 +50,11 @@ export function updateIndexForUpsert(
 ): IncomingEdgesIndex {
   const nodeId: NodeIdAndFilePath = node.absoluteFilePathIsID
 
-  // Defensive: handle undefined index
-  const indexEntries: readonly (readonly [NodeIdAndFilePath, readonly NodeIdAndFilePath[]])[] =
-    index ? Array.from(index.entries()) : []
+  // Shallow-copy the index. Value arrays are immutable: every mutation below replaces an
+  // entry with a freshly-allocated array (filter/spread), never mutating one in place, so
+  // sharing the untouched arrays with the previous index is safe. This avoids cloning every
+  // entry's array on each delta (this runs on every node upsert). `index ?? []` keeps the
+  // prior defensive behaviour of treating a missing index as empty.
 
   // Step 1: Remove old references if this is an update
   const indexAfterRemovals: Map<NodeIdAndFilePath, readonly NodeIdAndFilePath[]> = O.isSome(previousNode)
@@ -70,9 +72,9 @@ export function updateIndexForUpsert(
           }
           return acc
         },
-        new Map(indexEntries.map(([k, v]) => [k, [...v]]))
+        new Map(index ?? [])
       )
-    : new Map(indexEntries.map(([k, v]) => [k, [...v]]))
+    : new Map(index ?? [])
 
   // Step 2: Add new references
   return node.outgoingEdges.reduce<Map<NodeIdAndFilePath, readonly NodeIdAndFilePath[]>>(
@@ -101,9 +103,8 @@ export function updateIndexForDelete(
 ): IncomingEdgesIndex {
   const deletedNodeId: NodeIdAndFilePath = deletedNode.absoluteFilePathIsID
 
-  // Defensive: handle undefined index
-  const indexEntries: readonly (readonly [NodeIdAndFilePath, readonly NodeIdAndFilePath[]])[] =
-    index ? Array.from(index.entries()) : []
+  // Shallow-copy the index (see updateIndexForUpsert): value arrays are immutable, so the
+  // untouched arrays can be shared with the previous index instead of cloned per entry.
 
   // Step 1: Remove references from this node's outgoing edges
   const indexAfterEdgeRemovals: Map<NodeIdAndFilePath, readonly NodeIdAndFilePath[]> =
@@ -121,7 +122,7 @@ export function updateIndexForDelete(
         }
         return acc
       },
-      new Map(indexEntries.map(([k, v]) => [k, [...v]]))
+      new Map(index ?? [])
     )
 
   // Step 2: Also remove the deleted node's own entry (nodes pointing to it)

--- a/packages/libraries/graph-model/src/pure/graph/graph-operations/indexes/linkResolutionIndexes.test.ts
+++ b/packages/libraries/graph-model/src/pure/graph/graph-operations/indexes/linkResolutionIndexes.test.ts
@@ -167,6 +167,20 @@ describe('nodeByBaseNameIndex', () => {
       expect(fooNodes).toContain('/project/a/foo.md')
       expect(fooNodes).toContain('/project/b/foo.md')
     })
+
+    it('should not mutate the input index when adding to a colliding basename', () => {
+      // The updater shallow-copies the index and shares value arrays; adding a colliding
+      // entry must replace the array, not push into the shared original.
+      const fooNodes: readonly NodeIdAndFilePath[] = ['/project/a/foo.md']
+      const index: NodeByBaseNameIndex = new Map([['foo', fooNodes]])
+      const newNode: GraphNode = createTestNode('/project/b/foo.md')
+
+      updateNodeByBaseNameIndexForUpsert(index, newNode, O.none)
+
+      // Original index and its array must be untouched (shallow-copy correctness).
+      expect(index.get('foo')).toEqual(['/project/a/foo.md'])
+      expect(fooNodes).toEqual(['/project/a/foo.md'])
+    })
   })
 
   describe('updateNodeByBaseNameIndexForDelete', () => {

--- a/packages/libraries/graph-model/src/pure/graph/graph-operations/indexes/linkResolutionIndexes.ts
+++ b/packages/libraries/graph-model/src/pure/graph/graph-operations/indexes/linkResolutionIndexes.ts
@@ -33,39 +33,40 @@ export function getBaseName(path: string): string {
 }
 
 /**
- * Mutable helper: add a nodeId to a basename entry in-place. O(1) via Map.get/set.
- * Operates on mutable Map copy — callers create the copy, this mutates it.
+ * Copy-on-write helper: add a nodeId to a basename entry by replacing its array. O(1) Map ops.
+ * Never mutates an existing array in place, so the map may safely share value arrays with a
+ * previous index (see mutableCopy). Operates on the caller's owned Map copy.
  */
 function addToIndex(
-  map: Map<string, NodeIdAndFilePath[]>,
+  map: Map<string, readonly NodeIdAndFilePath[]>,
   basename: string,
   nodeId: NodeIdAndFilePath
 ): void {
   if (basename === '') return
 
-  const existing: NodeIdAndFilePath[] | undefined = map.get(basename)
+  const existing: readonly NodeIdAndFilePath[] | undefined = map.get(basename)
   if (existing) {
-    if (!existing.includes(nodeId)) existing.push(nodeId)
+    if (!existing.includes(nodeId)) map.set(basename, [...existing, nodeId])
   } else {
     map.set(basename, [nodeId])
   }
 }
 
 /**
- * Mutable helper: remove a nodeId from a basename entry in-place. O(1) via Map.get/set/delete.
- * Operates on mutable Map copy — callers create the copy, this mutates it.
+ * Copy-on-write helper: remove a nodeId from a basename entry by replacing/deleting its array.
+ * O(1) Map ops. Never mutates an existing array in place (filter allocates a new one).
  */
 function removeFromIndex(
-  map: Map<string, NodeIdAndFilePath[]>,
+  map: Map<string, readonly NodeIdAndFilePath[]>,
   basename: string,
   nodeId: NodeIdAndFilePath
 ): void {
   if (basename === '') return
 
-  const existing: NodeIdAndFilePath[] | undefined = map.get(basename)
+  const existing: readonly NodeIdAndFilePath[] | undefined = map.get(basename)
   if (!existing) return
 
-  const filtered: NodeIdAndFilePath[] = existing.filter(id => id !== nodeId)
+  const filtered: readonly NodeIdAndFilePath[] = existing.filter(id => id !== nodeId)
   if (filtered.length === 0) {
     map.delete(basename)
   } else {
@@ -77,7 +78,7 @@ function removeFromIndex(
  * Mutable helper: remove an entire basename key in-place. O(1) via Map.delete.
  */
 function removeKey(
-  map: Map<string, NodeIdAndFilePath[]>,
+  map: Map<string, readonly NodeIdAndFilePath[]>,
   basename: string
 ): void {
   if (basename === '') return
@@ -85,12 +86,14 @@ function removeKey(
 }
 
 /**
- * Create a mutable deep copy of a ReadonlyMap index.
- * Each value array is shallow-copied so mutations don't affect the original.
+ * Shallow-copy a ReadonlyMap index into a mutable Map. Value arrays are shared, not cloned:
+ * every mutator (addToIndex/removeFromIndex/removeKey) replaces or deletes a whole entry rather
+ * than mutating its array in place, so the original index is never affected. This avoids cloning
+ * every value array on each delta (these updaters run on every node upsert/delete).
+ * `index ?? []` keeps the prior behaviour of treating a missing index as empty.
  */
-function mutableCopy(index: NodeByBaseNameIndex | UnresolvedLinksIndex | undefined): Map<string, NodeIdAndFilePath[]> {
-  if (!index) return new Map()
-  return new Map(Array.from(index.entries()).map(([k, v]) => [k, [...v]] as [string, NodeIdAndFilePath[]]))
+function mutableCopy(index: NodeByBaseNameIndex | UnresolvedLinksIndex | undefined): Map<string, readonly NodeIdAndFilePath[]> {
+  return new Map(index ?? [])
 }
 
 /**
@@ -102,7 +105,7 @@ function mutableCopy(index: NodeByBaseNameIndex | UnresolvedLinksIndex | undefin
 export function buildNodeByBaseNameIndex(
   nodes: Record<NodeIdAndFilePath, GraphNode>
 ): NodeByBaseNameIndex {
-  const map: Map<string, NodeIdAndFilePath[]> = new Map()
+  const map: Map<string, readonly NodeIdAndFilePath[]> = new Map()
 
   Object.keys(nodes).forEach(nodeId => {
     addToIndex(map, getBaseName(nodeId), nodeId)
@@ -122,7 +125,7 @@ export function buildNodeByBaseNameIndex(
 export function buildUnresolvedLinksIndex(
   nodes: Record<NodeIdAndFilePath, GraphNode>
 ): UnresolvedLinksIndex {
-  const map: Map<string, NodeIdAndFilePath[]> = new Map()
+  const map: Map<string, readonly NodeIdAndFilePath[]> = new Map()
 
   Object.entries(nodes).forEach(([nodeId, node]) => {
     node.outgoingEdges
@@ -146,7 +149,7 @@ export function updateNodeByBaseNameIndexForUpsert(
   const nodeId: NodeIdAndFilePath = node.absoluteFilePathIsID
   const newBasename: string = getBaseName(nodeId)
 
-  const map: Map<string, NodeIdAndFilePath[]> = mutableCopy(index)
+  const map: Map<string, readonly NodeIdAndFilePath[]> = mutableCopy(index)
 
   // If update, remove old entry if basename changed
   if (O.isSome(previousNode)) {
@@ -175,7 +178,7 @@ export function updateNodeByBaseNameIndexForDelete(
   if (!index) return new Map()
   if (basename === '') return index
 
-  const map: Map<string, NodeIdAndFilePath[]> = mutableCopy(index)
+  const map: Map<string, readonly NodeIdAndFilePath[]> = mutableCopy(index)
   removeFromIndex(map, basename, deletedNodeId)
 
   return map
@@ -198,7 +201,7 @@ export function updateUnresolvedLinksIndexForUpsert(
   const nodeId: NodeIdAndFilePath = node.absoluteFilePathIsID
   const nodeBasename: string = getBaseName(nodeId)
 
-  const map: Map<string, NodeIdAndFilePath[]> = mutableCopy(index)
+  const map: Map<string, readonly NodeIdAndFilePath[]> = mutableCopy(index)
 
   // Step 1: If this is an update, remove old unresolved links from this node
   if (O.isSome(previousNode)) {
@@ -235,7 +238,7 @@ export function updateUnresolvedLinksIndexForDelete(
   const deletedNodeId: NodeIdAndFilePath = deletedNode.absoluteFilePathIsID
   const deletedBasename: string = getBaseName(deletedNodeId)
 
-  const map: Map<string, NodeIdAndFilePath[]> = mutableCopy(index)
+  const map: Map<string, readonly NodeIdAndFilePath[]> = mutableCopy(index)
 
   // Step 1: Remove deleted node from any unresolved link tracking
   deletedNode.outgoingEdges.forEach(edge => {

--- a/packages/libraries/graph-model/src/pure/graph/graph-operations/traversal/getSubgraphByDistance.ts
+++ b/packages/libraries/graph-model/src/pure/graph/graph-operations/traversal/getSubgraphByDistance.ts
@@ -76,56 +76,46 @@ export function getSubgraphByDistance(
   return createGraph(filteredNodes)
 }
 
-type DfsVisitFn = (
-  nodeId: NodeIdAndFilePath,
-  distance: number,
-  visited: ReadonlySet<NodeIdAndFilePath>
-) => ReadonlySet<NodeIdAndFilePath>
-
 /**
  * Pure DFS traversal without context node handling.
+ *
+ * `visited` is both the cycle/duplicate guard and the result: every node added is exactly
+ * the set returned. Accumulating into a single mutable Set keeps this O(V); the previous
+ * implementation threaded an immutable set and rebuilt it (`new Set([...visited, id])`) on
+ * every visit, which is O(V^2). DFS order and the first-reach distance semantics are
+ * unchanged — the per-edge `distance + cost < maxDistance` filter was constant across a
+ * node's edges, so it is equivalent to a single guard around each edge group.
  */
 function dfsTraversal(
   graph: Graph,
   startNodeId: NodeIdAndFilePath,
   maxDistance: number
 ): ReadonlySet<NodeIdAndFilePath> {
-  const processed: Set<NodeIdAndFilePath> = new Set()
+  const visited: Set<NodeIdAndFilePath> = new Set()
 
-  const dfsVisit: DfsVisitFn = (
-    nodeId: NodeIdAndFilePath,
-    distance: number,
-    visited: ReadonlySet<NodeIdAndFilePath>
-  ): ReadonlySet<NodeIdAndFilePath> => {
-    if (processed.has(nodeId) || !graph.nodes[nodeId]) {
-      return visited
+  const dfsVisit = (nodeId: NodeIdAndFilePath, distance: number): void => {
+    if (visited.has(nodeId) || !graph.nodes[nodeId]) {
+      return
     }
 
-    processed.add(nodeId)
+    visited.add(nodeId)
     const node: GraphNode = graph.nodes[nodeId]
-    const newVisited: ReadonlySet<NodeIdAndFilePath> = new Set([...visited, nodeId])
 
     // Explore outgoing edges (children) with cost 1.5
-    const afterChildren: ReadonlySet<NodeIdAndFilePath> = node.outgoingEdges
-      .filter(() => distance + 1.5 < maxDistance)
-      .reduce<ReadonlySet<NodeIdAndFilePath>>(
-        (acc, edge) => dfsVisit(edge.targetId, distance + 1.5, acc),
-        newVisited
-      )
+    if (distance + 1.5 < maxDistance) {
+      node.outgoingEdges.forEach(edge => dfsVisit(edge.targetId, distance + 1.5))
+    }
 
     // Explore incoming edges (parents) with cost 1.0
-    const incomingNodes: readonly GraphNode[] = getIncomingNodes(node, graph)
-    const afterParents: ReadonlySet<NodeIdAndFilePath> = incomingNodes
-      .filter(() => distance + 1.0 < maxDistance)
-      .reduce<ReadonlySet<NodeIdAndFilePath>>(
-        (acc, parentNode) => dfsVisit(parentNode.absoluteFilePathIsID, distance + 1.0, acc),
-        afterChildren
+    if (distance + 1.0 < maxDistance) {
+      getIncomingNodes(node, graph).forEach(parentNode =>
+        dfsVisit(parentNode.absoluteFilePathIsID, distance + 1.0)
       )
-
-    return afterParents
+    }
   }
 
-  return dfsVisit(startNodeId, 0, new Set())
+  dfsVisit(startNodeId, 0)
+  return visited
 }
 
 /**

--- a/packages/libraries/graph-state/src/project.ts
+++ b/packages/libraries/graph-state/src/project.ts
@@ -51,8 +51,10 @@ function filterByCollapse(
 
     const visibleFolderIds = new Set(visibleFolders.map((info) => info.id))
 
+    // Object.entries already returns a fresh array, so sort it in place directly — the prior
+    // identity .map (rewrapping each entry as a const tuple) allocated N tuples + an array per
+    // projection purely to widen the static type, which the annotation already covers.
     const nodeEntries: Array<readonly [string, GraphNode]> = Object.entries<GraphNode>(graphNodes)
-        .map(([nodeId, node]) => [nodeId, node] as const)
         .sort(([left], [right]) => left.localeCompare(right))
         .filter(([, node]) => isProjectableGraphNode(node))
 

--- a/packages/systems/graph-db-server/src/application/core/graph/handleWritePositions.ts
+++ b/packages/systems/graph-db-server/src/application/core/graph/handleWritePositions.ts
@@ -39,27 +39,30 @@ export function graphWithUpdatedPositions(
   positions: GraphNodePositions,
 ): { graph: Graph; written: number } {
   let written = 0
-  const nodes: Record<string, GraphNode> = Object.entries(graph.nodes).reduce(
-    (acc: Record<string, GraphNode>, [nodeId, node]: [string, GraphNode]) => {
-      const position = positions[nodeId]
-      if (!position) {
-        return { ...acc, [nodeId]: node }
-      }
+  // Build the next nodes record in a single O(N) pass. The previous
+  // `reduce(..., { ...acc, [nodeId]: node })` spread the whole accumulator on
+  // every iteration, making this O(N^2) in the node count for every position
+  // write. Assigning into one fresh object is O(N) and preserves the exact
+  // semantics: unchanged nodes keep their original reference, only nodes with
+  // a supplied position are rebuilt, and `written` still counts graph nodes
+  // that received a position.
+  const nodes: Record<string, GraphNode> = {}
+  for (const [nodeId, node] of Object.entries(graph.nodes)) {
+    const position = positions[nodeId]
+    if (!position) {
+      nodes[nodeId] = node
+      continue
+    }
 
-      written += 1
-      return {
-        ...acc,
-        [nodeId]: {
-          ...node,
-          nodeUIMetadata: {
-            ...node.nodeUIMetadata,
-            position: O.some(position),
-          },
-        },
-      }
-    },
-    {},
-  )
+    written += 1
+    nodes[nodeId] = {
+      ...node,
+      nodeUIMetadata: {
+        ...node.nodeUIMetadata,
+        position: O.some(position),
+      },
+    }
+  }
 
   return {
     graph: {

--- a/packages/systems/graph-db-server/src/data/graph/mutations/applyGraphDelta.ts
+++ b/packages/systems/graph-db-server/src/data/graph/mutations/applyGraphDelta.ts
@@ -59,22 +59,30 @@ function commitGraphDeltaMemState(prepared: PreparedMemState): GraphDelta {
     setGraph(prepared.graph);
 
     // Fire onNewNode hook (fire-and-forget). Runs for both UI and FS-event paths.
-    // dispatchOnNewNodeHooks filters for UpsertNode with previousNode=None, so
-    // delete-only deltas (e.g. removeReadPath) are no-ops.
-    void loadSettings().then(settings => {
-        const hookPath: string | undefined = settings.hooks?.onNewNode
-        if (hookPath && !hookPath.startsWith('#')) {
-            const callbacks = getCallbacks()
-            if (callbacks.onNewNodeHook) {
-                // Dispatch for each new node upsert
-                for (const d of prepared.appliedDelta) {
-                    if (d.type === 'UpsertNode' && O.isNone(d.previousNode)) {
-                        callbacks.onNewNodeHook(d.nodeToUpsert.absoluteFilePathIsID, prepared.appliedDelta)
-                    }
+    // The hook only ever fires for brand-new node upserts (UpsertNode with
+    // previousNode=None) — the registered dispatcher itself filters to those, so
+    // delete-only and edit-only deltas are already no-ops. Gate the settings
+    // read on that condition FIRST: loadSettings() hits disk + parses on every
+    // call by design, and in steady state edits/deletes/position-writes vastly
+    // outnumber node creations, so reading settings on every commit just to
+    // discover there is nothing to dispatch is wasted per-mutation IO.
+    const introducesNewNode: boolean = prepared.appliedDelta.some(
+        d => d.type === 'UpsertNode' && O.isNone(d.previousNode),
+    )
+    if (introducesNewNode) {
+        void loadSettings().then(settings => {
+            const hookPath: string | undefined = settings.hooks?.onNewNode
+            if (!hookPath || hookPath.startsWith('#')) return
+            const onNewNodeHook = getCallbacks().onNewNodeHook
+            if (!onNewNodeHook) return
+            // Dispatch for each new node upsert
+            for (const d of prepared.appliedDelta) {
+                if (d.type === 'UpsertNode' && O.isNone(d.previousNode)) {
+                    onNewNodeHook(d.nodeToUpsert.absoluteFilePathIsID, prepared.appliedDelta)
                 }
             }
-        }
-    })
+        })
+    }
 
     return prepared.appliedDelta
 }

--- a/packages/systems/voicetree-cli/bin/vt
+++ b/packages/systems/voicetree-cli/bin/vt
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# When installed from npm (or `npm pack`'d), the published tarball ships
-# `dist/voicetree-cli.js` alongside this script — exec it directly.
-# When run from a monorepo checkout, `dist/` is gitignored and absent;
-# fall back to running the TS sources via tsx.
+# `vt` runs from one of two code sources, discriminated by `src/` presence:
+#   - Published tarball (`npm install` / `npm pack`): ships `dist/` + `bin/`
+#     but NO `src/` — exec the prebuilt bundle directly (no tsx needed).
+#   - Monorepo / dev checkout: `src/` is present and `dist/` is gitignored —
+#     ALWAYS run the live TS sources via tsx. A stale or stray `dist/` bundle
+#     must never shadow current source (a bundle built before an env-var
+#     rename once kept running the old name — this gate prevents that class).
 set -euo pipefail
 
 # Resolve symlinks to find the real location of this script
@@ -16,11 +19,12 @@ while [ -L "$_script" ]; do
 done
 PACKAGE_DIR="$(cd "$(dirname "$_script")/.." && pwd)"
 
-# Bundled path (published tarball): a single self-contained ESM bundle.
-# `VT_FORCE_SOURCE=1` skips the bundle and uses the tsx source path so
-# in-monorepo tests don't run against a stale or unrelated dist build.
+# Bundled path: trust the prebuilt bundle ONLY in a published install — i.e.
+# when `src/` is absent. In a monorepo checkout `src/` is always present, so a
+# stray `dist/voicetree-cli.js` (e.g. left by a manual `npm run build`) can
+# never shadow live source. `VT_FORCE_SOURCE=1` forces source regardless.
 BUNDLE="$PACKAGE_DIR/dist/voicetree-cli.js"
-if [ -z "${VT_FORCE_SOURCE:-}" ] && [ -f "$BUNDLE" ]; then
+if [ -z "${VT_FORCE_SOURCE:-}" ] && [ ! -d "$PACKAGE_DIR/src" ] && [ -f "$BUNDLE" ]; then
     exec node "$BUNDLE" "$@"
 fi
 

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/folder-handle/FolderHandleService.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/folder-handle/FolderHandleService.ts
@@ -136,6 +136,12 @@ interface ChipEntry {
     readonly el: HTMLDivElement;
     readonly chevronBtn: HTMLButtonElement;
     readonly eyeBtn: HTMLButtonElement;
+    /**
+     * Last-rendered chevron collapsed state. positionChip() runs on every
+     * pan/zoom frame but the chevron glyph only changes on collapse/expand;
+     * this lets us skip the innerHTML SVG re-parse when nothing changed.
+     */
+    chevronCollapsed: boolean | undefined;
 }
 
 export function setupFolderHandles(cy: Core): void {
@@ -266,7 +272,7 @@ export function setupFolderHandles(cy: Core): void {
         el.appendChild(chevronBtn);
         el.appendChild(eyeBtn);
         overlay.appendChild(el);
-        chips.set(folderId, {el, chevronBtn, eyeBtn});
+        chips.set(folderId, {el, chevronBtn, eyeBtn, chevronCollapsed: undefined});
         positionChip(folderId);
     }
 
@@ -299,9 +305,14 @@ export function setupFolderHandles(cy: Core): void {
         entry.el.style.transformOrigin = '0 0';
 
         // Chevron glyph reflects state: down (expanded — "click to collapse"),
-        // right (collapsed — "click to expand").
+        // right (collapsed — "click to expand"). Setting innerHTML re-parses the
+        // SVG; positionChip runs every pan/zoom frame, so only rewrite the glyph
+        // when the collapsed state actually changed.
         const isCollapsed: boolean = (node as NodeSingular).data('collapsed') === true;
-        entry.chevronBtn.innerHTML = isCollapsed ? CHEVRON_RIGHT_SVG : CHEVRON_DOWN_SVG;
+        if (entry.chevronCollapsed !== isCollapsed) {
+            entry.chevronBtn.innerHTML = isCollapsed ? CHEVRON_RIGHT_SVG : CHEVRON_DOWN_SVG;
+            entry.chevronCollapsed = isCollapsed;
+        }
     }
 
     function positionAllChips(): void {

--- a/webapp/src/shell/edge/UI-edge/floating-windows/anchoring/headless-badge-overlay.ts
+++ b/webapp/src/shell/edge/UI-edge/floating-windows/anchoring/headless-badge-overlay.ts
@@ -213,6 +213,11 @@ function repositionBadges(): void {
     const zoom: number = cy.zoom();
     const terminals: Map<TerminalId, TerminalData> = getTerminals();
 
+    // Transform + origin depend only on zoom, which is constant for this frame —
+    // compute once instead of rebuilding the same strings for every badge.
+    const badgeTransform: string = getWindowTransform('css-transform', zoom, 'top-center');
+    const badgeTransformOrigin: string = getTransformOrigin('top-center');
+
     for (const [terminalId, badge] of badgeOverlayState.badgeElements) {
         const terminal: TerminalData | undefined = terminals.get(terminalId);
         if (!terminal || !O.isSome(terminal.anchoredToNodeId)) continue;
@@ -231,8 +236,8 @@ function repositionBadges(): void {
         const screenPos: { readonly x: number; readonly y: number } = graphToScreenPosition(graphPos, zoom);
         badge.style.left = `${screenPos.x}px`;
         badge.style.top = `${screenPos.y}px`;
-        badge.style.transform = getWindowTransform('css-transform', zoom, 'top-center');
-        badge.style.transformOrigin = getTransformOrigin('top-center');
+        badge.style.transform = badgeTransform;
+        badge.style.transformOrigin = badgeTransformOrigin;
     }
 }
 

--- a/webapp/src/shell/edge/main/graph/watch_folder/folderScanning.ts
+++ b/webapp/src/shell/edge/main/graph/watch_folder/folderScanning.ts
@@ -30,32 +30,36 @@ export async function isValidSubdirectory(
     }
 }
 
+type SubfolderModifiedAt = { path: AbsolutePath; modifiedAt: number }
+
 export async function getSubfoldersWithModifiedAt(
     projectRoot: AbsolutePath,
-): Promise<readonly { path: AbsolutePath; modifiedAt: number }[]> {
-    const results: { path: AbsolutePath; modifiedAt: number }[] = []
-
+): Promise<readonly SubfolderModifiedAt[]> {
     try {
         const rootStat: Stats = await fs.stat(projectRoot)
-        results.push({ path: projectRoot, modifiedAt: rootStat.mtime.getTime() })
-
         const entries: Dirent[] = await fs.readdir(projectRoot, { withFileTypes: true })
-        for (const entry of entries) {
-            if (!entry.isDirectory() || entry.name.startsWith('.')) {
-                continue
-            }
-            const fullPath: string = normalizePath(path.join(projectRoot, entry.name))
-            try {
-                const stat: Stats = await fs.stat(fullPath)
-                results.push({
-                    path: toAbsolutePath(fullPath),
-                    modifiedAt: stat.mtime.getTime(),
-                })
-            } catch {
-                // Skip folders we cannot stat.
-            }
-        }
 
+        // Each subfolder stat is independent; run them concurrently rather
+        // than awaiting one at a time. The final sort makes the result order
+        // independent of stat completion order, so this is output-identical.
+        const subfolders: readonly (SubfolderModifiedAt | null)[] = await Promise.all(
+            entries
+                .filter((entry: Dirent) => entry.isDirectory() && !entry.name.startsWith('.'))
+                .map(async (entry: Dirent): Promise<SubfolderModifiedAt | null> => {
+                    const fullPath: string = normalizePath(path.join(projectRoot, entry.name))
+                    try {
+                        const stat: Stats = await fs.stat(fullPath)
+                        return { path: toAbsolutePath(fullPath), modifiedAt: stat.mtime.getTime() }
+                    } catch {
+                        return null // Skip folders we cannot stat.
+                    }
+                }),
+        )
+
+        const results: SubfolderModifiedAt[] = [
+            { path: projectRoot, modifiedAt: rootStat.mtime.getTime() },
+            ...subfolders.filter((s: SubfolderModifiedAt | null): s is SubfolderModifiedAt => s !== null),
+        ]
         results.sort((a, b) => b.modifiedAt - a.modifiedAt)
         return results
     } catch {

--- a/webapp/src/shell/edge/main/runtime/electron/daemon/queries/daemon-graph-queries.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/daemon/queries/daemon-graph-queries.ts
@@ -135,13 +135,12 @@ export async function writeCurrentPositionsThroughDaemon(): Promise<{ written: n
 }
 
 function collectPositionsFromGraph(graph: Graph): PositionMap {
-    return Object.entries(graph.nodes).reduce(
-        (acc: PositionMap, [nodeId, node]: [string, GraphNode]) => {
-            const position: O.Option<Position> = node.nodeUIMetadata.position
-            return O.isSome(position)
-                ? { ...acc, [nodeId]: position.value }
-                : acc
-        },
-        {},
-    )
+    const positions: PositionMap = {}
+    for (const [nodeId, node] of Object.entries(graph.nodes)) {
+        const position: O.Option<Position> = node.nodeUIMetadata.position
+        if (O.isSome(position)) {
+            positions[nodeId] = position.value
+        }
+    }
+    return positions
 }

--- a/webapp/src/shell/edge/main/runtime/electron/daemon/sync/daemon-folder-tree-sync.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/daemon/sync/daemon-folder-tree-sync.ts
@@ -21,45 +21,53 @@ export async function buildFolderTreeSyncPayload(
   const writeFolderPath: AbsolutePath = toAbsolutePath(projectState.writeFolderPath)
   const graphFilePaths: Set<string> = new Set<string>(Object.keys(graph.nodes))
 
-  let rootTree: FolderTreeNode | null = null
-  try {
-    const rootEntry: DirectoryEntry = await getDirectoryTree(projectState.projectRoot)
-    rootTree = buildFolderTree(rootEntry, loadedPaths, writeFolderPath, graphFilePaths)
-  } catch {
-    rootTree = null
+  // Each folder scan is an independent recursive `fs.readdir`. Build the
+  // tree for one folder, returning null on any unreadable folder so a single
+  // failure never rejects the whole batch (matches the prior per-folder
+  // try/catch). `maxDepth` omitted => getDirectoryTree's default for the root.
+  const buildTreeFor = async (
+    folder: string,
+    maxDepth?: number,
+  ): Promise<FolderTreeNode | null> => {
+    try {
+      const entry: DirectoryEntry = maxDepth === undefined
+        ? await getDirectoryTree(folder)
+        : await getDirectoryTree(folder, maxDepth)
+      return buildFolderTree(entry, loadedPaths, writeFolderPath, graphFilePaths)
+    } catch {
+      return null
+    }
   }
 
   const starredFolders: readonly string[] = await getStarredFolders()
+  const externalFolders: readonly string[] = getExternalReadPaths(
+    projectState.readPaths,
+    projectState.projectRoot,
+  )
+
+  // Root, starred and external scans are mutually independent — run them
+  // concurrently so total latency is the slowest scan, not their sum.
+  const [rootTree, starredTreeList, externalTreeList]: [
+    FolderTreeNode | null,
+    readonly (FolderTreeNode | null)[],
+    readonly (FolderTreeNode | null)[],
+  ] = await Promise.all([
+    buildTreeFor(projectState.projectRoot),
+    Promise.all(starredFolders.map((folder) => buildTreeFor(folder, 3))),
+    Promise.all(externalFolders.map((folder) => buildTreeFor(folder, 3))),
+  ])
 
   const starredTrees: Record<string, FolderTreeNode> = {}
-  for (const folder of starredFolders) {
-    try {
-      const entry: DirectoryEntry = await getDirectoryTree(folder, 3)
-      starredTrees[folder] = buildFolderTree(
-        entry,
-        loadedPaths,
-        writeFolderPath,
-        graphFilePaths,
-      )
-    } catch {
-      // Ignore unreadable starred folders; this matches the existing push path.
-    }
-  }
+  starredFolders.forEach((folder, index) => {
+    const tree: FolderTreeNode | null = starredTreeList[index]
+    if (tree !== null) starredTrees[folder] = tree
+  })
 
   const externalTrees: Record<string, FolderTreeNode> = {}
-  for (const folder of getExternalReadPaths(projectState.readPaths, projectState.projectRoot)) {
-    try {
-      const entry: DirectoryEntry = await getDirectoryTree(folder, 3)
-      externalTrees[folder] = buildFolderTree(
-        entry,
-        loadedPaths,
-        writeFolderPath,
-        graphFilePaths,
-      )
-    } catch {
-      // Ignore unreadable external trees; this matches the existing push path.
-    }
-  }
+  externalFolders.forEach((folder, index) => {
+    const tree: FolderTreeNode | null = externalTreeList[index]
+    if (tree !== null) externalTrees[folder] = tree
+  })
 
   return { externalTrees, rootTree, starredFolders, starredTrees }
 }

--- a/webapp/src/shell/edge/main/workspace/saveNodePositions.ts
+++ b/webapp/src/shell/edge/main/workspace/saveNodePositions.ts
@@ -68,7 +68,8 @@ export async function cleanupOrphanedContextNodes(): Promise<void> {
 }
 
 function collectPositions(cyNodes: readonly NodeDefinition[]): Record<string, Position> {
-    return cyNodes.reduce((acc: Record<string, Position>, node: NodeDefinition) => {
+    const positions: Record<string, Position> = {};
+    for (const node of cyNodes) {
         const id: unknown = node.data.id;
         const position: Position | undefined = node.position as Position | undefined;
         if (
@@ -77,12 +78,10 @@ function collectPositions(cyNodes: readonly NodeDefinition[]): Record<string, Po
             || !Number.isFinite(position.x)
             || !Number.isFinite(position.y)
         ) {
-            return acc;
+            continue;
         }
 
-        return {
-            ...acc,
-            [id]: position,
-        };
-    }, {});
+        positions[id] = position;
+    }
+    return positions;
 }


### PR DESCRIPTION
## What

12 **behavior-preserving** runtime performance fixes found by a parallel sweep across 5 subsystems, scoped to **steady-state** hot paths (startup/cold-start deliberately excluded — owned elsewhere). Each fix is an easy, no-downside win; genuinely risky/architectural wins were left as documented recommendations, not applied.

| # | Impact | Commit | Area | Fix |
|---|--------|--------|------|-----|
| 1 | HIGH | `60e563199` | graph-model | per-delta deep-clone → shallow-copy of incoming-edges index (fires on every delta); `readonly`-narrowed to compile-enforce safety + regression test |
| 2 | HIGH | `ee0b3442f` | graph-model | same for link-resolution indexes; `addToIndex`/`removeFromIndex` made copy-on-write + regression test |
| 3 | HIGH | `f6c258f98` | edge/main | `{...acc,[id]:pos}` spread-in-reduce **O(n²)→O(n)** building node-position maps (every drag-release) |
| 4 | MED-HIGH | `606cb6a86` | graph-model | subgraph DFS **O(V²)→O(V)** (reused existing `processed` guard) |
| 5 | MED | `322f7aa7a` | graph-db-server | de-quadratic `graphWithUpdatedPositions` (every position write); unchanged nodes keep ref identity |
| 6 | MED (**measured**) | `238e93045` | backend | read each markdown file once not twice + drop dead regex — **76.7ms→64.9ms (~15%)** on idle re-parse |
| 7 | MED | `ff9a6bca0` | edge/main | parallelize independent folder scans in renderer sync (per-folder error isolation + order preserved) |
| 8 | MED | `03ee662f3` | edge/main | parallelize subfolder `fs.stat` sweep; output still sorted (identical) |
| 9 | MED | `56bda2e8e` | renderer | skip chevron `innerHTML` reparse on every pan/zoom frame (guard on collapse state) |
| 10 | LOW-MED | `e4fdd89b3` | graph-db-server | gate per-commit disk `loadSettings()` behind "delta introduces a new node" |
| 11 | LOW-MED | `eb253f1a0` | graph-state | drop identity `.map` over all nodes in `project()` |
| 12 | LOW | `fd6c06c68` | renderer | hoist loop-invariant transforms out of per-badge zoom loop |

(Also carries one pre-existing branch commit, `71de970f1` `fix(cli): never let a stale dist bundle shadow live source in dev`.)

## Verification

Independently re-ran the highest-risk/highest-frequency lanes locally and proved no regressions:
- **graph-model**: 971 pass + new COW regression tests; `tsc` introduced **0 new errors** (pre-existing ones proven identical vs baseline).
- **graph-state**: 481 pass. **edge/main `saveNodePositions`**: 4 pass.
- For graph-db-server (Ivan) and Python (Jay), reverted each lane and confirmed the suite's pass/fail set is **identical** to baseline — the changes add no new failures.

## Honesty notes

- All impact labels are Big-O/alloc-count **estimates** except #6, which is **measured**. No fabricated numbers.
- Every fix preserves outputs/ordering exactly. The only non-result differences are: concurrency/fd-profile (#7, #8) and elimination of a redundant disk read (#10).
- The `{...acc,[id]:x}` spread-in-reduce O(n²) anti-pattern recurred in 3 hot paths (#3, #5, behind #1/#2) — worth a lint rule as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)