### PR TITLE
feat(dev-setup): single-source Mac↔VM dev model (read-only base + origin hub)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,7 +268,7 @@ test_output/*
 /health-dashboard/reports/*.json
 /health-dashboard/reports/*.json.tmp.*
 /health-dashboard/reports/checks/*.json
-/health-dashboard/reports/scores-history/*.local.csv
+/health-dashboard/reports/scores-history/*.csv
 !/health-dashboard/reports/SCHEMA.md
 !/health-dashboard/reports/.gitkeep
 !/health-dashboard/reports/scores-history/

--- a/scripts/dev-setup/common/configure-base.sh
+++ b/scripts/dev-setup/common/configure-base.sh
@@ -24,6 +24,12 @@
 #   VT_WORKTREE_ROOT   worktree placement root           (default: per platform)
 #   VT_SYNC_INTERVAL   timer cadence, seconds            (default: 150)
 #   VT_DAILY_BRANCH    daily-driver branch name          (default: daily-<role>)
+#   VT_ALERT_PARENT_NODE  VoiceTree node id the daemon attaches alert nodes under.
+#                      STRONGLY recommended on a headless VM: there OS notifications
+#                      are silent (no DISPLAY for notify-send; wall reaches no one),
+#                      so the graph node is the primary alert channel — but a root
+#                      `vt graph create` with no parent may be refused. Threaded into
+#                      the timer unit so timer-detected dirty/divergence alerts land.
 #   VT_SKIP_TIMER=1    configure base but do NOT install the live timer
 set -euo pipefail
 
@@ -34,6 +40,7 @@ SYNC_BASE="$(cd "$SCRIPT_DIR/../remote" && pwd)/vt-sync-base.sh"
 BASE="${VT_BASE_DIR:?configure-base: set VT_BASE_DIR to the base checkout}"
 BRANCH="${VT_BASE_BRANCH:-dev-manu}"
 INTERVAL="${VT_SYNC_INTERVAL:-150}"
+ALERT_PARENT_NODE="${VT_ALERT_PARENT_NODE:-}"
 
 [ -d "$BASE/.git" ] || { echo "configure-base: $BASE is not a git repository" >&2; exit 1; }
 
@@ -113,6 +120,10 @@ install_timer_systemd() {
     echo "→ configure-base: no write access to /etc/systemd/system — skipping timer (run as root to install)" >&2
     return 0
   fi
+  # On the headless VM, the graph node is the primary alert channel (OS notifs
+  # are silent there) — thread the parent node through so the daemon can attach.
+  local alert_env=""
+  [ -n "$ALERT_PARENT_NODE" ] && alert_env="Environment=VT_ALERT_PARENT_NODE=$ALERT_PARENT_NODE"
   cat > "$svc" <<EOF
 [Unit]
 Description=VoiceTree single-source base fast-forward (vt-sync-base)
@@ -122,6 +133,7 @@ After=network-online.target
 Type=oneshot
 Environment=VT_BASE_DIR=$BASE
 Environment=VT_BASE_BRANCH=$BRANCH
+${alert_env}
 ExecStart=$SYNC_BASE
 EOF
   cat > "$tmr" <<EOF
@@ -145,6 +157,8 @@ install_timer_launchd() {
   local label=com.voicetree.vt-sync-base
   local plist="$HOME/Library/LaunchAgents/$label.plist"
   mkdir -p "$HOME/Library/LaunchAgents"
+  local alert_kv=""
+  [ -n "$ALERT_PARENT_NODE" ] && alert_kv="    <key>VT_ALERT_PARENT_NODE</key><string>$ALERT_PARENT_NODE</string>"
   cat > "$plist" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -157,6 +171,7 @@ install_timer_launchd() {
   <dict>
     <key>VT_BASE_DIR</key><string>$BASE</string>
     <key>VT_BASE_BRANCH</key><string>$BRANCH</string>
+${alert_kv}
   </dict>
   <key>StartInterval</key><integer>${INTERVAL}</integer>
   <key>RunAtLoad</key><true/>

--- a/scripts/dev-setup/common/configure-base.sh
+++ b/scripts/dev-setup/common/configure-base.sh
@@ -11,7 +11,7 @@
 #   D9  creates a blessed daily-driver worktree (daily-mac / daily-vm) as the
 #       stable "local dev" home
 #       + installs the dev-flow commands (vt-land/vt-sync/vt-pr/vt-worktree)
-#       + installs the 2-3 min sync timer (systemd on Linux / launchd on macOS)
+#       + installs the ~10s sync timer (systemd on Linux / launchd on macOS)
 #
 # Run AFTER git-gate is on PATH. This script supplies VT_SYNC=1 to its own
 # gated git calls (checkout/merge in the base) so the read-only guard lets the
@@ -22,7 +22,7 @@
 #   VT_BASE_DIR        base checkout to configure        (REQUIRED)
 #   VT_BASE_BRANCH     pinned branch                     (default: dev-manu)
 #   VT_WORKTREE_ROOT   worktree placement root           (default: per platform)
-#   VT_SYNC_INTERVAL   timer cadence, seconds            (default: 150)
+#   VT_SYNC_INTERVAL   timer cadence, seconds            (default: 10)
 #   VT_DAILY_BRANCH    daily-driver branch name          (default: daily-<role>)
 #   VT_ALERT_PARENT_NODE  VoiceTree node id the daemon attaches alert nodes under.
 #                      STRONGLY recommended on a headless VM: there OS notifications
@@ -31,6 +31,13 @@
 #                      `vt graph create` with no parent may be refused. Threaded into
 #                      the timer unit so timer-detected dirty/divergence alerts land.
 #   VT_SKIP_TIMER=1    configure base but do NOT install the live timer
+#
+# Sync cadence (VT_SYNC_INTERVAL, default 10s): a `git fetch` with no new commits
+# is one cheap negotiation, so a 10s tick is the PRIMARY cross-machine propagation
+# path — a change landed on one machine reaches the other's base within ~10s with
+# zero user action. The explicit `vt-land` cross-machine nudge (nudge_both) is now
+# an OPTIONAL latency optimisation (instant instead of <=10s), NOT a correctness
+# requirement; if the nudge ssh fails, the timer still converges within one tick.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -39,7 +46,7 @@ SYNC_BASE="$(cd "$SCRIPT_DIR/../remote" && pwd)/vt-sync-base.sh"
 
 BASE="${VT_BASE_DIR:?configure-base: set VT_BASE_DIR to the base checkout}"
 BRANCH="${VT_BASE_BRANCH:-dev-manu}"
-INTERVAL="${VT_SYNC_INTERVAL:-150}"
+INTERVAL="${VT_SYNC_INTERVAL:-10}"
 ALERT_PARENT_NODE="${VT_ALERT_PARENT_NODE:-}"
 
 [ -d "$BASE/.git" ] || { echo "configure-base: $BASE is not a git repository" >&2; exit 1; }
@@ -112,7 +119,8 @@ fi
 # --- dev-flow commands on PATH ----------------------------------------------
 bash "$DEV_FLOW_INSTALL"
 
-# --- 2-3 min sync timer (the backstop for GitHub-web PR merges) -------------
+# --- ~10s sync timer (the backstop for GitHub-web PR merges + the primary
+#     cross-machine propagation path; cadence = VT_SYNC_INTERVAL) ------------
 install_timer_systemd() {
   local svc=/etc/systemd/system/vt-sync-base.service
   local tmr=/etc/systemd/system/vt-sync-base.timer
@@ -136,14 +144,16 @@ Environment=VT_BASE_BRANCH=$BRANCH
 ${alert_env}
 ExecStart=$SYNC_BASE
 EOF
+  # AccuracySec=1s is required: systemd's default accuracy (1min) would batch a
+  # 10s timer up to ~1min, defeating the fast cadence. Keep it tight.
   cat > "$tmr" <<EOF
 [Unit]
 Description=Run vt-sync-base every ${INTERVAL}s (single-source base cache)
 
 [Timer]
 OnBootSec=60
-OnUnitActiveSec=${INTERVAL}
-AccuracySec=15
+OnUnitActiveSec=${INTERVAL}s
+AccuracySec=1s
 
 [Install]
 WantedBy=timers.target

--- a/scripts/dev-setup/common/configure-base.sh
+++ b/scripts/dev-setup/common/configure-base.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# configure-base.sh — turn a checkout into a read-only fast-forward cache of
+# origin (the "base"), the per-machine half of the single-source dev model.
+# Shared by setup-devbox-env.sh (VM) and setup-laptop-env.sh (Mac); the only
+# platform difference is the sync timer (systemd vs launchd), handled here.
+#
+# It (idempotently):
+#   D4  refuses if the base has unpushed commits or uncommitted edits (no data loss)
+#   D1  pins a real local branch ($VT_BASE_BRANCH, default dev-manu) at origin and
+#       fast-forwards it (NOT detached HEAD)
+#   D9  creates a blessed daily-driver worktree (daily-mac / daily-vm) as the
+#       stable "local dev" home
+#       + installs the dev-flow commands (vt-land/vt-sync/vt-pr/vt-worktree)
+#       + installs the 2-3 min sync timer (systemd on Linux / launchd on macOS)
+#
+# Run AFTER git-gate is on PATH. This script supplies VT_SYNC=1 to its own
+# gated git calls (checkout/merge in the base) so the read-only guard lets the
+# pin through (D3); the worktree-add is left ungated so git-gate does placement
+# + dependency bootstrap.
+#
+# Config (env):
+#   VT_BASE_DIR        base checkout to configure        (REQUIRED)
+#   VT_BASE_BRANCH     pinned branch                     (default: dev-manu)
+#   VT_WORKTREE_ROOT   worktree placement root           (default: per platform)
+#   VT_SYNC_INTERVAL   timer cadence, seconds            (default: 150)
+#   VT_DAILY_BRANCH    daily-driver branch name          (default: daily-<role>)
+#   VT_SKIP_TIMER=1    configure base but do NOT install the live timer
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEV_FLOW_INSTALL="$(cd "$SCRIPT_DIR/../dev-flow" && pwd)/install.sh"
+SYNC_BASE="$(cd "$SCRIPT_DIR/../remote" && pwd)/vt-sync-base.sh"
+
+BASE="${VT_BASE_DIR:?configure-base: set VT_BASE_DIR to the base checkout}"
+BRANCH="${VT_BASE_BRANCH:-dev-manu}"
+INTERVAL="${VT_SYNC_INTERVAL:-150}"
+
+[ -d "$BASE/.git" ] || { echo "configure-base: $BASE is not a git repository" >&2; exit 1; }
+
+case "$(uname -s)" in
+  Darwin) ROLE="mac"; WT_ROOT_DEFAULT="$HOME/repos/vt-wts-synced" ;;
+  *)      ROLE="vm";  WT_ROOT_DEFAULT="$HOME/vt-wts" ;;
+esac
+WT_ROOT="${VT_WORKTREE_ROOT:-$WT_ROOT_DEFAULT}"
+DAILY_BRANCH="${VT_DAILY_BRANCH:-daily-$ROLE}"
+
+base_git()  { git -C "$BASE" "$@"; }
+# A git call that the read-only guard would block (run by the configurer, not a user).
+gated_git() { VT_SYNC=1 git -C "$BASE" "$@"; }
+
+echo "→ configure-base: $BASE  branch=$BRANCH  role=$ROLE  worktree-root=$WT_ROOT"
+
+# --- fetch (own git is gate-exempt for consistency) -------------------------
+VT_SYNC=1 base_git fetch origin --prune
+
+base_git show-ref --verify --quiet "refs/remotes/origin/$BRANCH" \
+  || { echo "configure-base: origin/$BRANCH does not exist — cannot pin the base to it" >&2; exit 1; }
+
+# --- D4 migration guard: never strand local work ----------------------------
+if ! base_git diff --quiet || ! base_git diff --cached --quiet; then
+  echo "configure-base: REFUSING — $BASE has uncommitted changes." >&2
+  echo "  Move them into a worktree (or commit + push), then re-run." >&2
+  exit 1
+fi
+
+guard_unpushed() { # $1 = ref; refuse if it has commits not on origin/$BRANCH
+  local ref="$1" n
+  base_git rev-parse --verify --quiet "$ref" >/dev/null 2>&1 || return 0
+  n="$(base_git rev-list --count "origin/$BRANCH..$ref" 2>/dev/null || echo 0)"
+  if [ "${n:-0}" -gt 0 ]; then
+    echo "configure-base: REFUSING — '$ref' has $n commit(s) not on origin/$BRANCH:" >&2
+    base_git log --oneline "origin/$BRANCH..$ref" >&2
+    echo "  Push or PR them first — re-pointing the base would orphan them (D4)." >&2
+    exit 1
+  fi
+}
+guard_unpushed "refs/heads/$BRANCH"
+cur="$(base_git symbolic-ref --quiet --short HEAD || true)"
+[ "$cur" = "$BRANCH" ] && guard_unpushed HEAD
+
+# --- D1 pin a real local branch at origin and fast-forward it ---------------
+if base_git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  [ "$cur" = "$BRANCH" ] || gated_git checkout "$BRANCH"
+  gated_git merge --ff-only "origin/$BRANCH"
+else
+  gated_git checkout -B "$BRANCH" "origin/$BRANCH"
+fi
+base_git branch --set-upstream-to="origin/$BRANCH" "$BRANCH" >/dev/null
+echo "→ configure-base: base pinned at origin/$BRANCH ($(base_git rev-parse --short HEAD))"
+
+# --- D9 blessed daily-driver worktree ---------------------------------------
+# Per-machine branch name (daily-mac / daily-vm): self-answers "which machine"
+# and avoids cross-machine push collisions. Its upstream is origin/$BRANCH so a
+# `vt-land` from it goes to the integration branch (its own name stays local).
+if base_git show-ref --verify --quiet "refs/heads/$DAILY_BRANCH"; then
+  echo "→ configure-base: daily worktree branch '$DAILY_BRANCH' already exists (skip)"
+else
+  mkdir -p "$WT_ROOT"
+  # Leave this ungated so git-gate does placement + dependency bootstrap.
+  VT_WORKTREE_ROOT="$WT_ROOT" git -C "$BASE" worktree add -b "$DAILY_BRANCH" "$WT_ROOT/daily" "origin/$BRANCH"
+  git -C "$WT_ROOT/daily" branch --set-upstream-to="origin/$BRANCH" "$DAILY_BRANCH" >/dev/null 2>&1 || true
+  echo "→ configure-base: created daily worktree $WT_ROOT/daily on $DAILY_BRANCH (falls behind origin until its next land/rebase)"
+fi
+
+# --- dev-flow commands on PATH ----------------------------------------------
+bash "$DEV_FLOW_INSTALL"
+
+# --- 2-3 min sync timer (the backstop for GitHub-web PR merges) -------------
+install_timer_systemd() {
+  local svc=/etc/systemd/system/vt-sync-base.service
+  local tmr=/etc/systemd/system/vt-sync-base.timer
+  if ! { [ -w /etc/systemd/system ] || [ "$(id -u)" = 0 ]; }; then
+    echo "→ configure-base: no write access to /etc/systemd/system — skipping timer (run as root to install)" >&2
+    return 0
+  fi
+  cat > "$svc" <<EOF
+[Unit]
+Description=VoiceTree single-source base fast-forward (vt-sync-base)
+After=network-online.target
+
+[Service]
+Type=oneshot
+Environment=VT_BASE_DIR=$BASE
+Environment=VT_BASE_BRANCH=$BRANCH
+ExecStart=$SYNC_BASE
+EOF
+  cat > "$tmr" <<EOF
+[Unit]
+Description=Run vt-sync-base every ${INTERVAL}s (single-source base cache)
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=${INTERVAL}
+AccuracySec=15
+
+[Install]
+WantedBy=timers.target
+EOF
+  systemctl daemon-reload
+  systemctl enable --now vt-sync-base.timer
+  echo "→ configure-base: installed + started systemd timer vt-sync-base.timer (${INTERVAL}s)"
+}
+
+install_timer_launchd() {
+  local label=com.voicetree.vt-sync-base
+  local plist="$HOME/Library/LaunchAgents/$label.plist"
+  mkdir -p "$HOME/Library/LaunchAgents"
+  cat > "$plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$label</string>
+  <key>ProgramArguments</key>
+  <array><string>$SYNC_BASE</string></array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>VT_BASE_DIR</key><string>$BASE</string>
+    <key>VT_BASE_BRANCH</key><string>$BRANCH</string>
+  </dict>
+  <key>StartInterval</key><integer>${INTERVAL}</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardErrorPath</key><string>$HOME/.cache/vt-sync-base/launchd.err</string>
+  <key>StandardOutPath</key><string>$HOME/.cache/vt-sync-base/launchd.out</string>
+</dict>
+</plist>
+EOF
+  mkdir -p "$HOME/.cache/vt-sync-base"
+  launchctl unload "$plist" >/dev/null 2>&1 || true
+  launchctl load "$plist"
+  echo "→ configure-base: installed + loaded launchd agent $label (${INTERVAL}s)"
+}
+
+if [ "${VT_SKIP_TIMER:-0}" = "1" ]; then
+  echo "→ configure-base: VT_SKIP_TIMER=1 — base configured, timer NOT installed"
+else
+  if [ "$ROLE" = "mac" ]; then install_timer_launchd; else install_timer_systemd; fi
+fi
+
+echo "✔ configure-base: $BASE is a read-only ff cache of origin/$BRANCH. Edit in worktrees; land via origin."

--- a/scripts/dev-setup/dev-flow/_common.sh
+++ b/scripts/dev-setup/dev-flow/_common.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# _common.sh — shared helpers for the machine-LOCAL dev-flow commands
+# (vt-land / vt-sync / vt-pr / vt-worktree). Sourced, never executed.
+#
+# These commands are deliberately NOT `vt` subverbs: on the VM `vt` is a
+# forwarder that ssh's every call to the Mac, so a `vt land` would run on the
+# wrong machine. They are hyphen-named local scripts that act on the LOCAL
+# base/worktree, and nudge the OTHER machine's cache by absolute path over ssh
+# (never the `vt` name). See scripts/dev-setup/distributed-architecture.md.
+
+vt_uname="$(uname -s)"
+
+# Base repo path on each machine (where vt-sync-base.sh lives). Overridable.
+VT_MAC_REPO="${VT_MAC_REPO:-/Users/bobbobby/repos/vtrepo}"
+VT_VM_REPO="${VT_VM_REPO:-/root/vtrepo}"
+VT_SYNC_BASE_REL="scripts/dev-setup/remote/vt-sync-base.sh"
+
+# Repo path for THIS machine.
+self_repo() {
+  if [ "$vt_uname" = "Darwin" ]; then printf '%s' "$VT_MAC_REPO"; else printf '%s' "$VT_VM_REPO"; fi
+}
+
+# Resolve VT_REMOTE_HOST (Mac→VM ssh target) from env, then ~/.env, then repo .env.
+resolve_remote_host() {
+  if [ -n "${VT_REMOTE_HOST:-}" ]; then printf '%s' "$VT_REMOTE_HOST"; return 0; fi
+  local f v top
+  top="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  for f in "$HOME/.env" "${top:+$top/.env}"; do
+    [ -n "$f" ] && [ -f "$f" ] || continue
+    v="$(awk -F= '/^VT_REMOTE_HOST=/{sub(/^VT_REMOTE_HOST=/,""); print; exit}' "$f")"
+    v="${v%\"}"; v="${v#\"}"; v="${v%\'}"; v="${v#\'}"
+    [ -n "$v" ] && { printf '%s' "$v"; return 0; }
+  done
+  return 1
+}
+
+# Fast-forward THIS machine's base now (one tick of the daemon).
+nudge_local() {
+  local s; s="$(self_repo)/$VT_SYNC_BASE_REL"
+  if [ -x "$s" ]; then "$s" || true; else echo "vt: local sync script not found at $s" >&2; fi
+}
+
+# Nudge the OTHER machine's base by ABSOLUTE PATH over ssh (D2) — reuse the `mac`
+# alias / multiplexing already shipped to the devbox; never `ssh host 'vt ...'`.
+nudge_other() {
+  if [ "$vt_uname" = "Darwin" ]; then
+    local host
+    host="$(resolve_remote_host)" || { echo "vt: VT_REMOTE_HOST not set — skipping VM cache nudge (its timer will catch up)" >&2; return 0; }
+    ssh -o BatchMode=yes -o ConnectTimeout=8 "$host" "$VT_VM_REPO/$VT_SYNC_BASE_REL" \
+      || echo "vt: warning: could not nudge VM cache at $host (its timer will catch up)" >&2
+  else
+    ssh -o BatchMode=yes -o ConnectTimeout=8 mac "$VT_MAC_REPO/$VT_SYNC_BASE_REL" \
+      || echo "vt: warning: could not nudge Mac cache via 'ssh mac' (its timer will catch up)" >&2
+  fi
+}
+
+nudge_both() { nudge_local; nudge_other; }
+
+# Refuse dev-flow mutations in the read-only base; require a linked worktree.
+require_worktree() {
+  local gd cd
+  gd="$(git rev-parse --git-dir 2>/dev/null)" || { echo "vt: not inside a git repository" >&2; exit 1; }
+  cd="$(git rev-parse --git-common-dir 2>/dev/null)"
+  if [ "$gd" = "$cd" ]; then
+    echo "vt: this checkout is the read-only base — run from a worktree (vt-worktree <name>)" >&2
+    exit 1
+  fi
+}
+
+# Integration branch to land/PR onto: explicit --onto, else the worktree's
+# upstream (origin/X → X), else $VT_BASE_BRANCH (default dev-manu).
+default_onto() {
+  local up
+  up="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+  case "$up" in
+    origin/*) printf '%s' "${up#origin/}"; return 0 ;;
+  esac
+  printf '%s' "${VT_BASE_BRANCH:-dev-manu}"
+}

--- a/scripts/dev-setup/dev-flow/install.sh
+++ b/scripts/dev-setup/dev-flow/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# install.sh — put the machine-LOCAL dev-flow commands on PATH.
+#
+# Symlinks vt-land / vt-sync / vt-pr / vt-worktree into $HOME/bin — the same dir
+# git-gate installs its `git` shim into, which is already guaranteed first on
+# PATH (interactive, login, and /etc/environment non-login). Idempotent.
+# _common.sh is sourced from the repo via symlink resolution, not installed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST_DIR="${VT_BIN_DIR:-$HOME/bin}"
+mkdir -p "$DEST_DIR"
+
+for cmd in vt-land vt-sync vt-pr vt-worktree; do
+  src="$SCRIPT_DIR/$cmd"
+  [ -f "$src" ] || { echo "install.sh: missing helper $src" >&2; exit 1; }
+  chmod +x "$src"
+  ln -sfn "$src" "$DEST_DIR/$cmd"
+  echo "→ dev-flow: $DEST_DIR/$cmd -> $src"
+done
+
+echo "✔ dev-flow commands installed into $DEST_DIR (git-gate already prepends it to PATH)."

--- a/scripts/dev-setup/dev-flow/vt-land
+++ b/scripts/dev-setup/dev-flow/vt-land
@@ -38,11 +38,16 @@ msg="${positional[0]:-}"
 require_worktree
 [ -n "$onto" ] || onto="$(default_onto)"
 
-# Commit the change being landed, if there is one. Untracked files are left
-# alone (they are not "the change"); only tracked edits are landed.
-if ! git diff --quiet || ! git diff --cached --quiet; then
+# Commit the change being landed, if there is one. Stage EVERYTHING under the
+# worktree (git add -A) — tracked edits AND brand-new files — so landing a new
+# file does the obvious thing. (The old `commit -am` staged only tracked edits,
+# silently dropping new files while still printing "landed".) git-ignored files
+# are excluded by git add -A, so the read-only base's ignored report data etc.
+# never get swept in.
+if [ -n "$(git status --porcelain)" ]; then
   [ -n "$msg" ] || { echo "vt-land: working tree has changes — give a commit message: vt-land [--onto BR] \"msg\"" >&2; exit 1; }
-  git commit -am "$msg"
+  git add -A
+  git commit -m "$msg"
 elif [ -n "$msg" ]; then
   echo "vt-land: nothing to commit; landing the existing HEAD (message ignored)" >&2
 fi
@@ -55,6 +60,21 @@ if ! git rebase "origin/$onto"; then
     echo "vt-land: rebase onto origin/$onto hit a conflict — git will not guess."
     echo "  resolve the conflict, then:  git rebase --continue && vt-land --onto $onto"
     echo "  or back out:                 git rebase --abort"
+  } >&2
+  exit 1
+fi
+
+# After rebasing onto the freshly-fetched tip, HEAD == origin/$onto means there
+# is nothing of ours to push. Refuse loudly rather than printing a misleading
+# "landed" on a no-op push (the new-file footgun, and any empty land).
+onto_before="$(git rev-parse "origin/$onto")"
+head_sha="$(git rev-parse HEAD)"
+if [ "$head_sha" = "$onto_before" ]; then
+  {
+    echo ""
+    echo "vt-land: nothing to land — HEAD is already at origin/$onto (no new commits)."
+    echo "  Nothing was pushed. If you meant to land local work, check 'git log origin/$onto..HEAD';"
+    echo "  vt-land stages all changes (git add -A) before committing, so a new file should land."
   } >&2
   exit 1
 fi
@@ -80,5 +100,13 @@ run_local_check
 
 echo "vt-land: pushing HEAD → origin/$onto"
 git push origin "HEAD:$onto"
-echo "vt-land: landed on origin/$onto — nudging both caches"
+
+# A successful push updates the local refs/remotes/origin/$onto. Assert the ref
+# actually advanced to our HEAD before claiming success — never report "landed"
+# when the remote did not move (e.g. a silent "Everything up-to-date").
+if [ "$(git rev-parse "origin/$onto")" != "$head_sha" ]; then
+  echo "vt-land: push did not advance origin/$onto to ${head_sha:0:9} — NOT landed." >&2
+  exit 1
+fi
+echo "vt-land: landed on origin/$onto (${onto_before:0:9} → ${head_sha:0:9}) — nudging both caches"
 nudge_both

--- a/scripts/dev-setup/dev-flow/vt-land
+++ b/scripts/dev-setup/dev-flow/vt-land
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# vt-land — the quick "make it stick" path (D8). Commit the current change,
+# rebase onto the integration branch so it fast-forwards, run a fast local
+# check, push to origin, and nudge BOTH caches. No PR, no CI — use vt-pr for
+# reviewed work.
+#
+# Usage:
+#   vt-land "message"               # land onto the worktree's upstream (else dev-manu)
+#   vt-land --onto <branch> "msg"   # land onto an explicit branch
+#
+# Safety:
+#   - refuses to run in the read-only base (must be a worktree)
+#   - a real rebase conflict HALTS and asks you to resolve (git won't guess)
+#   - a failed local check aborts BEFORE pushing (keeps the branch green)
+set -euo pipefail
+
+_self="${BASH_SOURCE[0]}"
+while [ -L "$_self" ]; do
+  _t="$(readlink "$_self")"
+  case "$_t" in /*) _self="$_t" ;; *) _self="$(cd "$(dirname "$_self")" && pwd)/$_t" ;; esac
+done
+_DIR="$(cd "$(dirname "$_self")" && pwd)"
+# shellcheck source=_common.sh
+. "$_DIR/_common.sh"
+
+onto=""
+positional=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --onto)    onto="${2:-}"; shift 2 ;;
+    --onto=*)  onto="${1#--onto=}"; shift ;;
+    -h|--help) sed -n '2,/^set -euo/p' "$_self" | sed 's/^# \{0,1\}//;/^set -euo/d'; exit 0 ;;
+    *)         positional+=("$1"); shift ;;
+  esac
+done
+msg="${positional[0]:-}"
+
+require_worktree
+[ -n "$onto" ] || onto="$(default_onto)"
+
+# Commit the change being landed, if there is one. Untracked files are left
+# alone (they are not "the change"); only tracked edits are landed.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  [ -n "$msg" ] || { echo "vt-land: working tree has changes — give a commit message: vt-land [--onto BR] \"msg\"" >&2; exit 1; }
+  git commit -am "$msg"
+elif [ -n "$msg" ]; then
+  echo "vt-land: nothing to commit; landing the existing HEAD (message ignored)" >&2
+fi
+
+echo "vt-land: fetching origin and rebasing onto origin/$onto"
+git fetch origin
+if ! git rebase "origin/$onto"; then
+  {
+    echo ""
+    echo "vt-land: rebase onto origin/$onto hit a conflict — git will not guess."
+    echo "  resolve the conflict, then:  git rebase --continue && vt-land --onto $onto"
+    echo "  or back out:                 git rebase --abort"
+  } >&2
+  exit 1
+fi
+
+# Fast local sanity gate (OD-3): keep a broken commit off the shared branch.
+# Override with VT_LAND_CHECK="<command>"; set VT_LAND_CHECK= (empty) to skip.
+run_local_check() {
+  if [ "${VT_LAND_CHECK+set}" = set ]; then
+    [ -n "$VT_LAND_CHECK" ] || { echo "vt-land: VT_LAND_CHECK empty — skipping local gate" >&2; return 0; }
+    echo "vt-land: local check: $VT_LAND_CHECK" >&2
+    bash -c "$VT_LAND_CHECK" || { echo "vt-land: local check failed — NOT landing" >&2; exit 1; }
+    return 0
+  fi
+  local root; root="$(git rev-parse --show-toplevel)"
+  if [ -f "$root/package.json" ] && grep -q '"typecheck"' "$root/package.json" 2>/dev/null; then
+    echo "vt-land: running 'pnpm -s typecheck'" >&2
+    ( cd "$root" && pnpm -s typecheck ) || { echo "vt-land: typecheck failed — NOT landing" >&2; exit 1; }
+  else
+    echo "vt-land: no 'typecheck' script and no VT_LAND_CHECK — skipping local gate (set VT_LAND_CHECK to enforce one)" >&2
+  fi
+}
+run_local_check
+
+echo "vt-land: pushing HEAD → origin/$onto"
+git push origin "HEAD:$onto"
+echo "vt-land: landed on origin/$onto — nudging both caches"
+nudge_both

--- a/scripts/dev-setup/dev-flow/vt-pr
+++ b/scripts/dev-setup/dev-flow/vt-pr
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# vt-pr — the reviewed path (D8). Commit (optional), push the feature branch,
+# and open a PR against the integration branch via gh. Slower on purpose (CI +
+# review); use vt-land for quick solo changes.
+#
+# Usage:
+#   vt-pr ["message"]               # PR against the worktree's upstream (else dev-manu)
+#   vt-pr --onto <branch> ["msg"]   # PR against an explicit base branch
+set -euo pipefail
+
+_self="${BASH_SOURCE[0]}"
+while [ -L "$_self" ]; do
+  _t="$(readlink "$_self")"
+  case "$_t" in /*) _self="$_t" ;; *) _self="$(cd "$(dirname "$_self")" && pwd)/$_t" ;; esac
+done
+_DIR="$(cd "$(dirname "$_self")" && pwd)"
+# shellcheck source=_common.sh
+. "$_DIR/_common.sh"
+
+onto=""
+positional=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --onto|--base) onto="${2:-}"; shift 2 ;;
+    --onto=*)      onto="${1#--onto=}"; shift ;;
+    --base=*)      onto="${1#--base=}"; shift ;;
+    -h|--help)     sed -n '2,/^set -euo/p' "$_self" | sed 's/^# \{0,1\}//;/^set -euo/d'; exit 0 ;;
+    *)             positional+=("$1"); shift ;;
+  esac
+done
+msg="${positional[0]:-}"
+
+require_worktree
+[ -n "$onto" ] || onto="$(default_onto)"
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "$onto" ]; then
+  echo "vt-pr: HEAD is on '$onto' (the base of the PR) — create the worktree on a feature branch instead" >&2
+  exit 1
+fi
+
+if { ! git diff --quiet || ! git diff --cached --quiet; } && [ -n "$msg" ]; then
+  git commit -am "$msg"
+elif { ! git diff --quiet || ! git diff --cached --quiet; }; then
+  echo "vt-pr: uncommitted changes present — commit them first, or pass a message: vt-pr \"msg\"" >&2
+  exit 1
+fi
+
+echo "vt-pr: pushing $branch to origin"
+git push -u origin "$branch"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "vt-pr: pushed '$branch'. gh CLI not found — open the PR manually against '$onto'." >&2
+  exit 0
+fi
+gh pr create --base "$onto" --head "$branch" --fill

--- a/scripts/dev-setup/dev-flow/vt-sync
+++ b/scripts/dev-setup/dev-flow/vt-sync
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# vt-sync — fast-forward THIS machine's read-only base to origin now, then nudge
+# the other machine's base too. The on-demand counterpart to the 2-3 min timer.
+#
+# Usage:
+#   vt-sync                # ff this base + nudge the other machine
+#   vt-sync --local-only   # ff only this machine's base
+set -euo pipefail
+
+_self="${BASH_SOURCE[0]}"
+while [ -L "$_self" ]; do
+  _t="$(readlink "$_self")"
+  case "$_t" in /*) _self="$_t" ;; *) _self="$(cd "$(dirname "$_self")" && pwd)/$_t" ;; esac
+done
+_DIR="$(cd "$(dirname "$_self")" && pwd)"
+# shellcheck source=_common.sh
+. "$_DIR/_common.sh"
+
+case "${1:-}" in
+  --local-only) nudge_local ;;
+  -h|--help)    sed -n '2,/^set -euo/p' "$_self" | sed 's/^# \{0,1\}//;/^set -euo/d' ;;
+  "")           nudge_both ;;
+  *)            echo "vt-sync: unknown argument: $1 (try --local-only)" >&2; exit 64 ;;
+esac

--- a/scripts/dev-setup/dev-flow/vt-worktree
+++ b/scripts/dev-setup/dev-flow/vt-worktree
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# vt-worktree — create a writable worktree off origin/<branch> (the ONLY place
+# you edit, since the base is read-only). Branch defaults to $VT_BASE_BRANCH.
+# git-gate owns placement (under this machine's worktree root) and auto-installs
+# deps, so just pass a name.
+#
+# Usage:
+#   vt-worktree <name> [<branch>]    # branch defaults to dev-manu (VT_BASE_BRANCH)
+set -euo pipefail
+
+name="${1:-}"
+branch="${2:-${VT_BASE_BRANCH:-dev-manu}}"
+if [ -z "$name" ] || [ "$name" = "-h" ] || [ "$name" = "--help" ]; then
+  echo "usage: vt-worktree <name> [<branch>]   (branch defaults to ${VT_BASE_BRANCH:-dev-manu})" >&2
+  [ -z "$name" ] && exit 64 || exit 0
+fi
+
+# Refresh origin so we branch off the latest (the base may be mid-tick).
+git fetch origin "$branch" >/dev/null 2>&1 || git fetch origin >/dev/null 2>&1 || true
+
+# git-gate rewrites the destination into this machine's worktree root and runs
+# the dep bootstrap; we pass a bare name and read the resulting path back.
+git worktree add -b "$name" "$name" "origin/$branch"
+
+path="$(git worktree list --porcelain | awk -v b="refs/heads/$name" '
+  /^worktree /{p=$2} $0=="branch "b{print p; exit}')"
+echo ""
+echo "vt-worktree: created '$name' off origin/$branch"
+[ -n "$path" ] && echo "  cd $path     # edit + run there; then: vt-land \"msg\"  (or vt-pr)"

--- a/scripts/dev-setup/dev-flow/vt-worktree
+++ b/scripts/dev-setup/dev-flow/vt-worktree
@@ -4,9 +4,23 @@
 # git-gate owns placement (under this machine's worktree root) and auto-installs
 # deps, so just pass a name.
 #
+# The command that takes you INTO a worktree must work from ANY cwd — you do not
+# live in the base — so it resolves the base (VT_BASE_DIR, else this machine's
+# repo) and runs every git against it with `git -C "$base"`, rather than assuming
+# the cwd is a checkout.
+#
 # Usage:
 #   vt-worktree <name> [<branch>]    # branch defaults to dev-manu (VT_BASE_BRANCH)
 set -euo pipefail
+
+_self="${BASH_SOURCE[0]}"
+while [ -L "$_self" ]; do
+  _t="$(readlink "$_self")"
+  case "$_t" in /*) _self="$_t" ;; *) _self="$(cd "$(dirname "$_self")" && pwd)/$_t" ;; esac
+done
+_DIR="$(cd "$(dirname "$_self")" && pwd)"
+# shellcheck source=_common.sh
+. "$_DIR/_common.sh"
 
 name="${1:-}"
 branch="${2:-${VT_BASE_BRANCH:-dev-manu}}"
@@ -15,14 +29,22 @@ if [ -z "$name" ] || [ "$name" = "-h" ] || [ "$name" = "--help" ]; then
   [ -z "$name" ] && exit 64 || exit 0
 fi
 
+# Resolve the base checkout; never depend on the caller's cwd being a repo.
+base="${VT_BASE_DIR:-$(self_repo)}"
+[ -d "$base/.git" ] || {
+  echo "vt-worktree: base '$base' is not a git repository." >&2
+  echo "  Set VT_BASE_DIR to your base checkout (the read-only cache of origin)." >&2
+  exit 1
+}
+
 # Refresh origin so we branch off the latest (the base may be mid-tick).
-git fetch origin "$branch" >/dev/null 2>&1 || git fetch origin >/dev/null 2>&1 || true
+git -C "$base" fetch origin "$branch" >/dev/null 2>&1 || git -C "$base" fetch origin >/dev/null 2>&1 || true
 
 # git-gate rewrites the destination into this machine's worktree root and runs
 # the dep bootstrap; we pass a bare name and read the resulting path back.
-git worktree add -b "$name" "$name" "origin/$branch"
+git -C "$base" worktree add -b "$name" "$name" "origin/$branch"
 
-path="$(git worktree list --porcelain | awk -v b="refs/heads/$name" '
+path="$(git -C "$base" worktree list --porcelain | awk -v b="refs/heads/$name" '
   /^worktree /{p=$2} $0=="branch "b{print p; exit}')"
 echo ""
 echo "vt-worktree: created '$name' off origin/$branch"

--- a/scripts/dev-setup/distributed-architecture.md
+++ b/scripts/dev-setup/distributed-architecture.md
@@ -53,21 +53,40 @@ forwards to the Mac, so a `vt land` would run on the wrong machine. They act on
 the local base/worktree and nudge the OTHER machine's cache by absolute path over
 ssh (`ssh mac …` / `ssh $VT_REMOTE_HOST …`), never via the `vt` name.
 
-## Enforcement — how "read-only" is real (3 layers)
+## Enforcement — how "read-only" is real (2 layers + self-heal)
 
-1. **Structural (pinned branch):** the base's `dev-manu` is advanced only by the
-   daemon's `merge --ff-only`. There is nothing for a user command to push that
-   wouldn't be a no-op ff.
-2. **Prevent (git-gate):** `scripts/dev-setup/git-gate/git-gate.sh` refuses
-   `commit|merge|rebase|reset|cherry-pick|am|apply` in the **main worktree** of a
-   voicetree clone (detected by `git-dir == git-common-dir` + origin URL). Linked
-   worktrees are always writable. The daemon bypasses the whole gate with
-   `VT_SYNC=1`.
+1. **Prevent (git-gate):** `scripts/dev-setup/git-gate/git-gate.sh` refuses
+   `commit|merge|rebase|reset|cherry-pick|am|pull|revert|update-ref` (and a
+   *mutating* `apply` — read-only `--check`/`--stat`/`--numstat`/`--summary`
+   probes are allowed) in the **main worktree** of a voicetree clone (detected by
+   `git-dir == git-common-dir` + origin URL). Linked worktrees are always
+   writable. The daemon bypasses the whole gate with `VT_SYNC=1`.
+
+   **This is a PATH-shim guardrail, not a hard boundary.** It only intercepts
+   callers that resolve `git` through `$HOME/bin` — any actor invoking real git
+   directly (`/usr/bin/git`, a shell alias, `gh`, the VoiceTree app / IDEs /
+   language servers via libgit2/nodegit) edits the base freely. Because the base
+   keeps a *real* pinned branch (below), such an out-of-band commit STICKS on the
+   ref and the daemon then refuses to fast-forward over it → a persistent
+   `diverged` alert until a manual re-pin. So the guard makes the *everyday*
+   bypass hard; it does not make divergence impossible. (A daemon-installed
+   `reference-transaction` / `pre-commit` hook in the base would catch all
+   binaries and close the whole class — a possible future hardening, not built.)
+2. **Pinned-branch ff-only (the base ref's only legitimate writer):** the base's
+   `dev-manu` is advanced ONLY by the daemon's `merge --ff-only`. There is nothing
+   for a user command to push that wouldn't be a no-op ff.
 3. **Self-heal (the daemon, `vt-sync-base.sh`):** every ~2-3 min (and on demand
    via `vt-sync` / `vt-land`) it runs `git fetch origin --prune` then
    `git merge --ff-only origin/$VT_BASE_BRANCH`. It NEVER resets over data: on a
-   dirty / diverged / ff-collision base it raises an alert (red VoiceTree node +
-   OS notification) and retries idempotently.
+   dirty / diverged / ff-collision base it raises an alert and retries
+   idempotently. Alert delivery is best-effort on every path; the durable record
+   is the daemon log (`~/.cache/vt-sync-base/vt-sync-base.log`). On the Mac the OS
+   notification is the live channel; **on the headless VM the graph node is the
+   primary channel** — there `notify-send` needs a `DISPLAY` and `wall` reaches no
+   one, so set `VT_ALERT_PARENT_NODE` (configure-base threads it into the timer)
+   for VM alerts to land. The VM's graph-create rides the `vt` forwarder over the
+   reverse ssh tunnel to the Mac (where the graph lives), so VM alerting depends
+   on that tunnel being up.
 
 ## Components
 
@@ -105,3 +124,11 @@ Naming convention:
 
 Dependency install is routed by `VT_DEV_ROLE` (`mac` vs `remote`) in the worktree
 async hook; `VT_DEV_ROLE` is used ONLY for dep routing, never to compute a path.
+
+After a `worktree add`, git-gate normalizes the new worktree's admin pointers to
+**relative** paths (host-portable, needed for cross-host mutagen sync) via
+`git worktree repair --relative-paths`. That flag exists only on **git ≥ 2.48**;
+on older git (e.g. the VM's 2.43) it falls back to a plain `worktree repair` and
+the pointers stay absolute. That is harmless for VM-local `/root/vt-wts` trees
+(they never sync across hosts), but the host-portable-pointer benefit for the
+Mac's mirrored `vt-wts-synced` trees is unavailable until git is upgraded.

--- a/scripts/dev-setup/distributed-architecture.md
+++ b/scripts/dev-setup/distributed-architecture.md
@@ -75,7 +75,7 @@ ssh (`ssh mac …` / `ssh $VT_REMOTE_HOST …`), never via the `vt` name.
 2. **Pinned-branch ff-only (the base ref's only legitimate writer):** the base's
    `dev-manu` is advanced ONLY by the daemon's `merge --ff-only`. There is nothing
    for a user command to push that wouldn't be a no-op ff.
-3. **Self-heal (the daemon, `vt-sync-base.sh`):** every ~2-3 min (and on demand
+3. **Self-heal (the daemon, `vt-sync-base.sh`):** every ~10s (and on demand
    via `vt-sync` / `vt-land`) it runs `git fetch origin --prune` then
    `git merge --ff-only origin/$VT_BASE_BRANCH`. It NEVER resets over data: on a
    dirty / diverged / ff-collision base it raises an alert and retries
@@ -95,7 +95,7 @@ ssh (`ssh mac …` / `ssh $VT_REMOTE_HOST …`), never via the `vt` name.
 | read-only guard | `git-gate/git-gate.sh` | both | refuse ref-moves in the base |
 | base config | `common/configure-base.sh` (via `setup-{devbox,laptop}-env.sh --configure-base`) | both | pin branch ff, migration guard, daily worktree, timer |
 | sync daemon | `remote/vt-sync-base.sh` | both | fetch + ff the base (self-heal + alert) |
-| timer | systemd (VM) / launchd (Mac), written by configure-base | both | run the daemon every ~2-3 min |
+| timer | systemd (VM) / launchd (Mac), written by configure-base | both | run the daemon every ~10s |
 | `vt-sync` | `dev-flow/vt-sync` | both | ff this base now + nudge the other |
 | `vt-land` / `vt-pr` | `dev-flow/` | both | the dev-flow one-liners above |
 | `vt-worktree` | `dev-flow/vt-worktree` | both | make a writable worktree off origin |

--- a/scripts/dev-setup/distributed-architecture.md
+++ b/scripts/dev-setup/distributed-architecture.md
@@ -1,44 +1,107 @@
 # Distributed dev architecture
 
+## Single source of truth: origin is the only writable copy
+
+`dev-manu` (and every branch) used to exist as three independently-writable
+copies — the Mac checkout, the VM checkout, and origin — so they drifted and you
+held a 3-way "are Mac/VM/origin in sync?" diff in your head. Under the
+single-source model there is exactly one writable copy of any branch — **origin**
+— and each machine's base checkout is a **read-only fast-forward cache** of it.
+
+```
+        origin/<branch>        ◀──────────── the ONLY writable copy
+         ▲   ▲      │   │
+   push  │   │      │   │ ff (auto, can't conflict)
+ feature │   │      ▼   ▼
+   ┌─────┘   │   Mac base ── read-only ff cache (pinned local dev-manu @ origin)
+   │         └── VM  base ── read-only ff cache (pinned local dev-manu @ origin)
+   │                  │
+   │  bases NEVER written locally → ff is always clean, never conflicts
+   │
+ worktrees (the only writable trees) branch off origin/<branch>, push to origin
+```
+
+- **Base checkout** (`~/repos/vtrepo` on Mac, `/root/vtrepo` on the VM) = a
+  read-only cache. It keeps a **real pinned local branch** (`dev-manu`, override
+  `$VT_BASE_BRANCH`) advanced ONLY by the sync daemon via `git merge --ff-only
+  origin/<branch>` — a friendly branch name, not detached HEAD. It is also a
+  full fetch-mirror of `origin/*`, so worktrees can branch off ANY branch.
+- **Worktrees** = the only writable trees. One branch, one owner machine.
+- A change reaches a branch ONLY via origin (PR merge or fast-forward push). The
+  caches only follow. One writer can't disagree with itself → nothing to reconcile.
+
+The one rule to hold, identical on Mac and VM:
+**don't edit the base; work in a worktree; integration is a push to origin.**
+
+## Dev flow (same on either machine)
+
+```
+vt-worktree feat            # git worktree add -b feat … origin/dev-manu (gate places + installs deps)
+cd <printed path>           # edit + run the app here (the base rejects commits)
+# quick / solo:
+vt-land "msg"               # commit → fetch → rebase origin/dev-manu → fast check → push HEAD:dev-manu → nudge both caches
+# reviewed:
+vt-pr  "msg"                # push feature branch + gh pr create --base dev-manu → CI → merge
+```
+
+The **daily-driver worktree** (`$VT_WORKTREE_ROOT/daily` on `daily-mac` /
+`daily-vm`, created by the installer) is the stable "local dev" home so you never
+reach back into the base. It falls behind origin until its next land/rebase.
+
+These helpers are **machine-LOCAL commands, not `vt` subverbs** — on the VM `vt`
+forwards to the Mac, so a `vt land` would run on the wrong machine. They act on
+the local base/worktree and nudge the OTHER machine's cache by absolute path over
+ssh (`ssh mac …` / `ssh $VT_REMOTE_HOST …`), never via the `vt` name.
+
+## Enforcement — how "read-only" is real (3 layers)
+
+1. **Structural (pinned branch):** the base's `dev-manu` is advanced only by the
+   daemon's `merge --ff-only`. There is nothing for a user command to push that
+   wouldn't be a no-op ff.
+2. **Prevent (git-gate):** `scripts/dev-setup/git-gate/git-gate.sh` refuses
+   `commit|merge|rebase|reset|cherry-pick|am|apply` in the **main worktree** of a
+   voicetree clone (detected by `git-dir == git-common-dir` + origin URL). Linked
+   worktrees are always writable. The daemon bypasses the whole gate with
+   `VT_SYNC=1`.
+3. **Self-heal (the daemon, `vt-sync-base.sh`):** every ~2-3 min (and on demand
+   via `vt-sync` / `vt-land`) it runs `git fetch origin --prune` then
+   `git merge --ff-only origin/$VT_BASE_BRANCH`. It NEVER resets over data: on a
+   dirty / diverged / ff-collision base it raises an alert (red VoiceTree node +
+   OS notification) and retries idempotently.
+
+## Components
+
+| Component | Where | Runs on | Does |
+|-----------|-------|---------|------|
+| read-only guard | `git-gate/git-gate.sh` | both | refuse ref-moves in the base |
+| base config | `common/configure-base.sh` (via `setup-{devbox,laptop}-env.sh --configure-base`) | both | pin branch ff, migration guard, daily worktree, timer |
+| sync daemon | `remote/vt-sync-base.sh` | both | fetch + ff the base (self-heal + alert) |
+| timer | systemd (VM) / launchd (Mac), written by configure-base | both | run the daemon every ~2-3 min |
+| `vt-sync` | `dev-flow/vt-sync` | both | ff this base now + nudge the other |
+| `vt-land` / `vt-pr` | `dev-flow/` | both | the dev-flow one-liners above |
+| `vt-worktree` | `dev-flow/vt-worktree` | both | make a writable worktree off origin |
+
+Kept mutagen sessions (created via `vt-remote.sh`): `vt-wts` (Mac→VM worktree
+mirror for remote test runs) and the health-dashboard data syncs (`vt-csv-history`,
+`vt-reports`). The retired `vt-remote` full-repo replica (`/root/vtrepo-synced`)
+is gone — teardown with `mutagen sync terminate vt-remote`.
+
 ## Worktree placement (owned by the git wrapper, not the app)
 
 The VoiceTree app is worktree-convention-free: it runs `git worktree add` with a
 bare name and reads the resulting path back from git. ALL placement lives in the
-machine-level git wrapper (`scripts/dev-setup/git-gate/git-gate.sh`), configured
-per machine via `VT_WORKTREE_ROOT` (written by the git-gate installer):
+machine-level git wrapper (`git-gate/git-gate.sh`), configured per machine via
+`VT_WORKTREE_ROOT` (written by the git-gate installer):
 
 | Machine        | Worktree root (`VT_WORKTREE_ROOT`) | Mirrored? |
 | -------------- | ---------------------------------- | --------- |
-| macOS          | `$HOME/repos/vt-wts-synced`        | yes       |
+| macOS          | `$HOME/repos/vt-wts-synced`        | yes (`vt-wts`) |
 | Linux / remote | `$HOME/vt-wts`  (= `/root/vt-wts`) | no        |
 
 Naming convention:
-- `-synced` suffix = "part of the mutagen mirror" — the **same basename on both
+- `-synced` suffix = part of the mutagen mirror — the **same basename on both
   ends** of the sync.
 - no suffix (`vt-wts`) = locally-authored, **not** mirrored.
 
-## Source trees
-
-Mac-owned source (mirrored to the remote via mutagen):
-- `~/repos/vtrepo`          ↔ `/root/vtrepo-synced`
-- `~/repos/vt-wts-synced`   ↔ `/root/vt-wts-synced`
-
-Remote-owned source (lives only on the dev box, not mirrored):
-- `/root/vtrepo`
-- `/root/vt-wts`
-
-## Placement map
-
-- Mac authors a worktree  → `~/repos/vt-wts-synced/<name>` → mutagen →
-  remote `/root/vt-wts-synced/<name>`.
-- Remote authors a worktree → `/root/vt-wts/<name>` (local, not mirrored).
-
-## Rules
-
-- `*-synced` is owned by Mac + mutagen; do not edit it as source of truth on the
-  remote.
-- Remote agents that own their work use `/root/vtrepo` and `/root/vt-wts`.
-- Dependency install is routed by `VT_DEV_ROLE` (`mac` vs `remote`) in the
-  worktree async hook — Mac-created worktrees install deps locally and in the
-  synced root; remote-created worktrees install deps only in `/root/vt-wts`.
-  `VT_DEV_ROLE` is used ONLY for dep routing, never to compute a worktree path.
+Dependency install is routed by `VT_DEV_ROLE` (`mac` vs `remote`) in the worktree
+async hook; `VT_DEV_ROLE` is used ONLY for dep routing, never to compute a path.

--- a/scripts/dev-setup/git-gate/git-gate.sh
+++ b/scripts/dev-setup/git-gate/git-gate.sh
@@ -101,27 +101,58 @@ in_voicetree_base() {
   esac
 }
 
+# Emit the read-only-base block message (with a divergence-recovery hint) and exit.
+deny_base_edit() {
+  local base_top
+  base_top="$("$REAL_GIT" "${GATE_GLOBAL_OPTS[@]}" rev-parse --show-toplevel 2>/dev/null || true)"
+  {
+    echo ""
+    echo "  ✗ git-gate: BLOCKED — this checkout is the origin cache (read-only base)."
+    echo "    command: git ${ORIG_ARGS[*]}"
+    echo ""
+    echo "    The base is a read-only fast-forward cache of origin/$(gate_base_branch)."
+    echo "    Editing happens in a worktree; integration happens via origin —"
+    echo "    the base only ever fast-forwards. Never commit/merge/rebase/pull/revert here."
+    echo ""
+    echo "    Work in a worktree instead:"
+    echo "      vt-worktree <name> [<branch>]   # or: git worktree add -b <name> <name> origin/<branch>"
+    echo "    Then land it:"
+    echo "      vt-land \"msg\"                   # quick fast-forward push to the integration branch"
+    echo "      vt-pr                           # open a PR for reviewed work"
+    echo ""
+    echo "    If the base has already diverged from origin, re-pin it with:"
+    echo "      VT_SYNC=1 git -C ${base_top:-<base>} reset --hard origin/$(gate_base_branch)"
+    echo ""
+  } >&2
+  exit 1
+}
+
+# `git apply` cannot move a ref, but a real apply dirties the read-only base (the
+# daemon then refuses to fast-forward). Treat apply as mutating UNLESS it carries
+# only a read-only inspection flag — `--check` / `--stat` / `--numstat` /
+# `--summary` touch nothing, so tooling that probes patches must stay unblocked.
+# A bare `-R` (reverse-apply) DOES write the tree, so it remains gated.
+apply_is_readonly() {
+  local a
+  for a in "$@"; do
+    case "$a" in
+      --check|--stat|--numstat|--summary) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# D5 read-only base guard. `pull` (= fetch+merge) and `revert` (= a commit) both
+# move the base ref and were the everyday muscle-memory bypasses of the original
+# list; `update-ref` rewrites the ref directly. All are gated here. The sync
+# daemon and configure-base reach these paths with VT_SYNC=1 (whole-gate bypass,
+# handled at the very top) so the legitimate fast-forward is never blocked.
 case "$sub" in
-  commit|merge|rebase|reset|cherry-pick|am|apply)
-    if in_voicetree_base; then
-      {
-        echo ""
-        echo "  ✗ git-gate: BLOCKED — this checkout is the origin cache (read-only base)."
-        echo "    command: git ${ORIG_ARGS[*]}"
-        echo ""
-        echo "    The base is a read-only fast-forward cache of origin/$(gate_base_branch)."
-        echo "    Editing happens in a worktree; integration happens via origin —"
-        echo "    the base only ever fast-forwards. Never commit/merge/rebase here."
-        echo ""
-        echo "    Work in a worktree instead:"
-        echo "      vt-worktree <name> [<branch>]   # or: git worktree add -b <name> <name> origin/<branch>"
-        echo "    Then land it:"
-        echo "      vt-land \"msg\"                   # quick fast-forward push to the integration branch"
-        echo "      vt-pr                           # open a PR for reviewed work"
-        echo ""
-      } >&2
-      exit 1
-    fi
+  commit|merge|rebase|reset|cherry-pick|am|pull|revert|update-ref)
+    in_voicetree_base && deny_base_edit
+    ;;
+  apply)
+    if in_voicetree_base && ! apply_is_readonly "${@:2}"; then deny_base_edit; fi
     ;;
 esac
 
@@ -133,40 +164,10 @@ gate_worktree_root() {
   printf '%s' "${VT_WORKTREE_ROOT:-$HOME/vt-wts}"
 }
 
-worktree_add_path_arg() {
-  local expect_option_value=0
-  local after_separator=0
-  local arg
-  for arg in "${@:3}"; do
-    if [ "$after_separator" -eq 1 ]; then
-      printf '%s\n' "$arg"
-      return 0
-    fi
-    if [ "$expect_option_value" -eq 1 ]; then
-      expect_option_value=0
-      continue
-    fi
-    case "$arg" in
-      --)
-        after_separator=1
-        ;;
-      -b|-B|--orphan|--reason)
-        expect_option_value=1
-        ;;
-      -*)
-        ;;
-      *)
-        printf '%s\n' "$arg"
-        return 0
-        ;;
-    esac
-  done
-}
-
-# Like worktree_add_path_arg, but prints the 1-based index of the destination
-# positional within the passed args (the stripped `worktree add ...` argv), so
-# the caller can REWRITE that element for placement enforcement. Empty if none.
-# Scanning starts at $3 (after the `worktree add` tokens).
+# Print the 1-based index of the destination positional within the passed args
+# (the stripped `worktree add ...` argv). The caller reads the value back with
+# `${!idx}` and can REWRITE that element for placement enforcement. Empty if no
+# destination positional is present. Scanning starts at $3 (after `worktree add`).
 worktree_add_path_index() {
   local i=3 n=$#
   local expect_option_value=0
@@ -309,26 +310,25 @@ if [ "$sub" = "worktree" ] && [ "$sub_arg" = "add" ]; then
   # <worktree-root>/<basename-of-given-path> so callers (the VoiceTree app,
   # agents, plain `git worktree add -b x x`) never need to know the convention.
   # Escape hatch: VT_GIT_GATE_NO_PLACEMENT=1 honors the caller's explicit path.
+  given_idx="$(worktree_add_path_index "$@")"
   if [ "${VT_GIT_GATE_NO_PLACEMENT:-}" = "1" ]; then
-    wt_path="$(worktree_add_path_arg "$@")"
+    # Honor the caller's explicit destination path (no placement rewrite).
+    wt_path="${given_idx:+${!given_idx}}"
+  elif [ -n "$given_idx" ]; then
+    given_path="${!given_idx}"
+    wt_root="$(gate_worktree_root)"
+    wt_path="$wt_root/$(basename "$given_path")"
+    mkdir -p "$wt_root"
+    # Replace the destination positional in the stripped argv, then rebuild
+    # the full real-git argv as <global opts> + <rewritten subcommand args>.
+    rewritten=("$@")
+    rewritten[$((given_idx - 1))]="$wt_path"
+    ORIG_ARGS=("${GATE_GLOBAL_OPTS[@]}" "${rewritten[@]}")
+    echo "git-gate: placement → $wt_path" >&2
   else
-    given_idx="$(worktree_add_path_index "$@")"
-    if [ -n "$given_idx" ]; then
-      given_path="${!given_idx}"
-      wt_root="$(gate_worktree_root)"
-      wt_path="$wt_root/$(basename "$given_path")"
-      mkdir -p "$wt_root"
-      # Replace the destination positional in the stripped argv, then rebuild
-      # the full real-git argv as <global opts> + <rewritten subcommand args>.
-      rewritten=("$@")
-      rewritten[$((given_idx - 1))]="$wt_path"
-      ORIG_ARGS=("${GATE_GLOBAL_OPTS[@]}" "${rewritten[@]}")
-      echo "git-gate: placement → $wt_path" >&2
-    else
-      # No destination positional found — leave argv untouched (real git will
-      # error on its own, which is the correct surface for a malformed add).
-      wt_path="$(worktree_add_path_arg "$@")"
-    fi
+    # No destination positional found — leave argv untouched (real git will
+    # error on its own, which is the correct surface for a malformed add).
+    wt_path=""
   fi
   echo "git-gate: running git worktree add" >&2
   "$REAL_GIT" "${ORIG_ARGS[@]}"

--- a/scripts/dev-setup/git-gate/git-gate.sh
+++ b/scripts/dev-setup/git-gate/git-gate.sh
@@ -25,6 +25,16 @@ for cand in /opt/homebrew/bin/git /usr/local/bin/git /usr/bin/git /opt/local/bin
 done
 [ -n "$REAL_GIT" ] || { echo "git-gate: cannot find real git" >&2; exit 127; }
 
+# VT_SYNC=1 short-circuits the ENTIRE gate (D3). The read-only-base sync daemon
+# (vt-sync-base.sh) and the first-run base configuration run their own git with
+# this set: they must never hit the read-only base guard, the checkout/reset
+# reason logic, or any password prompt (they run with no TTY and would deadlock).
+# This is the single blessed bypass — and it is intentionally the very first
+# thing the gate does, before any argv parsing or reason logic.
+if [ "${VT_SYNC:-}" = "1" ]; then
+  exec "$REAL_GIT" "$@"
+fi
+
 # Preserve the original argv so we can forward it unchanged to real git later.
 # Then strip git's global options ahead of the subcommand so that callers like
 # `git -C <path> worktree add ...` or `git --git-dir=... worktree add ...` are
@@ -64,6 +74,56 @@ sub_arg="${2:-}"
 rest="${*:2}"
 reason=""
 suggestion=""
+
+# --- D5 read-only base guard ------------------------------------------------
+# The MAIN worktree of a voicetree clone is the read-only fast-forward cache of
+# origin (the "base"). All editing happens in linked worktrees; integration
+# happens via origin. Refuse ref-moving subcommands in the base with a helpful
+# message. Detection is structural and machine-independent:
+#   - main worktree:   git-dir == git-common-dir
+#   - linked worktree: they differ → always allowed (never gated here)
+# and confirmed to be a voicetree clone via the origin URL, so unrelated repos
+# (e.g. brain) are untouched. The sync daemon is already exempt via VT_SYNC=1.
+gate_base_branch() { printf '%s' "${VT_BASE_BRANCH:-dev-manu}"; }
+
+in_voicetree_base() {
+  local gd cd url
+  gd="$("$REAL_GIT" "${GATE_GLOBAL_OPTS[@]}" rev-parse --git-dir 2>/dev/null)" || return 1
+  cd="$("$REAL_GIT" "${GATE_GLOBAL_OPTS[@]}" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  [ -n "$gd" ] && [ "$gd" = "$cd" ] || return 1
+  url="$("$REAL_GIT" "${GATE_GLOBAL_OPTS[@]}" remote get-url origin 2>/dev/null)" || return 1
+  # Match the voicetree[-public] repo at a path boundary (covers https, ssh, and
+  # local-path origins) so a repo merely ending in "...voicetree.git" can't false
+  # positive. The trailing .git is optional (local clones may omit it).
+  case "$url" in
+    */voicetree.git|*/voicetree|*/voicetree-public.git|*/voicetree-public) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+case "$sub" in
+  commit|merge|rebase|reset|cherry-pick|am|apply)
+    if in_voicetree_base; then
+      {
+        echo ""
+        echo "  ✗ git-gate: BLOCKED — this checkout is the origin cache (read-only base)."
+        echo "    command: git ${ORIG_ARGS[*]}"
+        echo ""
+        echo "    The base is a read-only fast-forward cache of origin/$(gate_base_branch)."
+        echo "    Editing happens in a worktree; integration happens via origin —"
+        echo "    the base only ever fast-forwards. Never commit/merge/rebase here."
+        echo ""
+        echo "    Work in a worktree instead:"
+        echo "      vt-worktree <name> [<branch>]   # or: git worktree add -b <name> <name> origin/<branch>"
+        echo "    Then land it:"
+        echo "      vt-land \"msg\"                   # quick fast-forward push to the integration branch"
+        echo "      vt-pr                           # open a PR for reviewed work"
+        echo ""
+      } >&2
+      exit 1
+    fi
+    ;;
+esac
 
 # Per-machine worktree root. This wrapper is the ONE place that owns worktree
 # PLACEMENT: callers pass a bare name and we put the tree here. The default
