### PR TITLE
fix(perf-stack): self-healing install preflight + legible Go-version failure

### DIFF
--- a/infra/perf-stack/scripts/install-binaries.mjs
+++ b/infra/perf-stack/scripts/install-binaries.mjs
@@ -361,6 +361,28 @@ const copyTree = async (from, to) => {
   await import('node:fs/promises').then((fs) => fs.cp(from, to, { recursive: true }))
 }
 
+// "go version go1.20.1 darwin/arm64" -> [1, 20, 1]; unrecognized output -> null.
+export const parseGoVersion = (stdout) => {
+  const match = /go(\d+)\.(\d+)(?:\.(\d+))?/.exec(stdout ?? '')
+  if (!match) return null
+  return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)]
+}
+
+// True iff version triple `a` is >= `b`, each being [major, minor, patch].
+export const versionGte = (a, b) => {
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] !== b[i]) return a[i] > b[i]
+  }
+  return true
+}
+
+// The source builds lean on GOTOOLCHAIN=auto (below) to download whatever
+// toolchain a dependency's go.mod requests — Tempo's go.mod declares go 1.26.2.
+// That mechanism was introduced in Go 1.21; on older Go it silently doesn't
+// exist and the build dies with a misattributed "invalid go version" go.mod
+// parse error. So the real, load-bearing precondition is Go >= 1.21.
+const MIN_GO_VERSION = [1, 21, 0]
+
 const installSourceBuild = async (binary, manifest) => {
   const pinnedSha = binary.sha256[PLATFORM]
   if (!pinnedSha) {
@@ -374,6 +396,15 @@ const installSourceBuild = async (binary, manifest) => {
 
   const goVersion = spawnSync('go', ['version'], { encoding: 'utf8' })
   if (goVersion.status !== 0) throw new Error(`${binary.name} requires go for the ${PLATFORM} source build`)
+
+  const installedGo = parseGoVersion(goVersion.stdout)
+  if (!installedGo || !versionGte(installedGo, MIN_GO_VERSION)) {
+    const found = installedGo ? installedGo.join('.') : `unrecognized (${goVersion.stdout?.trim()})`
+    throw new Error(
+      `${binary.name} needs Go >= ${MIN_GO_VERSION.join('.')} to bootstrap the toolchain its ` +
+        `go.mod requests; found ${found}. Install a newer Go (e.g. \`brew install go\`) and re-run perf:install.`,
+    )
+  }
 
   const tempDir = await mkdtemp(join(tmpdir(), `vt-perf-${binary.name}-`))
   try {

--- a/infra/perf-stack/scripts/install-binaries.mjs
+++ b/infra/perf-stack/scripts/install-binaries.mjs
@@ -17,7 +17,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { spawnSync } from 'node:child_process'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
@@ -192,6 +192,13 @@ const BINARIES = [
     binaryCandidates: ['otelcol-contrib'],
   },
 ]
+
+// The filenames a complete install writes into BIN_DIR — one per binary
+// (installArchive/installSourceBuild both target `join(BIN_DIR, binary.name)`).
+// Exported so the preflight (ensure-perf-stack.mjs) can test install
+// *completeness* against the same source of truth the installer produces,
+// rather than guessing from directory non-emptiness. The two can never drift.
+export const BINARY_NAMES = BINARIES.map((binary) => binary.name)
 
 const exists = async (path) => access(path).then(() => true, () => false)
 
@@ -434,7 +441,15 @@ const main = async () => {
   }
 }
 
-main().catch((err) => {
-  console.error(err.message)
-  process.exit(1)
-})
+// Run the installer only when invoked as a script. Guarding the entrypoint
+// keeps the module importable (e.g. for BINARY_NAMES / the pure helpers) without
+// triggering a full install as a side effect of `import`.
+// `process.argv[1]` is absent under `node -e`, workers, and some test runners;
+// guard it so an import in those contexts can't crash on pathToFileURL(undefined).
+const isEntrypoint = Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href
+if (isEntrypoint) {
+  main().catch((err) => {
+    console.error(err.message)
+    process.exit(1)
+  })
+}

--- a/infra/perf-stack/scripts/install-binaries.test.mjs
+++ b/infra/perf-stack/scripts/install-binaries.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { parseGoVersion, versionGte } from './install-binaries.mjs'
+
+test('parseGoVersion extracts the [major, minor, patch] triple from `go version` output', () => {
+  assert.deepEqual(parseGoVersion('go version go1.20.1 darwin/arm64'), [1, 20, 1])
+  assert.deepEqual(parseGoVersion('go version go1.26.3 linux/amd64'), [1, 26, 3])
+})
+
+test('parseGoVersion treats an absent patch as 0', () => {
+  assert.deepEqual(parseGoVersion('go version go1.21 linux/amd64'), [1, 21, 0])
+})
+
+test('parseGoVersion returns null for unrecognized / empty output', () => {
+  assert.equal(parseGoVersion('command not found: go'), null)
+  assert.equal(parseGoVersion(''), null)
+  assert.equal(parseGoVersion(undefined), null)
+})
+
+test('versionGte compares major, then minor, then patch', () => {
+  assert.equal(versionGte([1, 21, 0], [1, 21, 0]), true, 'equal counts as >=')
+  // The exact failure that bit: Go 1.20.1 is below the 1.21 GOTOOLCHAIN floor.
+  assert.equal(versionGte([1, 20, 1], [1, 21, 0]), false, 'older minor is below the floor')
+  assert.equal(versionGte([1, 26, 3], [1, 21, 0]), true, 'newer minor clears the floor')
+  assert.equal(versionGte([2, 0, 0], [1, 21, 0]), true, 'newer major clears the floor')
+  assert.equal(versionGte([1, 21, 2], [1, 21, 1]), true, 'patch breaks the tie when major+minor match')
+  assert.equal(versionGte([1, 21, 0], [1, 21, 1]), false, 'lower patch is below when major+minor match')
+})

--- a/scripts/ensure-perf-stack.mjs
+++ b/scripts/ensure-perf-stack.mjs
@@ -2,7 +2,9 @@
 // Idempotent preflight that makes the local LGTM perf stack ready and resolves
 // the OTLP endpoint a launched process should export to.
 //
-//   - installs the native binaries if infra/perf-stack/bin/ is empty (first run)
+//   - installs the native binaries if any expected binary is missing (first run,
+//     or recovery from an interrupted install — install-binaries.mjs is
+//     idempotent and only does work for the binaries not already in place)
 //   - brings the stack up (lifecycle.mjs `up` is itself idempotent: its ps-scan
 //     skips services that are already running, so a warm stack is a fast no-op)
 //   - returns the OTLP gRPC endpoint + a per-run service.instance.id
@@ -19,12 +21,12 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { DEFAULT_OTLP_ENDPOINT, GRAFANA_BASE_URL } from './perf-stack-endpoints.mjs'
+import { BINARY_NAMES } from '../infra/perf-stack/scripts/install-binaries.mjs'
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const PERF_BIN_DIR = join(REPO_ROOT, 'infra/perf-stack/bin')
 const INSTALL_SCRIPT = join(REPO_ROOT, 'infra/perf-stack/scripts/install-binaries.mjs')
 const LIFECYCLE_SCRIPT = join(REPO_ROOT, 'infra/perf-stack/scripts/lifecycle.mjs')
-const INSTALL_MANIFEST = '.install-manifest.json'
 
 // Opt-out lever: PERF_STACK=0 makes the preflight a complete no-op so the
 // launched process runs exactly as it does today (NDJSON-only, no collector).
@@ -44,7 +46,7 @@ export const INTERACTIVE_PERF_TIER = 'lite'
  * @typedef {object} EnsurePerfStackPorts
  * @property {NodeJS.ProcessEnv} env                                    base environment (read-only)
  * @property {(action: PerfStackAction) => Promise<{ code: number, stdout?: string, stderr?: string }>} run  effect boundary
- * @property {() => Promise<boolean>} binHasContents                    true when binaries are already installed
+ * @property {() => Promise<boolean>} installIsComplete                 true when every expected binary is present
  * @property {(message: string) => void} [log]                          progress sink (defaults to stderr)
  * @property {() => string} [newRunId]                                  fresh run id factory (defaults to uuid v4)
  */
@@ -56,7 +58,7 @@ export const INTERACTIVE_PERF_TIER = 'lite'
 export async function ensurePerfStack({
   env,
   run,
-  binHasContents,
+  installIsComplete,
   log = (message) => process.stderr.write(`${message}\n`),
   newRunId = randomUUID,
 }) {
@@ -64,8 +66,12 @@ export async function ensurePerfStack({
     return { enabled: false }
   }
 
-  if (!(await binHasContents())) {
-    log('installing perf stack (first run only)…')
+  // Re-runs whenever the install is incomplete — a partial/interrupted install
+  // converges here rather than wedging. The installer is idempotent, so on a
+  // complete stack this branch is skipped and on a partial one it only fills
+  // in the missing binaries.
+  if (!(await installIsComplete())) {
+    log('installing perf stack…')
     const install = await run('install')
     if (install.code !== 0) {
       throw new Error(perfStackFailure('install perf stack binaries', install))
@@ -109,12 +115,15 @@ function perfStackFailure(action, result) {
 // CLI shell — real ports + command launch. Everything below is the impure edge.
 // ---------------------------------------------------------------------------
 
-async function realBinHasContents() {
+async function realInstallIsComplete() {
   try {
-    const entries = await readdir(PERF_BIN_DIR)
-    return entries.some((entry) => entry !== INSTALL_MANIFEST)
+    const present = new Set(await readdir(PERF_BIN_DIR))
+    // Complete iff every binary the installer produces is on disk. A partial
+    // install (some names missing) reads as incomplete, so the preflight
+    // re-runs the idempotent installer instead of proceeding to a doomed `up`.
+    return BINARY_NAMES.every((name) => present.has(name))
   } catch {
-    // ENOENT (dir absent) → binaries not installed.
+    // ENOENT (dir absent) → nothing installed yet.
     return false
   }
 }
@@ -147,7 +156,7 @@ async function main(argv = process.argv.slice(2), baseEnv = process.env) {
   const result = await ensurePerfStack({
     env: baseEnv,
     run: realRun,
-    binHasContents: realBinHasContents,
+    installIsComplete: realInstallIsComplete,
   })
 
   const [command, ...commandArgs] = argv
@@ -179,7 +188,9 @@ async function main(argv = process.argv.slice(2), baseEnv = process.env) {
   return code ?? 1
 }
 
-const isEntrypoint = import.meta.url === pathToFileURL(process.argv[1]).href
+// `process.argv[1]` is absent under `node -e`, workers, and some test runners;
+// guard it so an import in those contexts can't crash on pathToFileURL(undefined).
+const isEntrypoint = Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href
 if (isEntrypoint) {
   main().then(
     (code) => {

--- a/scripts/ensure-perf-stack.test.mjs
+++ b/scripts/ensure-perf-stack.test.mjs
@@ -3,34 +3,47 @@ import assert from 'node:assert/strict'
 
 import { ensurePerfStack } from './ensure-perf-stack.mjs'
 
+// The set of binaries a complete install produces, abbreviated for the tests.
+// The harness models bin/ as the SET of present binary files (not a single
+// installed/not-installed flag) so a *partial* install — some present, some
+// missing — is representable and assertable.
+const ALL = ['grafana', 'loki', 'tempo']
+
 // Black-box harness: a tiny in-memory interpreter of the perf-stack effect
-// vocabulary. `run('install' | 'up')` mutates world-state (installed/running)
-// exactly as the real subprocesses would, so tests assert on the *observable
-// result of the side effects* (did the stack become installed/running?) rather
-// than on whether an internal helper was called. `binHasContents` mirrors the
-// real bin/ probe by reading the same world-state.
+// vocabulary. `run('install' | 'up')` mutates world-state (which binaries are
+// present / whether the stack is running) exactly as the real subprocesses
+// would, so tests assert on the *observable result of the side effects* rather
+// than on whether an internal helper was called. `installIsComplete` mirrors
+// the real bin/ probe by reading the same world-state.
 function fakePerfStack({
-  installed = false,
+  present = [],
   running = false,
+  expected = ALL,
   installCode = 0,
   upCode = 0,
-  failInstallIfPresent = false,
+  failInstallIfComplete = false,
 } = {}) {
-  const world = { installed, running }
+  const world = { present: new Set(present), running }
+  const isComplete = () => expected.every((name) => world.present.has(name))
   return {
     world,
-    binHasContents: () => Promise.resolve(world.installed),
+    installIsComplete: () => Promise.resolve(isComplete()),
     run: (action) => {
       if (action === 'install') {
-        // A correct preflight never reinstalls when binaries are already
-        // present; encode that contract as the boundary refusing the call.
-        if (failInstallIfPresent && world.installed) {
-          throw new Error('install must not run when binaries are already present')
+        // A correct preflight never reinstalls when the install is already
+        // complete; encode that contract as the boundary refusing the call.
+        if (failInstallIfComplete && isComplete()) {
+          throw new Error('install must not run when the install is already complete')
         }
-        if (installCode === 0) world.installed = true
+        // The real installer is idempotent and converges on the full set: it
+        // fills in every missing binary and no-ops the ones already present.
+        if (installCode === 0) for (const name of expected) world.present.add(name)
         return Promise.resolve({ code: installCode, stderr: installCode ? 'download failed' : '' })
       }
       if (action === 'up') {
+        // `up` dies on the first missing binary — the real failure mode this
+        // models ("tempo binary missing"). It succeeds only on a full install.
+        if (!isComplete()) return Promise.resolve({ code: 1, stderr: 'tempo binary missing' })
         if (upCode === 0) world.running = true
         return Promise.resolve({ code: upCode, stderr: upCode ? 'port 2994 busy' : '' })
       }
@@ -42,17 +55,17 @@ function fakePerfStack({
 const silent = () => {}
 
 test('cold start: installs binaries then brings the stack up', async () => {
-  const stack = fakePerfStack({ installed: false, running: false })
+  const stack = fakePerfStack({ present: [], running: false })
 
   const result = await ensurePerfStack({
     env: {},
     run: stack.run,
-    binHasContents: stack.binHasContents,
+    installIsComplete: stack.installIsComplete,
     log: silent,
     newRunId: () => 'run-cold',
   })
 
-  assert.equal(stack.world.installed, true, 'binaries got installed')
+  assert.equal(stack.world.present.size, ALL.length, 'all binaries got installed')
   assert.equal(stack.world.running, true, 'stack got brought up')
   assert.deepEqual(result, {
     enabled: true,
@@ -62,13 +75,33 @@ test('cold start: installs binaries then brings the stack up', async () => {
   })
 })
 
-test('an enabled preflight selects the always-on lite perf tier', async () => {
-  const stack = fakePerfStack({ installed: true, running: true })
+test('partial install converges: missing binaries trigger a reinstall, then up', async () => {
+  // bin/ holds only 1 of 3 expected binaries — an install interrupted partway
+  // (Ctrl-C, sleep, a failed source-build). The old probe ("any file present?")
+  // treated this as complete and proceeded straight to a doomed `up`; the
+  // completeness probe re-runs the idempotent installer and converges instead.
+  const stack = fakePerfStack({ present: ['grafana'], running: false })
 
   const result = await ensurePerfStack({
     env: {},
     run: stack.run,
-    binHasContents: stack.binHasContents,
+    installIsComplete: stack.installIsComplete,
+    log: silent,
+    newRunId: () => 'run-partial',
+  })
+
+  assert.equal(stack.world.present.size, ALL.length, 'reinstall filled in the missing binaries')
+  assert.equal(stack.world.running, true, 'stack came up after recovery')
+  assert.equal(result.enabled, true)
+})
+
+test('an enabled preflight selects the always-on lite perf tier', async () => {
+  const stack = fakePerfStack({ present: ALL, running: true })
+
+  const result = await ensurePerfStack({
+    env: {},
+    run: stack.run,
+    installIsComplete: stack.installIsComplete,
     log: silent,
     newRunId: () => 'run-tier',
   })
@@ -76,49 +109,49 @@ test('an enabled preflight selects the always-on lite perf tier', async () => {
   assert.equal(result.tier, 'lite', 'interactive launches profile at the lite tier')
 })
 
-test('first-run install emits the one-time progress line', async () => {
-  const stack = fakePerfStack({ installed: false })
+test('an incomplete install emits the one-time progress line', async () => {
+  const stack = fakePerfStack({ present: [] })
   const lines = []
 
   await ensurePerfStack({
     env: {},
     run: stack.run,
-    binHasContents: stack.binHasContents,
+    installIsComplete: stack.installIsComplete,
     log: (message) => lines.push(message),
     newRunId: () => 'run-x',
   })
 
-  assert.deepEqual(lines, ['installing perf stack (first run only)…'])
+  assert.deepEqual(lines, ['installing perf stack…'])
 })
 
-test('warm stack: already installed → no reinstall, just an idempotent up', async () => {
-  // failInstallIfPresent makes the boundary throw if install is wrongly invoked.
-  const stack = fakePerfStack({ installed: true, running: true, failInstallIfPresent: true })
+test('warm stack: complete install → no reinstall, just an idempotent up', async () => {
+  // failInstallIfComplete makes the boundary throw if install is wrongly invoked.
+  const stack = fakePerfStack({ present: ALL, running: true, failInstallIfComplete: true })
   const lines = []
 
   const result = await ensurePerfStack({
     env: {},
     run: stack.run,
-    binHasContents: stack.binHasContents,
+    installIsComplete: stack.installIsComplete,
     log: (message) => lines.push(message),
     newRunId: () => 'run-warm',
   })
 
-  assert.equal(stack.world.installed, true)
+  assert.equal(stack.world.present.size, ALL.length)
   assert.equal(stack.world.running, true)
-  assert.deepEqual(lines, [], 'no first-run install message on a warm stack')
+  assert.deepEqual(lines, [], 'no install message on a complete, warm stack')
   assert.equal(result.endpoint, 'http://localhost:2994')
   assert.equal(result.instanceId, 'run-warm')
 })
 
 test('up failure surfaces a clear error and does not silently succeed', async () => {
-  const stack = fakePerfStack({ installed: true, running: false, upCode: 1 })
+  const stack = fakePerfStack({ present: ALL, running: false, upCode: 1 })
 
   await assert.rejects(
     ensurePerfStack({
       env: {},
       run: stack.run,
-      binHasContents: stack.binHasContents,
+      installIsComplete: stack.installIsComplete,
       log: silent,
     }),
     /failed to start the perf stack \(exit 1\)[\s\S]*port 2994 busy/,
@@ -127,13 +160,13 @@ test('up failure surfaces a clear error and does not silently succeed', async ()
 })
 
 test('install failure aborts before attempting up', async () => {
-  const stack = fakePerfStack({ installed: false, installCode: 1 })
+  const stack = fakePerfStack({ present: [], installCode: 1 })
 
   await assert.rejects(
     ensurePerfStack({
       env: {},
       run: stack.run,
-      binHasContents: stack.binHasContents,
+      installIsComplete: stack.installIsComplete,
       log: silent,
     }),
     /failed to install perf stack binaries \(exit 1\)[\s\S]*download failed/,
@@ -142,9 +175,7 @@ test('install failure aborts before attempting up', async () => {
 })
 
 test('PERF_STACK=0 is a complete no-op: no install, no up, exporter left detached', async () => {
-  // failInstallIfPresent + a down stack means any install OR up attempt would
-  // mutate world-state; assert nothing happened.
-  const stack = fakePerfStack({ installed: false, running: false })
+  const stack = fakePerfStack({ present: [], running: false })
   let installs = 0
   let ups = 0
   const countingRun = (action) => {
@@ -156,19 +187,19 @@ test('PERF_STACK=0 is a complete no-op: no install, no up, exporter left detache
   const result = await ensurePerfStack({
     env: { PERF_STACK: '0' },
     run: countingRun,
-    binHasContents: stack.binHasContents,
+    installIsComplete: stack.installIsComplete,
     log: silent,
   })
 
   assert.deepEqual(result, { enabled: false })
   assert.equal(installs, 0, 'no install subprocess ran')
   assert.equal(ups, 0, 'no up subprocess ran')
-  assert.equal(stack.world.installed, false)
+  assert.equal(stack.world.present.size, 0)
   assert.equal(stack.world.running, false)
 })
 
 test('honors a caller-provided endpoint and run instance id from env', async () => {
-  const stack = fakePerfStack({ installed: true, running: true })
+  const stack = fakePerfStack({ present: ALL, running: true })
 
   const result = await ensurePerfStack({
     env: {
@@ -176,7 +207,7 @@ test('honors a caller-provided endpoint and run instance id from env', async () 
       VOICETREE_RUN_INSTANCE_ID: 'preset-run',
     },
     run: stack.run,
-    binHasContents: stack.binHasContents,
+    installIsComplete: stack.installIsComplete,
     log: silent,
     newRunId: () => 'should-not-be-used',
   })


### PR DESCRIPTION
Two robustness fixes to the perf-stack preflight (`ensure-perf-stack.mjs` runs on the **default dev launch** — `webapp/package.json:44` — and is default-on, so these bugs hit the primary way the app starts).

## Flaw 1 — partial install treated as complete (High)
`binHasContents()` answered *"is `bin/` non-empty?"* but the call site needs *"is the install complete?"*. A single present binary satisfied it, so an **interrupted install** (some binaries missing) skipped install and let `up` die on the first missing binary — wedging the launch permanently until a manual `perf:install`.

- Replaced with `installIsComplete()`: every binary the installer produces must be present, checked against `BINARY_NAMES` — now exported from `install-binaries.mjs` as the single source of truth so probe and installer can't drift. Incomplete installs re-run the (idempotent) installer and converge. **Happy path unchanged.**
- **Prerequisite:** `install-binaries.mjs` ran `main()` on import, so it couldn't be imported for `BINARY_NAMES`. Guarded it behind an `isEntrypoint` check (hardened both scripts against an absent `process.argv[1]`).
- The test harness modelled the world as a boolean `installed` flag — structurally unable to represent a partial install, so it stayed green while encoding the same flawed mental model. Reshaped to a set of present binaries (with `up` failing on any missing binary) + added the partial-install regression test that would have caught the bug.

## Flaw 2 — Go version unchecked on source builds (Medium)
`installSourceBuild` only checked that `go` exists, not that it's new enough. The builds rely on `GOTOOLCHAIN=auto` (introduced in **Go 1.21**) to fetch the toolchain a dependency's `go.mod` requests (Tempo's declares `go 1.26.2`). On older Go the mechanism silently doesn't exist and the build dies with a misattributed *"invalid go version"* `go.mod` parse error.

- Assert Go ≥ 1.21 after confirming `go` exists, failing with the actual remedy. Version parse + compare extracted as pure, exported helpers (`parseGoVersion`, `versionGte`) with black-box unit tests.

## Verification
- 13/13 `node:test` cases pass (9 preflight + 4 helper); both scripts `node --check` clean.
- Verified locally via `node --test` — the `run-remote` gate is unreliable from a nested `wt-*` worktree (same limitation #189 documents). Relying on this PR's CI as the authoritative gate.

## Known residual (deliberate scope)
`installIsComplete()` checks names-present; it does **not** detect a *version bump* of an already-present binary (same as the original — strict improvement, no regression). Closing that is a follow-up (make the preflight manifest/version-aware, or consolidate the duplicated "is it installed?" decision into the installer).

## Relationship to #189
Orthogonal: #189's deps-freshness guard ensures pnpm `node_modules` freshness; this ensures perf-stack **native binary** completeness. Same functional-design pattern (pure decision + separated install side-effect, `.mjs` black-box test), zero file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)