### PR TITLE
fix(release): repair release pipeline — version typo + npm→pnpm build jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
     paths:
       - 'package.json'
-      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
       - 'knip.config.ts'
       - 'webapp/package.json'
       - '.github/workflows/release.yml'
@@ -94,12 +94,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Python (for node-gyp)
         uses: actions/setup-python@v5
@@ -156,11 +161,10 @@ jobs:
           cp backend/settings.py out/resources/backend/
           cp backend/logging_config.py out/resources/backend/
 
-      - name: Install frontend dependencies
-        working-directory: webapp
+      - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Update file timestamps for codesign
         run: |
@@ -259,12 +263,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Python (for node-gyp)
         uses: actions/setup-python@v5
@@ -300,15 +309,14 @@ jobs:
           Copy-Item -Force "backend\settings.py" "out\resources\backend\"
           Copy-Item -Force "backend\logging_config.py" "out\resources\backend\"
 
-      - name: Install frontend dependencies
-        working-directory: webapp
+      - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Rebuild native modules
         working-directory: webapp
-        run: npx electron-rebuild
+        run: pnpm exec electron-rebuild
 
       - name: Build & Publish Electron
         working-directory: webapp
@@ -353,12 +361,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -390,11 +403,10 @@ jobs:
           cp backend/settings.py out/resources/backend/
           cp backend/logging_config.py out/resources/backend/
 
-      - name: Install frontend dependencies
-        working-directory: webapp
+      - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build & Publish Electron
         working-directory: webapp

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -4,7 +4,7 @@
   "description": "Transform voice into navigable concept graphs",
   "author": "Manu Masson",
   "private": true,
-  "dmeversion": "2.9.16",
+  "version": "3.0.0",
   "type": "module",
   "main": "dist-electron/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Why

The VoiceTree release pipeline could not run. Two blockers, both already on `dev`/`main`:

- **B1 — version field typo.** `webapp/package.json` had the key `"dmeversion": "2.9.16"` instead of `"version"`. The pipeline reads `jq -r .version webapp/package.json` → `null`, so `check-version` could never compute a version to build or tag.
- **B2 — npm vs pnpm.** The repo migrated to pnpm (`pnpm-lock.yaml` + `pnpm-workspace.yaml`; **no** `package-lock.json`), but `release.yml`'s three build jobs still ran `npm ci` with `cache: 'npm'` / `cache-dependency-path: package-lock.json`. That fails outright — the `@vt/*` workspace deps are unresolvable by npm — so no artifact could build.

## What changed

**B1 — `webapp/package.json`**
- `"dmeversion": "2.9.16"` → `"version": "3.0.0"` (this release's locked version).

**B2 — `.github/workflows/release.yml`** (all three build jobs: `build-mac`, `build-windows`, `build-linux`)
- Added `pnpm/action-setup@v4` with `version: 10.32.1` **before** `actions/setup-node` — mirrors the repo's other workflows (`measures-budget-gate.generated.yml`) and matches the root `packageManager: "pnpm@10.32.1"` pin.
- `actions/setup-node`: `cache: 'npm'` → `cache: 'pnpm'`, `cache-dependency-path: package-lock.json` → `pnpm-lock.yaml`.
- Install step: `npm ci` (`working-directory: webapp`) → `pnpm install --frozen-lockfile` at the **workspace root** (renamed the step to "Install dependencies"). This also runs webapp's `postinstall` → `scripts/rebuild-native.sh`, which rebuilds the native modules for the Electron ABI.
- **Windows** native rebuild: `npx electron-rebuild` → `pnpm exec electron-rebuild`. `pnpm exec` resolves the locally-installed `@electron/rebuild` binary (hoisted to the workspace root via `node-linker=hoisted`) and — unlike `npx` — can **never** fall back to fetching the deprecated standalone `electron-rebuild` package from the registry. This step stays Windows-only because the `.sh` postinstall does not run under the Windows runner's default shell (the same reason it was Windows-only before).
- `on.push.paths`: dead `package-lock.json` trigger → `pnpm-lock.yaml`.

The subsequent `electron-vite build` / `electron-builder` steps are unchanged (they keep `working-directory: webapp` and resolve fine under pnpm).

## Local validation (proof B2 builds under pnpm)

Run from the worktree root on macOS:

```
$ pnpm install --frozen-lockfile
...
webapp postinstall: → rebuild-native: using electron-rebuild 4.0.4 at .../node_modules/.bin/electron-rebuild
webapp postinstall: → rebuild-native: webapp (Electron ABI)
webapp postinstall: Building modules: electron-trackpad-detect, node-pty
webapp postinstall: ✔ Rebuild Complete
webapp postinstall: → rebuild-native: packages/systems/vt-daemon (Electron ABI)
webapp postinstall: Building modules: node-pty
webapp postinstall: ✔ Rebuild Complete
webapp postinstall: → rebuild-native: packages/systems/graph-db-server (esbuild → dist/vt-graphd.mjs)
webapp postinstall: ✔ rebuild-native: all native modules built for correct ABIs
Done in 27.7s using pnpm v10.32.1

$ cd webapp && pnpm exec electron-vite build; echo "EXIT=$?"
EXIT=0
# fresh artifacts written:
#   dist/index.html                 2026-05-31 21:36:01   (the file the Windows job gates on)
#   dist-electron/main/index.js     2026-05-31 21:35:58
#   dist-electron/preload/index.js

$ jq -r .version webapp/package.json
3.0.0
```

`electron-vite` (6.0.0-beta) prints nothing when not attached to a TTY; the exit code and freshly-written artifacts are the signal. A full `electron-builder` run (signing/notarization) was not exercised locally — it needs Apple/CSC secrets that only exist in CI.

## Scope / deliberately NOT done

- **Windows code-signing** — not added (separate open decision).
- **electron-vite version** — left at `^6.0.0-beta.1` (separate open decision).
- **Pre-existing observations, not actioned here:**
  - `.github/workflows/main.yml` has the *same* latent bug — it runs `npm ci` with `cache: 'npm'` / `package-lock.json` and then invokes `pnpm` commands. Out of scope for this release-pipeline fix, but worth a follow-up.
  - `release.yml`'s `electron-vite build` / `electron-builder` steps still use `npx`; they work via hoisted resolution, but could be migrated to `pnpm exec` later for uniformity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