@@ -344,13 +404,14 @@ if [ "$sub" = "worktree" ] && [ "$sub_arg" = "remove" ]; then
       fi
       if [ -n "$remote_host" ]; then
         echo "git-gate: removing matching remote worktree residue on $remote_host" >&2
-        remote_root="/root/vtrepo-synced"
+        # The vt-remote full-repo mutagen replica (/root/vtrepo-synced) is retired
+        # under the single-source model; only the vt-wts worktree mirror remains.
         remote_wts_root="/root/vt-wts-synced"
         ssh -o BatchMode=yes -o ConnectTimeout=5 "$remote_host" \
-          "rm -rf '$remote_root/.git/worktrees/$wt_name' '$remote_root/.worktrees/$wt_name' '$remote_wts_root/$wt_name'" \
+          "rm -rf '$remote_wts_root/$wt_name'" \
           >/dev/null 2>&1 \
           && echo "git-gate: remote worktree residue removed for $wt_name" >&2 \
-          || echo "git-gate: warning: failed to ssh-clean $wt_name on $remote_host — drift may follow; run 'mutagen sync list vt-remote' to check" >&2
+          || echo "git-gate: warning: failed to ssh-clean $wt_name on $remote_host — drift may follow; run 'mutagen sync list vt-wts' to check" >&2
       else
         echo "git-gate: no VT_REMOTE_HOST found; skipping remote residue cleanup" >&2
       fi

