### PR TITLE
Remove double-tap-to-collapse on folder nodes

### DIFF
--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-handle-states.fixtures.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-handle-states.fixtures.ts
@@ -1,0 +1,147 @@
+/**
+ * Fixtures + screen-space helpers for the folder-handle UI states spec.
+ *
+ * Launches the packaged Electron app against a temp folder-test project (with
+ * an `auth/` folder note so the hover editor can resolve the folder note) and
+ * exposes the live cytoscape instance on `appWindow`.
+ */
+import { test as base, _electron as electron } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import {
+    type ExtendedWindow,
+    createFolderTestProject,
+} from '@e2e/electron/for_feature_development_not_LT_verification/graph/folder/folder-test-helpers';
+
+export const PROJECT_ROOT = path.resolve(process.cwd());
+export const SCREENSHOT_DIR = path.join(PROJECT_ROOT, 'e2e-tests/screenshots');
+
+export interface BBoxScreen {
+    readonly x1: number;
+    readonly y1: number;
+    readonly x2: number;
+    readonly y2: number;
+    readonly w: number;
+    readonly h: number;
+    readonly hostX: number;
+    readonly hostY: number;
+}
+
+export async function getFolderBBox(appWindow: Page, folderId: string): Promise<BBoxScreen> {
+    return appWindow.evaluate((id: string) => {
+        const cy = (window as unknown as ExtendedWindow).cytoscapeInstance;
+        if (!cy) throw new Error('No cytoscapeInstance');
+        const folder = cy.getElementById(id);
+        if (folder.length === 0) throw new Error(`No folder ${id}`);
+        // Body-only bbox so chevron-region math (top-left = chip anchor) is not
+        // skewed by the folder label that sits above the compound body.
+        const bb = folder.renderedBoundingBox({ includeLabels: false, includeOverlays: false });
+        const host = (cy.container() as HTMLElement).getBoundingClientRect();
+        return {
+            x1: bb.x1, y1: bb.y1, x2: bb.x2, y2: bb.y2, w: bb.w, h: bb.h,
+            hostX: host.left, hostY: host.top,
+        };
+    }, folderId);
+}
+
+export async function closeAllFloatingEditors(appWindow: Page): Promise<void> {
+    // Click an empty corner; HoverEditor uses click-outside to close.
+    await appWindow.mouse.move(8, 8);
+    await appWindow.mouse.click(8, 8);
+    await appWindow.waitForTimeout(250);
+}
+
+export const test = base.extend<{
+    electronApp: ElectronApplication;
+    appWindow: Page;
+    projectRoot: string;
+}>({
+    projectRoot: async ({}, use) => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vt-folder-handle-test-'));
+        const projectRoot = await createFolderTestProject(tempDir);
+        // Folder note so HoverEditor can resolve /<project>/auth/ → /<project>/auth/index.md
+        await fs.writeFile(
+            path.join(projectRoot, 'auth', 'index.md'),
+            `---\nposition:\n  x: 50\n  y: 120\n---\n# Auth Folder Note\n\nThis is the folder note for the auth/ folder.\n`,
+        );
+        await use(projectRoot);
+        await fs.rm(tempDir, { recursive: true, force: true });
+    },
+
+    electronApp: async ({ projectRoot }, use) => {
+        const tempUserData = await fs.mkdtemp(path.join(os.tmpdir(), 'vt-folder-handle-ud-'));
+
+        await fs.writeFile(path.join(tempUserData, 'voicetree-config.json'), JSON.stringify({
+            lastDirectory: projectRoot,
+            projectConfig: {
+                [projectRoot]: { writeFolderPath: projectRoot, readPaths: [] },
+            },
+        }, null, 2), 'utf8');
+
+        await fs.writeFile(path.join(tempUserData, 'projects.json'), JSON.stringify([{
+            id: 'folder-handle-test',
+            path: projectRoot,
+            name: 'folder-handle-test-project',
+            type: 'folder',
+            lastOpened: Date.now(),
+        }], null, 2), 'utf8');
+
+        const electronApp = await electron.launch({
+            args: [
+                path.join(PROJECT_ROOT, 'dist-electron/main/index.js'),
+                `--user-data-dir=${tempUserData}`,
+            ],
+            env: {
+                ...process.env,
+                NODE_ENV: 'test',
+                HEADLESS_TEST: '1',
+                MINIMIZE_TEST: '1',
+                VOICETREE_PERSIST_STATE: '1',
+            },
+            timeout: 30000,
+        });
+
+        await use(electronApp);
+
+        try {
+            const window = await electronApp.firstWindow();
+            await window.evaluate(async () => {
+                const api = (window as unknown as ExtendedWindow).electronAPI;
+                if (api) await api.main.stopFileWatching();
+            });
+            await window.waitForTimeout(300);
+        } catch {
+            // Best-effort cleanup only.
+        }
+
+        await electronApp.close();
+        await fs.rm(tempUserData, { recursive: true, force: true });
+    },
+
+    appWindow: async ({ electronApp }, use) => {
+        const window = await electronApp.firstWindow({ timeout: 20000 });
+
+        window.on('console', msg => {
+            const text = msg.text();
+            if (text.includes('error') || text.includes('Error') || text.includes('folder') || text.includes('FolderHandle') || text.includes('collapseFolder')) {
+                console.log(`BROWSER [${msg.type()}]:`, text);
+            }
+        });
+        window.on('pageerror', error => {
+            console.error('PAGE ERROR:', error.message);
+        });
+
+        await window.waitForLoadState('domcontentloaded');
+        await window.waitForSelector('text=Recent Projects', { timeout: 10000 });
+        await window.locator('button:has-text("folder-handle-test-project")').first().click();
+
+        await window.waitForFunction(
+            () => !!(window as unknown as ExtendedWindow).cytoscapeInstance,
+            { timeout: 30000 },
+        );
+        await window.waitForTimeout(3000);
+        await use(window);
+    },
+});

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-handle-states.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/folder_tree/electron-folder-handle-states.spec.ts
@@ -7,154 +7,29 @@
  * non-trivial assertion per state so the run goes red if the behavior
  * regresses.
  *