--- a/scripts/dev-setup/remote/install.sh
+++ b/scripts/dev-setup/remote/install.sh
@@ -2,11 +2,14 @@
 # install.sh — one-shot setup for routing dev commands to a remote dev box.
 #
 # Wires up the laptop side: writes VT_REMOTE_HOST to .env and ~/.env,
-# marks this machine as the Mac dev role, verifies SSH,
-# (optionally) pre-seeds the devbox with a fresh GitHub clone so the first
-# mutagen sync reconciles by hash instead of streaming the whole working
-# tree over the laptop uplink, creates the mutagen vt-remote session, and
-# routes git hooks through scripts/hooks.
+# marks this machine as the Mac dev role, verifies SSH, bootstraps the VM's
+# base checkout (a real GitHub clone), provisions tooling on it, and — under the
+# single-source model — configures that base as a read-only fast-forward cache
+# of origin (NOT a full-repo mutagen replica). Also routes git hooks.
+#
+# The old vt-remote full-repo mutagen session is retired; the kept syncs (vt-wts
+# worktree mirror + the health-dashboard data) are created separately via
+# scripts/dev-setup/remote/vt-remote.sh.
 #
 # Prereqs (on this laptop, before running):
 #   - voicetree-public cloned locally at ~/repos/vtrepo (you are here)
@@ -45,7 +48,9 @@ done
 
 : "${VT_REMOTE_HOST:?set VT_REMOTE_HOST=root@<your-devbox-host> before running (see --help)}"
 
-REMOTE_DIR="/root/vtrepo-synced"
+# Single-source model: the VM's own base checkout is the read-only ff cache (no
+# more /root/vtrepo-synced full-repo mutagen replica). Provision into it.
+REMOTE_DIR="${VT_BASE_DIR:-/root/vtrepo}"
 REPO_URL="${REPO_URL:-https://github.com/voicetreelab/voicetree-public.git}"
 ENV_FILE="$REPO_ROOT/.env"
 HOME_ENV_FILE="$HOME/.env"
@@ -194,15 +199,10 @@ ssh "$VT_REMOTE_HOST" "
 " || fail "code-search tools install failed"
 ok "ast-grep, ck, cgcli on PATH (cgcli needs node_modules; resolves per-worktree)"
 
-step "creating mutagen vt-remote session"
-if mutagen sync list vt-remote >/dev/null 2>&1; then
-  ok "session already exists (skip create)"
-else
-  bash "$SCRIPT_DIR/vt-remote.sh" sync-create &
-  create_pid=$!
-  wait "$create_pid" || fail "mutagen sync create failed"
-  ok "session created"
-fi
+# NOTE: the vt-remote full-repo mutagen session is RETIRED under the single-source
+# model — the VM base ($REMOTE_DIR) is a read-only ff cache of origin, configured
+# below after git-gate. The kept syncs (vt-wts + the two health-dashboard data
+# sessions) are created on demand via vt-remote.sh, not here.
 
 step "setting up standalone brain checkouts"
 bash "$SCRIPT_DIR/vt-remote.sh" brain-setup \