- * Implementation context: folder-handle-impl-shipped.md
- *   - TL chevron rendered as a cytoscape node background-image (no DOM overlay)
+ * Implementation context: FolderHandleService.ts
+ *   - TL chevron+eye strip is a DOM overlay chip (NOT a cytoscape background-
+ *     image — a compound folder's bbox would shrink the chip into a blurry
+ *     atlas blob). Same chip for expanded folders and collapsed pills.
  *   - Folder body is ungrabified when expanded; pill is grabbable when collapsed
  *   - setupCommandHover resolves /folder/ → /folder/index.md before opening editor
  *   - cy mouseover early-returns on isFolderNode → no grab cursor on folder body
+ *   - Folder collapse/expand is driven by the chevron chip (double-tap was removed)
  */
 
-import { test as base, expect, _electron as electron } from '@playwright/test';
-import type { ElectronApplication, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import * as path from 'path';
-import * as fs from 'fs/promises';
-import * as os from 'os';
 import {
     type ExtendedWindow,
-    createFolderTestProject,
     waitForGraphLoaded,
-} from '@e2e/electron/for_feature_development_not_LT_verification/graph/folder-test-helpers';
-
-const PROJECT_ROOT = path.resolve(process.cwd());
-const SCREENSHOT_DIR = path.join(PROJECT_ROOT, 'e2e-tests/screenshots');
-
-interface BBoxScreen {
-    readonly x1: number;
-    readonly y1: number;
-    readonly x2: number;
-    readonly y2: number;
-    readonly w: number;
-    readonly h: number;
-    readonly hostX: number;
-    readonly hostY: number;
-}
-
-async function getFolderBBox(appWindow: Page, folderId: string): Promise<BBoxScreen> {
-    return appWindow.evaluate((id: string) => {
-        const cy = (window as unknown as ExtendedWindow).cytoscapeInstance;
-        if (!cy) throw new Error('No cytoscapeInstance');
-        const folder = cy.getElementById(id);
-        if (folder.length === 0) throw new Error(`No folder ${id}`);
-        // Body-only bbox so chevron-region math (top-left = chip anchor) is not
-        // skewed by the folder label that sits above the compound body.
-        const bb = folder.renderedBoundingBox({includeLabels: false, includeOverlays: false});
-        const host = (cy.container() as HTMLElement).getBoundingClientRect();
-        return {
-            x1: bb.x1, y1: bb.y1, x2: bb.x2, y2: bb.y2, w: bb.w, h: bb.h,
-            hostX: host.left, hostY: host.top,
-        };
-    }, folderId);
-}
-
-async function closeAllFloatingEditors(appWindow: Page): Promise<void> {
-    // Click an empty corner; HoverEditor uses click-outside to close.
-    await appWindow.mouse.move(8, 8);
-    await appWindow.mouse.click(8, 8);
-    await appWindow.waitForTimeout(250);
-}
-
-const test = base.extend<{
-    electronApp: ElectronApplication;
-    appWindow: Page;
-    projectRoot: string;
-}>({
-    projectRoot: async ({}, use) => {
-        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vt-folder-handle-test-'));
-        const projectRoot = await createFolderTestProject(tempDir);
-        // Folder note so HoverEditor can resolve /<project>/auth/ → /<project>/auth/index.md
-        await fs.writeFile(
-            path.join(projectRoot, 'auth', 'index.md'),
-            `---\nposition:\n  x: 50\n  y: 120\n---\n# Auth Folder Note\n\nThis is the folder note for the auth/ folder.\n`,
-        );
-        await use(projectRoot);
-        await fs.rm(tempDir, { recursive: true, force: true });
-    },
-
-    electronApp: async ({ projectRoot }, use) => {
-        const tempUserData = await fs.mkdtemp(path.join(os.tmpdir(), 'vt-folder-handle-ud-'));
-
-        await fs.writeFile(path.join(tempUserData, 'voicetree-config.json'), JSON.stringify({
-            lastDirectory: projectRoot,
-            projectConfig: {
-                [projectRoot]: { writeFolderPath: projectRoot, readPaths: [] },
-            },
-        }, null, 2), 'utf8');
-
-        await fs.writeFile(path.join(tempUserData, 'projects.json'), JSON.stringify([{
-            id: 'folder-handle-test',
-            path: projectRoot,
-            name: 'folder-handle-test-project',
-            type: 'folder',
-            lastOpened: Date.now(),
-        }], null, 2), 'utf8');
-
-        const electronApp = await electron.launch({
-            args: [
-                path.join(PROJECT_ROOT, 'dist-electron/main/index.js'),
-                `--user-data-dir=${tempUserData}`,
-            ],
-            env: {
-                ...process.env,
-                NODE_ENV: 'test',
-                HEADLESS_TEST: '1',
-                MINIMIZE_TEST: '1',
-                VOICETREE_PERSIST_STATE: '1',
-            },
-            timeout: 30000,
-        });
-
-        await use(electronApp);
-
-        try {
-            const window = await electronApp.firstWindow();
-            await window.evaluate(async () => {
-                const api = (window as unknown as ExtendedWindow).electronAPI;
-                if (api) await api.main.stopFileWatching();
-            });
-            await window.waitForTimeout(300);
-        } catch {
-            // Best-effort cleanup only.
-        }
-
-        await electronApp.close();
-        await fs.rm(tempUserData, { recursive: true, force: true });
-    },
-
-    appWindow: async ({ electronApp }, use) => {
-        const window = await electronApp.firstWindow({ timeout: 20000 });
-
-        window.on('console', msg => {
-            const text = msg.text();
-            if (text.includes('error') || text.includes('Error') || text.includes('folder') || text.includes('FolderHandle') || text.includes('collapseFolder')) {
-                console.log(`BROWSER [${msg.type()}]:`, text);
-            }
-        });
-        window.on('pageerror', error => {
-            console.error('PAGE ERROR:', error.message);
-        });
-
-        await window.waitForLoadState('domcontentloaded');
-        await window.waitForSelector('text=Recent Projects', { timeout: 10000 });
-        await window.locator('button:has-text("folder-handle-test-project")').first().click();
-
-        await window.waitForFunction(
-            () => !!(window as unknown as ExtendedWindow).cytoscapeInstance,
-            { timeout: 30000 },
-        );
-        await window.waitForTimeout(3000);
-        await use(window);
-    },
-});
+    clickFolderChevron,
+} from '@e2e/electron/for_feature_development_not_LT_verification/graph/folder/folder-test-helpers';
+import {
+    test,
+    getFolderBBox,
+    closeAllFloatingEditors,
+    SCREENSHOT_DIR,
+} from './electron-folder-handle-states.fixtures';
 
 test.describe('Folder handle UI states', () => {
     test('exercises 8 folder-handle states with screenshot per state', async ({ appWindow, projectRoot }) => {
@@ -237,64 +112,40 @@ test.describe('Folder handle UI states', () => {
         console.log('[STATE 2] cursor after folder mouseover:', cursorAfterFolderHover);
         expect(cursorAfterFolderHover).not.toBe('grab');
 
-        // ── State 3: Chevron is rendered at TL corner (native cy bg-image) ─
-        // No DOM selector any more — assert the cy style carries the chevron
-        // data-URI, then visually clip around the rendered TL corner.
-        const chevronStyle = await appWindow.evaluate((id: string) => {
-            const cy = (window as unknown as ExtendedWindow).cytoscapeInstance!;
-            const node = cy.getElementById(id);
-            const bbFull = node.renderedBoundingBox();
-            const bbBody = node.renderedBoundingBox({includeLabels: false, includeOverlays: false});
-            const pos = node.position();
+        // ── State 3: Chevron chip rendered at folder TL (DOM overlay) ─────
+        // The chevron+eye strip is a FolderHandleService DOM overlay, not a
+        // cytoscape background-image. Assert the chip + chevron exist for the
+        // auth folder and the chevron carries its SVG glyph, then clip-shot the
+        // chip's actual rendered rect for visual review.
+        const chevronChip = await appWindow.evaluate((id: string) => {
+            const chip = Array.from(document.querySelectorAll<HTMLElement>('.vt-folder-handle'))
+                .find((el: HTMLElement) => el.dataset.folderId === id);
+            if (!chip) return { chipExists: false, chevronExists: false, hasGlyph: false, rect: null };
+            const chevron = chip.querySelector<HTMLElement>('.vt-folder-handle__chevron');
+            const r = chevron?.getBoundingClientRect();
             return {
-                backgroundImage: String(node.style('background-image') ?? ''),
-                bgW: String(node.style('background-width') ?? ''),
-                bgH: String(node.style('background-height') ?? ''),
-                posX: pos.x,
-                posY: pos.y,
-                modelW: node.width(),
-                modelH: node.height(),
-                padding: node.padding(),
-                bbFull: {x1: bbFull.x1, y1: bbFull.y1, x2: bbFull.x2, y2: bbFull.y2},
-                bbBody: {x1: bbBody.x1, y1: bbBody.y1, x2: bbBody.x2, y2: bbBody.y2},
-                zoom: cy.zoom(),
-                pan: {x: cy.pan().x, y: cy.pan().y},
+                chipExists: true,
+                chevronExists: chevron !== null,
+                hasGlyph: (chevron?.querySelector('svg') ?? null) !== null,
+                rect: r ? { x: r.left, y: r.top, w: r.width, h: r.height } : null,
             };
         }, authFolderId);
-        console.log('[STATE 3] chevron style:', {
-            hasImage: chevronStyle.backgroundImage.includes('data:image/svg+xml'),
-            bgW: chevronStyle.bgW,
-            bgH: chevronStyle.bgH,
-            posX: chevronStyle.posX,
-            posY: chevronStyle.posY,
-            modelW: chevronStyle.modelW,
-            modelH: chevronStyle.modelH,
-            padding: chevronStyle.padding,
-            bbFull: chevronStyle.bbFull,
-            bbBody: chevronStyle.bbBody,
-            zoom: chevronStyle.zoom,
-            pan: chevronStyle.pan,
-        });
-        expect(chevronStyle.backgroundImage).toContain('data:image/svg+xml');
-        expect(chevronStyle.backgroundImage).toContain('viewBox');
+        console.log('[STATE 3] chevron chip:', chevronChip);
+        expect(chevronChip.chipExists).toBe(true);
+        expect(chevronChip.chevronExists).toBe(true);
+        expect(chevronChip.hasGlyph).toBe(true);
+        expect(chevronChip.rect).not.toBeNull();
 
-        // Wide clip around the chevron region (TL corner of folder bbox) so the
-        // user can verify it visually.
-        const chevronAnchor = {
-            x: bbox.hostX + bbox.x1,
-            y: bbox.hostY + bbox.y1,
-        };
-        const chevronSizePx = 22;
+        const chevronRect = chevronChip.rect!;
         const clipPad = 60;
-        const clip = {
-            x: Math.max(0, chevronAnchor.x - clipPad),
-            y: Math.max(0, chevronAnchor.y - clipPad),
-            width: chevronSizePx + clipPad * 2,
-            height: chevronSizePx + clipPad * 2,
-        };
         await appWindow.screenshot({
             path: path.join(SCREENSHOT_DIR, 'folder-handle-3-chevron.png'),
-            clip,
+            clip: {
+                x: Math.max(0, chevronRect.x - clipPad),
+                y: Math.max(0, chevronRect.y - clipPad),
+                width: chevronRect.w + clipPad * 2,
+                height: chevronRect.h + clipPad * 2,
+            },
         });
 
         // ── State 4: Right-click in folder body → canvas vertical menu ───
@@ -360,28 +211,13 @@ test.describe('Folder handle UI states', () => {
 
         await closeAllFloatingEditors(appWindow);
 
-        // ── State 6: Real pointer click on chevron region → collapse ─────
-        // Race risk: setupCommandHover (HoverEditor.ts:239) starts an async
-        // openHoverEditor on `mouseover`. A real `mouse.click()` is fast
-        // enough (~10-30ms) that the cy tap fires before the editor finishes
-        // its IPC+DOM build, so the click hits the canvas, not the editor.
-        // If this assertion ever flakes, it surfaces a real production
-        // regression in chevron clickability, not test infrastructure.
+        // ── State 6: Click the chevron chip → collapse ───────────────────
+        // Clicks the FolderHandleService chevron DOM button directly (shared
+        // helper does a real screen-coordinate click + asserts the chevron is
+        // the top hit target), so it does not depend on the cy-tap-vs-hover-
+        // editor race that the old body-coordinate click had to dodge.
         await closeAllFloatingEditors(appWindow);
-        await appWindow.mouse.move(8, 8);
-        await appWindow.waitForTimeout(150);
-
-        // Re-fetch bbox in case the viewport shifted during States 4-5.
-        // Chevron paints at compound TL — body-only bbox.x1/y1 are compound
-        // TL coords when the compound has padding (cytoscape includes
-        // padding in the body bbox of compounds).
-        const bboxForChevron = await getFolderBBox(appWindow, authFolderId);
-        const chevronCenter = {
-            x: bboxForChevron.hostX + bboxForChevron.x1 + 11,
-            y: bboxForChevron.hostY + bboxForChevron.y1 + 11,
-        };
-        console.log('[STATE 6] real-click chevron at:', chevronCenter);
-        await appWindow.mouse.click(chevronCenter.x, chevronCenter.y);
+        await clickFolderChevron(appWindow, '/auth/');
 
         await expect.poll(
             async () =>
@@ -445,11 +281,8 @@ test.describe('Folder handle UI states', () => {
         await closeAllFloatingEditors(appWindow);
 
         // ── State 8: Drag inside expanded body → pans, folder stays put ──
-        // Re-expand via dbltap.
-        await appWindow.evaluate((id: string) => {
-            const cy = (window as unknown as ExtendedWindow).cytoscapeInstance!;
-            cy.getElementById(id).emit('dbltap');
-        }, authFolderId);
+        // Re-expand via the chevron chip.
+        await clickFolderChevron(appWindow, '/auth/');
         await expect.poll(
             async () =>
                 appWindow.evaluate((id: string) => {
@@ -528,5 +361,3 @@ test.describe('Folder handle UI states', () => {
         expect.soft(Math.abs(panDx) + Math.abs(panDy)).toBeGreaterThan(5);
     });
 });
-
-export { test };

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-collapse.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-collapse.spec.ts
@@ -1,8 +1,9 @@
 /**
  * E2E Test: Folder Node Collapsability
  *
- * Verifies that double-tapping a folder compound node collapses/expands it.
- * Collapse removes children from Cytoscape; expand re-derives from Graph via IPC.
+ * Verifies that toggling a folder compound node (via its chevron chip)
+ * collapses/expands it. Collapse removes children from Cytoscape; expand
+ * re-derives from Graph via IPC.
  *
  * Tests:
  * 1. Collapse: children removed from cy, folder.data('collapsed') set, childCount set
@@ -19,6 +20,7 @@ import {
     type ExtendedWindow,
     createFolderTestProject,
     waitForGraphLoaded,
+    toggleFolderViaChevron,
 } from './folder-test-helpers';
 
 const PROJECT_ROOT = path.resolve(process.cwd());
@@ -117,21 +119,6 @@ const test = base.extend<{
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-/** Emit a dbltap event on the folder compound node ending with the given suffix */
-async function emitDblTapOnFolder(page: Page, folderSuffix: string): Promise<string> {
-    return page.evaluate((suffix: string) => {
-        const cy = (window as unknown as ExtendedWindow).cytoscapeInstance;
-        if (!cy) throw new Error('No cytoscapeInstance');
-        const folder = cy.nodes()
-            .filter((n: import('cytoscape').NodeSingular) => n.data('isFolderNode') && n.id().endsWith(suffix))
-            .first();
-        if (!folder.length) throw new Error(`No folder node ending with: ${suffix}`);
-        const id = folder.id();
-        folder.emit('dbltap');
-        return id;
-    }, folderSuffix);
-}
-
 interface FolderState {
     collapsed: boolean;
     childCount: number | undefined;
@@ -168,8 +155,8 @@ test.describe('Folder Node Collapsability', () => {
         expect(before.collapsed).toBe(false);
         expect(before.cyChildrenLength).toBeGreaterThanOrEqual(2);
 
-        // Trigger collapse via dbltap
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        // Trigger collapse via the chevron chip
+        await toggleFolderViaChevron(appWindow, '/auth/');
 
         // Wait for children to be removed
         await expect.poll(
@@ -190,14 +177,14 @@ test.describe('Folder Node Collapsability', () => {
         await waitForGraphLoaded(appWindow, 3);
 
         // Collapse auth/
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        await toggleFolderViaChevron(appWindow, '/auth/');
         await expect.poll(
             () => getFolderState(appWindow, '/auth/').then(s => s.cyChildrenLength),
             { message: 'Waiting for auth/ to collapse', timeout: 5000 }
         ).toBe(0);
 
-        // Expand via second dbltap
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        // Expand via a second chevron toggle
+        await toggleFolderViaChevron(appWindow, '/auth/');
 
         // Wait for children to reappear
         await expect.poll(
@@ -251,7 +238,7 @@ test.describe('Folder Node Collapsability', () => {
         expect(edgesBefore).toBeGreaterThan(0);
 
         // Collapse auth/
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        await toggleFolderViaChevron(appWindow, '/auth/');
         await expect.poll(
             () => getFolderState(appWindow, '/auth/').then(s => s.cyChildrenLength),
             { message: 'Waiting for auth/ to collapse', timeout: 5000 }
@@ -272,7 +259,7 @@ test.describe('Folder Node Collapsability', () => {
         expect(nonSyntheticAfterCollapse).toBe(0);
 
         // Expand
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        await toggleFolderViaChevron(appWindow, '/auth/');
         await expect.poll(
             () => getFolderState(appWindow, '/auth/').then(s => s.cyChildrenLength),
             { message: 'Waiting for auth/ to expand', timeout: 10000 }
@@ -304,7 +291,7 @@ test.describe('Folder Node Collapsability', () => {
         await appWindow.screenshot({ path: 'e2e-tests/screenshots/folder-collapse-before.png' });
 
         // Collapse auth/
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        await toggleFolderViaChevron(appWindow, '/auth/');
         await expect.poll(
             () => getFolderState(appWindow, '/auth/').then(s => s.cyChildrenLength),
             { message: 'Waiting for auth/ to collapse', timeout: 5000 }

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-interaction-improvements.spec.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/electron-folder-interaction-improvements.spec.ts
@@ -15,6 +15,8 @@ import {
     type ExtendedWindow,
     createFolderTestProject,
     waitForGraphLoaded,
+    toggleFolderViaChevron,
+    clickFolderChevron,
 } from './folder-test-helpers';
 
 const PROJECT_ROOT = path.resolve(process.cwd());
@@ -131,20 +133,6 @@ const test = base.extend<{
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-async function emitDblTapOnFolder(page: Page, folderSuffix: string): Promise<string> {
-    return page.evaluate((suffix: string) => {
-        const cy = (window as unknown as ExtendedWindow).cytoscapeInstance;
-        if (!cy) throw new Error('No cytoscapeInstance');
-        const folder = cy.nodes()
-            .filter((n: import('cytoscape').NodeSingular) => n.data('isFolderNode') && n.id().endsWith(suffix))
-            .first();
-        if (!folder.length) throw new Error(`No folder node ending with: ${suffix}`);
-        const id = folder.id();
-        folder.emit('dbltap');
-        return id;
-    }, folderSuffix);
-}
-
 async function waitForFolderNode(page: Page, folderSuffix: string): Promise<string> {
     await expect.poll(
         () => page.evaluate((suffix: string) => {
@@ -174,34 +162,6 @@ async function closeFolderTreeSidebarIfVisible(page: Page): Promise<void> {
     if (!await sidebar.isVisible().catch(() => false)) return;
     await sidebar.locator('.folder-tree-close-btn').click();
     await expect(sidebar).not.toBeVisible({ timeout: 5000 });
-}
-
-async function clickFolderChevron(page: Page, folderSuffix: string): Promise<void> {
-    const point = await page.evaluate((suffix: string) => {
-        const cy = (window as unknown as ExtendedWindow).cytoscapeInstance;
-        if (!cy) throw new Error('No cytoscapeInstance');
-        const folder = cy.nodes()
-            .filter((n: import('cytoscape').NodeSingular) => n.data('isFolderNode') && n.id().endsWith(suffix))
-            .first();
-        if (!folder.length) throw new Error(`No folder node ending with: ${suffix}`);
-        const folderId = folder.id();
-        const chip = Array.from(document.querySelectorAll<HTMLElement>('.vt-folder-handle'))
-            .find((el: HTMLElement) => el.dataset.folderId === folderId);
-        if (!chip) throw new Error(`No folder handle chip for: ${folderId}`);
-        const chevron = chip.querySelector<HTMLElement>('.vt-folder-handle__chevron');
-        if (!chevron) throw new Error(`No folder chevron button for: ${folderId}`);
-        const rect = chevron.getBoundingClientRect();
-        const x = rect.left + rect.width / 2;
-        const y = rect.top + rect.height / 2;
-        const hit = document.elementFromPoint(x, y);
-        if (!hit?.closest('.vt-folder-handle__chevron')) {
-            const target = hit as HTMLElement | null;
-            throw new Error(`Folder chevron is not the top hit target for: ${folderId}; hit=${target?.tagName ?? 'null'} class=${target?.className ?? ''} id=${target?.id ?? ''}`);
-        }
-        return { x, y };
-    }, folderSuffix);
-
-    await page.mouse.click(point.x, point.y);
 }
 
 interface SyntheticEdgeInfo {
@@ -292,7 +252,7 @@ test.describe('BF-113: Synthetic edges on collapsed folders', () => {
         //   api/router.md → auth/login-flow.md (incoming to auth)
         //   auth/session-manager.md → api/gateway.md (outgoing from auth)
         //   readme.md → auth/login-flow.md (incoming to auth)
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        await toggleFolderViaChevron(appWindow, '/auth/');
 
         // Wait for collapse to complete
         await expect.poll(
@@ -317,7 +277,7 @@ test.describe('BF-113: Synthetic edges on collapsed folders', () => {
         await waitForGraphLoaded(appWindow, 3);
 
         // Collapse auth/
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        await toggleFolderViaChevron(appWindow, '/auth/');
         await expect.poll(
             () => getFolderCollapsedState(appWindow, '/auth/'),
             { message: 'Waiting for auth/ to collapse', timeout: 5000 }
@@ -328,7 +288,7 @@ test.describe('BF-113: Synthetic edges on collapsed folders', () => {
         expect(synthAfterCollapse.length).toBeGreaterThan(0);
 
         // Expand auth/
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        await toggleFolderViaChevron(appWindow, '/auth/');
         await expect.poll(
             () => getFolderCollapsedState(appWindow, '/auth/'),
             { message: 'Waiting for auth/ to expand', timeout: 10000 }
@@ -343,7 +303,7 @@ test.describe('BF-113: Synthetic edges on collapsed folders', () => {
         test.setTimeout(60000);
         await waitForGraphLoaded(appWindow, 3);
 
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        await toggleFolderViaChevron(appWindow, '/auth/');
         await expect.poll(
             () => getFolderCollapsedState(appWindow, '/auth/'),
             { message: 'Waiting for auth/ to collapse', timeout: 5000 }
@@ -366,7 +326,7 @@ test.describe('BF-113: Synthetic edges on collapsed folders', () => {
         await waitForGraphLoaded(appWindow, 3);
 
         // Collapse auth/
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        await toggleFolderViaChevron(appWindow, '/auth/');
         await expect.poll(
             () => getFolderCollapsedState(appWindow, '/auth/'),
             { message: 'Waiting for auth/ to collapse', timeout: 5000 }
@@ -419,7 +379,7 @@ test.describe('BF-114: File tree collapse toggle syncs with graph', () => {
             { message: 'Waiting for auth/ to collapse', timeout: 5000 }
         ).toBe(true);
 
-        await emitDblTapOnFolder(appWindow, '/auth/');
+        await clickFolderChevron(appWindow, '/auth/');
         await expect.poll(
             () => getFolderCollapsedState(appWindow, '/auth/'),
             { message: 'Waiting for auth/ to expand', timeout: 10000 }

--- a/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/folder-test-helpers.ts
+++ b/webapp/e2e-tests/electron/for_feature_development_not_LT_verification/graph/folder/folder-test-helpers.ts
@@ -67,6 +67,73 @@ export async function waitForGraphLoaded(page: Page, minNodes = 1): Promise<void
     }).toBeGreaterThanOrEqual(minNodes);
 }
 
+// ── Folder Collapse Trigger ───────────────────────────────────────────
+
+/**
+ * Toggle a folder's collapsed state via its FolderHandleService chevron chip —
+ * the user-facing affordance for collapse/expand. (Double-tapping the folder
+ * body no longer collapses it; the chevron, vertical menu, and folder-tree
+ * sidebar are the deliberate triggers.)
+ *
+ * Fires the chevron button's real click handler directly rather than via screen
+ * coordinates, so it is robust to viewport position and occlusion. Returns the
+ * resolved folder id. Throws if the folder or its chip cannot be found, so a
+ * missing affordance surfaces as a loud failure rather than a silent no-op.
+ */
+export async function toggleFolderViaChevron(page: Page, folderSuffix: string): Promise<string> {
+    return page.evaluate((suffix: string) => {
+        const cy = (window as unknown as ExtendedWindow).cytoscapeInstance;
+        if (!cy) throw new Error('No cytoscapeInstance');
+        const folder = cy.nodes()
+            .filter((n: NodeSingular) => n.data('isFolderNode') && n.id().endsWith(suffix))
+            .first();
+        if (!folder.length) throw new Error(`No folder node ending with: ${suffix}`);
+        const folderId = folder.id();
+        const chip = Array.from(document.querySelectorAll<HTMLElement>('.vt-folder-handle'))
+            .find((el: HTMLElement) => el.dataset.folderId === folderId);
+        if (!chip) throw new Error(`No folder handle chip for: ${folderId}`);
+        const chevron = chip.querySelector<HTMLButtonElement>('.vt-folder-handle__chevron');
+        if (!chevron) throw new Error(`No folder chevron button for: ${folderId}`);
+        chevron.click();
+        return folderId;
+    }, folderSuffix);
+}
+
+/**
+ * Click a folder's chevron chip via a real screen-coordinate mouse click,
+ * asserting the chevron is the top hit target first. Unlike
+ * {@link toggleFolderViaChevron} (which fires the handler programmatically),
+ * this exercises genuine on-screen clickability — use it when a test's purpose
+ * is to verify the chevron is actually reachable by the pointer.
+ */
+export async function clickFolderChevron(page: Page, folderSuffix: string): Promise<void> {
+    const point = await page.evaluate((suffix: string) => {
+        const cy = (window as unknown as ExtendedWindow).cytoscapeInstance;
+        if (!cy) throw new Error('No cytoscapeInstance');
+        const folder = cy.nodes()
+            .filter((n: NodeSingular) => n.data('isFolderNode') && n.id().endsWith(suffix))
+            .first();
+        if (!folder.length) throw new Error(`No folder node ending with: ${suffix}`);
+        const folderId = folder.id();
+        const chip = Array.from(document.querySelectorAll<HTMLElement>('.vt-folder-handle'))
+            .find((el: HTMLElement) => el.dataset.folderId === folderId);
+        if (!chip) throw new Error(`No folder handle chip for: ${folderId}`);
+        const chevron = chip.querySelector<HTMLElement>('.vt-folder-handle__chevron');
+        if (!chevron) throw new Error(`No folder chevron button for: ${folderId}`);
+        const rect = chevron.getBoundingClientRect();
+        const x = rect.left + rect.width / 2;
+        const y = rect.top + rect.height / 2;
+        const hit = document.elementFromPoint(x, y);
+        if (!hit?.closest('.vt-folder-handle__chevron')) {
+            const target = hit as HTMLElement | null;
+            throw new Error(`Folder chevron is not the top hit target for: ${folderId}; hit=${target?.tagName ?? 'null'} class=${target?.className ?? ''} id=${target?.id ?? ''}`);
+        }
+        return { x, y };
+    }, folderSuffix);
+
+    await page.mouse.click(point.x, point.y);
+}
+
 // ── Diagnostic Snapshot ───────────────────────────────────────────────
 
 export interface GraphDiagnostic {

--- a/webapp/src/shell/UI/views/VoiceTreeGraphViewHelpers/setupBasicCytoscapeEventListeners.ts
+++ b/webapp/src/shell/UI/views/VoiceTreeGraphViewHelpers/setupBasicCytoscapeEventListeners.ts
@@ -13,7 +13,6 @@ import { showNoVisibleNodesToast, hideNoVisibleNodesToast, isNoVisibleNodesToast
 import { cyFitIntoVisibleViewport, getResponsivePadding } from '@/utils/responsivePadding';
 // Import to make Window.electronAPI type available
 import type {} from '@/shell/electron';
-import { toggleFolderCollapse } from '@/shell/edge/UI-edge/graph/view/folderCollapse'
 import { dispatchSelect, dispatchDeselect } from '@vt/graph-state/state/selectionStore'
 
 export function setupBasicCytoscapeEventListeners(
@@ -90,11 +89,9 @@ export function setupBasicCytoscapeEventListeners(
     }
   });
 
-  // Folder collapsability — double-tap folder to toggle children visibility
-  cy.on('dbltap', 'node[?isFolderNode]', (evt) => {
-    const folderId: string = evt.target.id()
-    void toggleFolderCollapse(cy, folderId)
-  })
+  // Folder collapsability is driven by the explicit FolderHandleService
+  // chevron chip (and the vertical menu / folder-tree sidebar) — deliberately
+  // NOT by double-tapping the folder body, which fired too easily by accident.
 
   // Update node sizes when edges are added or removed
   // Only update the source and target nodes of the affected edge for efficiency

--- a/webapp/src/shell/UI/views/graph-view/IVoiceTreeGraphView.ts
+++ b/webapp/src/shell/UI/views/graph-view/IVoiceTreeGraphView.ts
@@ -211,24 +211,6 @@ export interface IVoiceTreeGraphView {
   onNodeSelected(callback: (nodeId: string) => void): () => void;
 
   /**
-   * Subscribe to node double-click events
-   *
-   * Behavior:
-   * - Fires when user double-clicks on a node
-   * - Provides the node ID
-   * - Multiple subscribers allowed
-   *
-   * @param callback - Function to call when node double-clicked
-   * @returns Unsubscribe function
-   *
-   * @example
-   * graphView.onNodeDoubleClick((nodeId) => {
-   *   //console.log('Double-clicked:', nodeId);
-   * });
-   */
-  onNodeDoubleClick(callback: (nodeId: string) => void): () => void;
-
-  /**
    * Subscribe to edge selection events
    *
    * Behavior:

--- a/webapp/src/shell/UI/views/graph-view/VoiceTreeGraphView.ts
+++ b/webapp/src/shell/UI/views/graph-view/VoiceTreeGraphView.ts
@@ -302,7 +302,6 @@ export class VoiceTreeGraphView extends Disposable implements IVoiceTreeGraphVie
 
     // Event emitters
     private nodeSelectedEmitter = new EventEmitter<string>();
-    private nodeDoubleClickEmitter = new EventEmitter<string>();
     private edgeSelectedEmitter = new EventEmitter<{ source: string; target: string }>();
     private layoutCompleteEmitter = new EventEmitter<void>();
 
@@ -560,10 +559,6 @@ export class VoiceTreeGraphView extends Disposable implements IVoiceTreeGraphVie
         return this.nodeSelectedEmitter.on(callback);
     }
 
-    onNodeDoubleClick(callback: (nodeId: string) => void): () => void {
-        return this.nodeDoubleClickEmitter.on(callback);
-    }
-
     onEdgeSelected(callback: (sourceId: string, targetId: string) => void): () => void {
         return this.edgeSelectedEmitter.on((data) => callback(data.source, data.target));
     }
@@ -595,7 +590,6 @@ export class VoiceTreeGraphView extends Disposable implements IVoiceTreeGraphVie
             animationService: this.animationService,
             navigator: this.navigator,
             nodeSelectedEmitter: this.nodeSelectedEmitter,
-            nodeDoubleClickEmitter: this.nodeDoubleClickEmitter,
             edgeSelectedEmitter: this.edgeSelectedEmitter,
             layoutCompleteEmitter: this.layoutCompleteEmitter,
         });

--- a/webapp/src/shell/UI/views/graph-view/disposeGraphView.ts
+++ b/webapp/src/shell/UI/views/graph-view/disposeGraphView.ts
@@ -34,7 +34,6 @@ export interface GraphViewDisposeDependencies {
     navigator: { destroy: () => void } | null;
     cleanupSettingsListener: (() => void) | null;
     nodeSelectedEmitter: EventEmitter<string>;
-    nodeDoubleClickEmitter: EventEmitter<string>;
     edgeSelectedEmitter: EventEmitter<{ source: string; target: string }>;
     layoutCompleteEmitter: EventEmitter<void>;
 }
@@ -105,7 +104,6 @@ export function disposeGraphView(deps: GraphViewDisposeDependencies): void {
 
     // Clear event emitters
     deps.nodeSelectedEmitter.clear();
-    deps.nodeDoubleClickEmitter.clear();
     deps.edgeSelectedEmitter.clear();
     deps.layoutCompleteEmitter.clear();
 }

--- a/webapp/src/shell/edge/UI-edge/floating-windows/editors/AnchoredEditor.folderGuard.test.ts
+++ b/webapp/src/shell/edge/UI-edge/floating-windows/editors/AnchoredEditor.folderGuard.test.ts
@@ -50,7 +50,7 @@ describe('AnchoredEditor visual style — folder cy node guard', () => {
         expect(folder.style('shape')).toBe('roundrectangle');
     });
 
-    it('open style leaves folder events enabled (so dbltap-to-collapse keeps working)', () => {
+    it('open style leaves folder events enabled (so folder hover/chip interactions keep working)', () => {
         const { folder } = setup();
 
         applyAnchoredEditorOpenStyle(folder);


### PR DESCRIPTION
## What

Double-clicking a folder node toggled its collapse/expand state. That trigger fired too easily by accident, so this removes it. **Folder collapse itself is unchanged** — it's still available via the explicit affordances:

- the chevron chip on the folder (`FolderHandleService`),
- the vertical menu, and
- the folder-tree sidebar.

Only the redundant double-tap *gesture* is gone.

## Changes

| Commit | Scope |
|---|---|
| `feat(graph): remove double-tap-to-collapse on folder nodes` | Drop the `cy.on('dbltap', …)` folder-collapse handler in `setupBasicCytoscapeEventListeners.ts`; update the folder e2e helpers/specs to drive collapse via the chevron chip instead of `dbltap`. |
| `refactor(graph-view): remove dead nodeDoubleClick emitter` | Remove the never-fired, never-subscribed `nodeDoubleClickEmitter` / `onNodeDoubleClick` across `VoiceTreeGraphView.ts`, `IVoiceTreeGraphView.ts`, `disposeGraphView.ts`. |
| `test(folder-handle): repair stale folder-handle-states e2e spec` | Fix a broken import + a stale `State 3` assertion (the chevron is a DOM-overlay chip now, not a cytoscape `background-image`); extract fixtures; drive collapse/expand via a real chevron click. |

Net: **11 files, +300 / −333** — mostly removal.

## Testing

Ran the full `--tier<=2` gate on the dev box: **38/38 checks green.** Most relevant coverage:

- `e2e-tier2-electron-critical` — 16/18 pass, 0 fail (the live folder-UI regression path)
- `webapp-check` (typecheck), all unit suites, `e2e-tier1`, `e2e-tier2-browser`, fuzz, structure/health, contracts, lint — all pass

Note: the repaired `electron-folder-handle-states.spec.ts` lives in the dev-only `for_feature_development_not_LT_verification/` tree, so it sits outside the CI tiers and isn't exercised by the gate above — it was verified by reusing the same `clickFolderChevron` path the passing `electron-folder-interaction-improvements` spec already exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