@@ -236,16 +236,40 @@ else
   ok "git-gate installed (no password — pass VT_GIT_GATE_PASS to set one)"
 fi
 
+# --- single-source base configuration (D3 ordering: AFTER git-gate) ----------
+# Now that git-gate is on the VM's PATH, convert the VM base into a read-only
+# fast-forward cache of origin: pin the base branch, create the daily worktree,
+# install the dev-flow commands + the systemd sync timer. configure-base.sh
+# supplies VT_SYNC=1 to its own gated git so the read-only guard lets the pin
+# through. Skip with VT_SKIP_BASE_CONFIG=1.
+if [ "${VT_SKIP_BASE_CONFIG:-0}" = "1" ]; then
+  ok "VM base configuration skipped (VT_SKIP_BASE_CONFIG=1)"
+else
+  step "configuring VM base $REMOTE_DIR as a read-only fast-forward cache of origin"
+  ssh "$VT_REMOTE_HOST" "VT_BASE_DIR=$(printf %q "$REMOTE_DIR") bash $REMOTE_DIR/scripts/dev-setup/remote/setup-devbox-env.sh --configure-base" \
+    || fail "VM base configuration failed (resolve unpushed commits / dirty tree on $REMOTE_DIR, then re-run)"
+  ok "VM base pinned to origin; daily worktree + dev-flow commands + sync timer installed"
+fi
+
 cat <<MSG
 
-✔ remote routing installed.
+✔ remote routing installed (single-source base model).
 
 Next:
-  - wait for steady state:   mutagen sync list vt-remote   # expect 'Status: Watching for changes'
   - check brain checkout:    bash scripts/dev-setup/remote/vt-remote.sh brain-status
-  - smoke test routing:      npm run test                  # expect '[run-remote] ...' lines
+  - configure THIS Mac base: bash scripts/dev-setup/remote/setup-laptop-env.sh --configure-base
+                             (run after git-gate is installed on the Mac)
+  - kept syncs (create as needed):
+      bash scripts/dev-setup/remote/vt-remote.sh vt-wts-create
+      bash scripts/dev-setup/remote/vt-remote.sh csv-history-create
+      bash scripts/dev-setup/remote/vt-remote.sh reports-create
   - git-gate:                installed; new shells route git through it. Set/rotate the
                              password with  VT_GIT_GATE_PASS=<pw> bash scripts/dev-setup/remote/install.sh
                              (or skip entirely with VT_SKIP_GIT_GATE=1).
+
+One-time teardown of the retired full-repo replica (run on the Mac, once):
+  mutagen sync terminate vt-remote     # stop the old /root/vtrepo-synced mirror
+  # then, on the VM, the old replica dir /root/vtrepo-synced can be removed once
+  # you have confirmed /root/vtrepo is the live base.
 
 MSG

--- a/scripts/dev-setup/remote/setup-devbox-env.sh
+++ b/scripts/dev-setup/remote/setup-devbox-env.sh
@@ -1,10 +1,25 @@
 #!/usr/bin/env bash
-# Configure machine-local env on the remote devbox.
+# Configure machine-local env on the remote devbox (VM).
+#
+# Default run: writes VT_DEV_ROLE + the ssh-mux block (safe to run early, before
+# git-gate exists — used by install.sh's first pass).
+# With --configure-base: ALSO turns the VM base ($VT_BASE_DIR, default
+# /root/vtrepo) into a read-only fast-forward cache of origin, creates the daily
+# worktree, installs the dev-flow commands + the systemd sync timer. Must run
+# AFTER git-gate is on PATH. See scripts/dev-setup/common/configure-base.sh.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOME_ENV_FILE="$HOME/.env"
+
+CONFIGURE_BASE=0
+for arg in "$@"; do
+  case "$arg" in
+    --configure-base) CONFIGURE_BASE=1 ;;
+    *) echo "setup-devbox-env.sh: unknown arg: $arg" >&2; exit 64 ;;
+  esac
+done
 
 bash "$SCRIPT_DIR/write-env-value.sh" "$HOME_ENV_FILE" VT_DEV_ROLE remote
 
@@ -45,3 +60,10 @@ EOF
   echo "setup-devbox-env: $cfg has ssh multiplexing + 'mac' host alias"
 }
 setup_ssh_mux
+
+# --- single-source base configuration (opt-in; needs git-gate on PATH) -------
+if [ "$CONFIGURE_BASE" = "1" ]; then
+  VT_BASE_DIR="${VT_BASE_DIR:-/root/vtrepo}" \
+  VT_WORKTREE_ROOT="${VT_WORKTREE_ROOT:-$HOME/vt-wts}" \
+    bash "$SCRIPT_DIR/../common/configure-base.sh"
+fi

--- a/scripts/dev-setup/remote/setup-laptop-env.sh
+++ b/scripts/dev-setup/remote/setup-laptop-env.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-# Configure machine-local laptop env for remote dev routing.
+# Configure machine-local laptop (Mac) env for remote dev routing.
+#
+# Default run: writes VT_REMOTE_HOST + VT_DEV_ROLE=mac.
+# With --configure-base: ALSO turns the Mac base ($VT_BASE_DIR, default the repo
+# root this script lives in) into a read-only fast-forward cache of origin,
+# creates the daily worktree, installs the dev-flow commands + the launchd sync
+# timer. Must run AFTER git-gate is on PATH. See common/configure-base.sh.
 
 set -euo pipefail
 
@@ -7,6 +13,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 REPO_ENV_FILE="$REPO_ROOT/.env"
 HOME_ENV_FILE="$HOME/.env"
+
+CONFIGURE_BASE=0
+for arg in "$@"; do
+  case "$arg" in
+    --configure-base) CONFIGURE_BASE=1 ;;
+    *) echo "setup-laptop-env.sh: unknown arg: $arg" >&2; exit 64 ;;
+  esac
+done
 
 : "${VT_REMOTE_HOST:?set VT_REMOTE_HOST=root@<your-devbox-host> before running}"
 
@@ -25,3 +39,9 @@ fi
 
 echo "setup-laptop-env: $REPO_ENV_FILE has VT_REMOTE_HOST=$VT_REMOTE_HOST"
 echo "setup-laptop-env: $HOME_ENV_FILE has VT_DEV_ROLE=mac and VT_REMOTE_HOST=$VT_REMOTE_HOST"
+
+# --- single-source base configuration (opt-in; needs git-gate on PATH) -------
+if [ "$CONFIGURE_BASE" = "1" ]; then
+  VT_BASE_DIR="${VT_BASE_DIR:-$REPO_ROOT}" \
+    bash "$SCRIPT_DIR/../common/configure-base.sh"
+fi

--- a/scripts/dev-setup/remote/vt-sync-base.sh
+++ b/scripts/dev-setup/remote/vt-sync-base.sh
@@ -56,9 +56,14 @@ log() {
 git_base() { git -C "$BASE" "$@"; }
 
 # --- alert delivery (D7) ----------------------------------------------------
-# OS notification is the GUARANTEED channel; the graph node is best-effort (the
-# daemon has no VoiceTree task context, so a root node needs VT_ALERT_PARENT_NODE
-# to attach cleanly — otherwise the create may be refused and we just log it).
+# There is NO single guaranteed real-time channel; delivery is best-effort on
+# every path, so the durable record is always the log line in $LOG (see alert()).
+#   - On the Mac, the OS notification (osascript) is the primary live channel.
+#   - On a headless VM, OS notification is effectively silent (notify-send needs
+#     a DISPLAY; wall reaches no logged-in TTY), so the graph node is the primary
+#     channel — but a root `vt graph create` with no parent may be refused, hence
+#     set VT_ALERT_PARENT_NODE (configure-base threads it into the timer unit).
+# Both notify_os and notify_graph swallow their own failures; alert() logs first.
 notify_os() {
   local title="$1" body="$2"
   if [ "$(uname -s)" = "Darwin" ]; then
@@ -167,7 +172,8 @@ if git_base merge-base --is-ancestor "$local_sha" "$remote_sha"; then
   exit 0
 fi
 
-# local is not an ancestor of origin → diverged (should be impossible with the
-# guard, but we never reset over local commits).
-alert diverged "base '$BASE' branch '$BRANCH' has DIVERGED from origin/$BRANCH — manual review; the cache will not be reset over local commits"
+# local is not an ancestor of origin → diverged. The PATH-shim guard makes the
+# common bypasses hard, but an out-of-band real-git/libgit2 commit can still
+# stick on the ref, so this is reachable; we never reset over local commits.
+alert diverged "base '$BASE' branch '$BRANCH' has DIVERGED from origin/$BRANCH — manual review; the cache will not be reset over local commits. To re-pin (discards the local divergence): VT_SYNC=1 git -C '$BASE' reset --hard origin/$BRANCH"
 exit 0

--- a/scripts/dev-setup/remote/vt-sync-base.sh
+++ b/scripts/dev-setup/remote/vt-sync-base.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# vt-sync-base.sh — read-only base self-heal daemon (ONE tick per invocation).
+#
+# The single-source dev model (see scripts/dev-setup/distributed-architecture.md):
+# origin is the only writable copy of any branch; each machine's base checkout is
+# a read-only fast-forward cache of origin. This script is the mechanism that
+# keeps the base pinned to origin. It is invoked two ways, both running ONE tick:
+#   - by a 2-3 min timer (systemd on Linux / launchd on macOS) — the backstop for
+#     PR merges done on GitHub, where no local actor can nudge;
+#   - on demand by vt-sync / vt-land (the hot path), locally and over ssh from the
+#     other machine (by ABSOLUTE PATH — never via the `vt` forwarder name).
+#
+# Behaviour (D1/D6/D7):
+#   git fetch origin --prune                     (keeps ALL origin/* refs fresh)
+#   then advance the pinned local base branch (default dev-manu) by
+#   git merge --ff-only origin/$VT_BASE_BRANCH   (never reset; never destroy data)
+# On a dirty / diverged / ff-collision base it raises an ALERT — a red VoiceTree
+# node (best-effort) AND an OS notification — and retries idempotently next tick.
+# Transient fetch / ref-lock failures (shared object store with worktrees) are
+# tolerated: the tick exits 0 and the next tick retries; it never wedges.
+#
+# Runs its own git with VT_SYNC=1 so git-gate's read-only base guard lets it
+# fast-forward (the daemon is the ONE writer of the base ref).
+#
+# Config (env, all optional):
+#   VT_BASE_DIR          base checkout to keep pinned   (default: this repo root)
+#   VT_BASE_BRANCH       pinned branch                  (default: dev-manu)
+#   VT_SYNC_STATE_DIR    alert markers + log            (default: ~/.cache/vt-sync-base)
+#   VT_ALERT_PARENT_NODE VoiceTree node id to attach alert nodes under (optional)
+
+# NOT `set -e`: a transient fetch failure must end the tick cleanly, not crash it.
+set -uo pipefail
+
+# Our own git must bypass git-gate's read-only base guard (D3): we are the daemon.
+export VT_SYNC=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE="${VT_BASE_DIR:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+BRANCH="${VT_BASE_BRANCH:-dev-manu}"
+STATE_DIR="${VT_SYNC_STATE_DIR:-$HOME/.cache/vt-sync-base}"
+LOG="$STATE_DIR/vt-sync-base.log"
+
+# Robust PATH for non-login ssh invocations: a bare `ssh host '<path>'` command
+# gets a minimal PATH, but git lives in /opt/homebrew/bin (macOS) or /usr/bin.
+case ":$PATH:" in
+  *:/opt/homebrew/bin:*) ;;
+  *) PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" ;;
+esac
+
+mkdir -p "$STATE_DIR"
+
+log() {
+  printf '%s vt-sync-base[%s]: %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$BRANCH" "$*" >> "$LOG"
+}
+
+git_base() { git -C "$BASE" "$@"; }
+
+# --- alert delivery (D7) ----------------------------------------------------
+# OS notification is the GUARANTEED channel; the graph node is best-effort (the
+# daemon has no VoiceTree task context, so a root node needs VT_ALERT_PARENT_NODE
+# to attach cleanly — otherwise the create may be refused and we just log it).
+notify_os() {
+  local title="$1" body="$2"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    osascript -e "display notification \"$body\" with title \"$title\"" >/dev/null 2>&1 || true
+  elif command -v notify-send >/dev/null 2>&1; then
+    notify-send "$title" "$body" >/dev/null 2>&1 || true
+  else
+    printf '%s: %s\n' "$title" "$body" | wall 2>/dev/null || true
+  fi
+}
+
+notify_graph() {
+  local state="$1" body="$2"
+  command -v vt >/dev/null 2>&1 || return 0
+  local payload
+  payload="$(VT_ALERT_PARENT_NODE="${VT_ALERT_PARENT_NODE:-}" python3 - "$state" "$body" "$BASE" "$BRANCH" <<'PY' 2>/dev/null
+import json, os, sys
+state, body, base, branch = sys.argv[1:5]
+node = {
+    "filename": "vt-sync-base-alert-%s" % state,
+    "title": "⚠ vt-sync-base: %s" % state,
+    "summary": body,
+    "color": "red",
+    "content": "Base `%s` on branch `%s` raised a **%s** alert:\n\n> %s\n\n"
+               "The read-only cache will keep retrying each tick; it will NOT "
+               "reset over local data. Resolve, then it self-heals."
+               % (base, branch, state, body),
+}
+payload = {"nodes": [node]}
+parent = os.environ.get("VT_ALERT_PARENT_NODE", "")
+if parent:
+    payload["parentNodeId"] = parent
+sys.stdout.write(json.dumps(payload))
+PY
+)" || return 0
+  [ -n "$payload" ] || return 0
+  if ! printf '%s' "$payload" | vt graph create >/dev/null 2>&1; then
+    log "graph alert best-effort failed (no VT task context? set VT_ALERT_PARENT_NODE) — OS notification still delivered"
+  fi
+}
+
+# Fire an alert at most once per distinct state (no per-tick spam). Markers clear
+# when the base returns to a healthy state, so a recurrence re-alerts.
+alert() {
+  local state="$1" body="$2"
+  log "ALERT[$state]: $body"
+  local marker="$STATE_DIR/alert-$state"
+  [ -f "$marker" ] && return 0
+  : > "$marker"
+  notify_os "vt-sync-base: $state" "$body"
+  notify_graph "$state" "$body"
+}
+
+clear_alerts() { rm -f "$STATE_DIR"/alert-* 2>/dev/null || true; }
+
+# --- the tick ---------------------------------------------------------------
+[ -d "$BASE/.git" ] || { log "no git repo at $BASE; nothing to do"; exit 0; }
+
+if ! git_base fetch origin --prune >>"$LOG" 2>&1; then
+  log "fetch failed (transient ref-lock / network?) — will retry next tick"
+  exit 0
+fi
+
+# Never fast-forward over uncommitted work — alert and stop (D7).
+if ! git_base diff --quiet || ! git_base diff --cached --quiet; then
+  alert dirty "base '$BASE' has uncommitted changes — move work to a worktree; the cache cannot fast-forward while dirty"
+  exit 0
+fi
+
+if ! git_base show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  alert no-branch "base '$BASE' has no local '$BRANCH' branch — run the base configuration (setup-*-env.sh --configure-base)"
+  exit 0
+fi
+
+# Keep HEAD pinned to the base branch (D1). Tree is clean (checked above), so a
+# re-pin is safe if a stray checkout left HEAD elsewhere.
+cur="$(git_base symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+if [ "$cur" != "$BRANCH" ]; then
+  if ! git_base checkout "$BRANCH" >>"$LOG" 2>&1; then
+    alert head "base '$BASE' HEAD is '$cur'; could not return it to '$BRANCH'"
+    exit 0
+  fi
+fi
+
+if ! git_base show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+  log "origin/$BRANCH not present after fetch — nothing to do this tick"
+  exit 0
+fi
+
+local_sha="$(git_base rev-parse "$BRANCH")"
+remote_sha="$(git_base rev-parse "origin/$BRANCH")"
+
+if [ "$local_sha" = "$remote_sha" ]; then
+  clear_alerts
+  exit 0
+fi
+
+if git_base merge-base --is-ancestor "$local_sha" "$remote_sha"; then
+  if git_base merge --ff-only "origin/$BRANCH" >>"$LOG" 2>&1; then
+    log "fast-forwarded $BRANCH ${local_sha:0:9}..${remote_sha:0:9}"
+    clear_alerts
+    exit 0
+  fi
+  # ff blocked while clean → almost always an untracked path origin now adds (G5).
+  alert collision "base '$BASE' could not fast-forward '$BRANCH' to origin/$BRANCH (an untracked file would be overwritten?) — resolve manually"
+  exit 0
+fi
+
+# local is not an ancestor of origin → diverged (should be impossible with the
+# guard, but we never reset over local commits).
+alert diverged "base '$BASE' branch '$BRANCH' has DIVERGED from origin/$BRANCH — manual review; the cache will not be reset over local commits"
+exit 0


### PR DESCRIPTION
## What

Makes the three "sources of truth" (Mac base / VM base / origin) functionally **one**: origin is the only writable copy of any branch; both machine bases are **read-only fast-forward caches** (a pinned local `dev-manu` branch, *not* detached HEAD); all editing happens in worktrees; all integration happens via origin. Everything is codebase scripts — setup is "run an installer once per machine".

Implements `~/brain/mem/mac-vm-single-source/decisions.md` D1–D10 (authoritative spec, folding in Sam's cognitive-complexity review and the any-branch generalization).

## Changes

| File | What |
|------|------|
| `git-gate/git-gate.sh` | **D5** read-only base guard: refuse `commit/merge/rebase/reset/cherry-pick/am/apply` in the MAIN worktree of a voicetree clone (`git-dir == git-common-dir` + origin match at a path boundary); linked worktrees always allowed; brain untouched. **D3** `VT_SYNC=1` short-circuits the WHOLE gate at the very top. **D10** removed dead `/root/vtrepo-synced` ref in worktree-remove cleanup (kept `vt-wts-synced`). |
| `remote/vt-sync-base.sh` (new) | Self-heal daemon (one tick/invocation): `fetch origin --prune` → `merge --ff-only origin/$VT_BASE_BRANCH` on the pinned base. Tolerates transient ref-lock failures. On dirty/divergence/ff-collision raises an ALERT (red `vt graph` node best-effort + OS notification) and retries idempotently, one node per distinct state. Runs its own git with `VT_SYNC=1`. (**D1/D6/D7**) |
| `dev-flow/{vt-land,vt-sync,vt-pr,vt-worktree,_common.sh,install.sh}` (new) | Machine-LOCAL commands on PATH (hyphen names, **not** `vt` subverbs — `vt` forwards to the Mac). `vt-land`: commit → rebase `origin/BR` → fast local check → push `HEAD:BR` → nudge BOTH caches via the other machine's `vt-sync-base.sh` **by absolute path over ssh** (reusing the `mac` alias / multiplexing). (**D2/D8**) |
| `common/configure-base.sh` (new) + `setup-{devbox,laptop}-env.sh --configure-base` | Pin the base ff cache (own git `VT_SYNC=1`); **D4** migration guard refusing unpushed commits / dirty tree; **D9** blessed `daily-<host>` worktree; 2–3 min timer (systemd on VM / launchd on Mac). |
| `remote/install.sh` | **D10** stop creating the `vt-remote` full-repo mutagen session; order base-config AFTER git-gate with the bypass; teardown note. Re-point `REMOTE_DIR` default to the base `/root/vtrepo`. |
| `distributed-architecture.md` | Document the model + dev flow. |
| `.gitignore` | **D10** widen health-dashboard ignore to `scores-history/*.csv` (keep `!.gitkeep`). |

## Verification (in isolation — throwaway repo + local bare `voicetree.git` remote, **26/26**)

base commit **BLOCKED**; worktree commit **SUCCEEDS**; `VT_SYNC=1` bypasses; daemon **ff's** a behind base; daemon **alerts and does NOT reset** on divergence + dirty; migration guard **REFUSES** unpushed commits; `configure-base` pins + creates the daily worktree + installs helpers; `vt-land` **round-trips** a change to origin; helpers **refuse** in the base. `bash -n` clean on all scripts (no shellcheck available on the box).

The live shared devbox was **not** mutated: no base converted to read-only, no mutagen session terminated, no live timers installed — rollout (running the installers on Mac + VM) is a separate deliberate step.

## Notes / things needing human review

- **Graph-alert channel**: the daemon's `vt graph create` works when it has a VoiceTree task context (validated end-to-end during verification). A real timer/launchd daemon has **no** task context, so attach alerts to a configured `VT_ALERT_PARENT_NODE`; the **OS notification is the guaranteed channel** and is always emitted. Documented in the script.
- **`install.sh` / `vt-remote.sh` topology**: `install.sh` now provisions and pins `/root/vtrepo` (the base) instead of the retired `/root/vtrepo-synced` replica. `vt-remote.sh`'s kept health-sync paths still default `REMOTE_DIR=/root/vtrepo-synced`; cutting those over to `/root/vtrepo` is an operational follow-up for the rollout (left out of this PR — it can't be verified without a real Mac↔VM run and the syncs are explicitly "kept").
- `install.sh` base-config + retirement paths are **not** exercisable in isolation (need a real Mac→VM run); they were reviewed by reading, not executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)