### PR TITLE
feat(worktree): place worktrees at ~/vt-wts + don't flood the workspace with new folders

### DIFF
--- a/packages/libraries/app-config/src/project/project-store.test.ts
+++ b/packages/libraries/app-config/src/project/project-store.test.ts
@@ -1,0 +1,125 @@
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {mkdirSync, mkdtempSync, rmSync, symlinkSync} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type {SavedProject} from '@vt/graph-model/project'
+import {VOICETREE_HOME_PATH_ENV} from '@vt/paths'
+import {dedupeProjectsByCanonicalPath, loadProjects, saveProject} from './project-store.ts'
+
+function makeProject(overrides: Partial<SavedProject> & {readonly path: string}): SavedProject {
+    return {
+        id: overrides.id ?? `id:${overrides.path}`,
+        path: overrides.path,
+        name: overrides.name ?? path.basename(overrides.path),
+        type: overrides.type ?? 'folder',
+        lastOpened: overrides.lastOpened ?? 1,
+    }
+}
+
+// Pure transform — fed an injected canonicalizer so the casing/symlink policy is
+// asserted deterministically on every platform (the real, filesystem-dependent
+// canonicalizer is `normalizeProjectPath`, covered in @vt/paths).
+describe('dedupeProjectsByCanonicalPath', () => {
+    const caseInsensitive: (projectPath: string) => string = (projectPath) => projectPath.toLowerCase()
+
+    it('collapses entries that canonicalize equal, keeping the most-recently-opened one', () => {
+        const older: SavedProject = makeProject({id: 'older', path: '/Users/x/Voicetree', lastOpened: 100})
+        const newer: SavedProject = makeProject({id: 'newer', path: '/Users/x/voicetree', lastOpened: 200})
+
+        const result: SavedProject[] = dedupeProjectsByCanonicalPath([older, newer], caseInsensitive)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]?.id).toBe('newer')
+    })
+
+    it('chooses the most-recent winner regardless of input order', () => {
+        const older: SavedProject = makeProject({id: 'older', path: '/p', lastOpened: 1})
+        const newer: SavedProject = makeProject({id: 'newer', path: '/P', lastOpened: 2})
+
+        expect(dedupeProjectsByCanonicalPath([older, newer], caseInsensitive)[0]?.id).toBe('newer')
+        expect(dedupeProjectsByCanonicalPath([newer, older], caseInsensitive)[0]?.id).toBe('newer')
+    })
+
+    it('keeps genuinely distinct directories', () => {
+        const alpha: SavedProject = makeProject({id: 'alpha', path: '/Users/x/alpha'})
+        const beta: SavedProject = makeProject({id: 'beta', path: '/Users/x/beta'})
+
+        const result: SavedProject[] = dedupeProjectsByCanonicalPath([alpha, beta], caseInsensitive)
+
+        expect(result.map((p) => p.id).sort()).toEqual(['alpha', 'beta'])
+    })
+})
+
+// Disk-level black-box tests: drive the real store against a temp VoiceTree home
+// and assert on what `loadProjects` observes. Symlinks (not casing) stand in for
+// "two paths, one directory" so the canonical collapse is deterministic on both
+// case-insensitive (dev macOS) and case-sensitive (CI Linux) filesystems.
+describe('project store (saveProject + loadProjects)', () => {
+    let home: string
+    let workspace: string
+    let previousHome: string | undefined
+
+    beforeEach(() => {
+        home = mkdtempSync(path.join(os.tmpdir(), 'vt-home-'))
+        workspace = mkdtempSync(path.join(os.tmpdir(), 'vt-workspace-'))
+        previousHome = process.env[VOICETREE_HOME_PATH_ENV]
+        process.env[VOICETREE_HOME_PATH_ENV] = home
+    })
+
+    afterEach(() => {
+        if (previousHome === undefined) {
+            delete process.env[VOICETREE_HOME_PATH_ENV]
+        } else {
+            process.env[VOICETREE_HOME_PATH_ENV] = previousHome
+        }
+        rmSync(home, {recursive: true, force: true})
+        rmSync(workspace, {recursive: true, force: true})
+    })
+
+    it('round-trips a saved project', async () => {
+        const dir: string = path.join(workspace, 'project')
+        mkdirSync(dir)
+
+        await saveProject(makeProject({id: 'p1', path: dir, lastOpened: 5}))
+
+        const loaded: SavedProject[] = await loadProjects()
+        expect(loaded).toHaveLength(1)
+        expect(loaded[0]?.id).toBe('p1')
+    })
+
+    it('collapses two records that resolve to the same directory into one', async () => {
+        const target: string = path.join(workspace, 'target')
+        const alias: string = path.join(workspace, 'alias')
+        mkdirSync(target)
+        symlinkSync(target, alias)
+
+        await saveProject(makeProject({id: 'via-target', path: target, lastOpened: 10}))
+        await saveProject(makeProject({id: 'via-alias', path: alias, lastOpened: 20}))
+
+        const loaded: SavedProject[] = await loadProjects()
+        expect(loaded).toHaveLength(1)
+        // The second save supersedes the first variant of the same directory.
+        expect(loaded[0]?.id).toBe('via-alias')
+    })
+
+    it('updates a project in place when saved again under the same id', async () => {
+        const dir: string = path.join(workspace, 'project')
+        mkdirSync(dir)
+
+        await saveProject(makeProject({id: 'p1', path: dir, name: 'first', lastOpened: 1}))
+        await saveProject(makeProject({id: 'p1', path: dir, name: 'second', lastOpened: 2}))
+
+        const loaded: SavedProject[] = await loadProjects()
+        expect(loaded).toHaveLength(1)
+        expect(loaded[0]?.name).toBe('second')
+    })
+
+    it('drops projects whose directory no longer exists', async () => {
+        const dir: string = path.join(workspace, 'gone')
+        mkdirSync(dir)
+        await saveProject(makeProject({id: 'ghost', path: dir}))
+        rmSync(dir, {recursive: true, force: true})
+
+        expect(await loadProjects()).toHaveLength(0)
+    })
+})

--- a/packages/libraries/app-config/src/project/project-store.ts
+++ b/packages/libraries/app-config/src/project/project-store.ts
@@ -1,7 +1,36 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import type { SavedProject } from '@vt/graph-model/project';
-import {resolveVoicetreeHomePath} from '@vt/paths';
+import {normalizeProjectPath, resolveVoicetreeHomePath} from '@vt/paths';
+
+/**
+ * Collapse projects that point at the same on-disk directory.
+ *
+ * Two entries can differ only by path casing (e.g. `~/Voicetree` vs
+ * `~/voicetree` on a case-insensitive filesystem) or by symlink, yet refer to
+ * one directory. Grouping by canonical path keeps a single entry per real
+ * directory — the most-recently-opened one — so the recent-projects list never
+ * shows a directory twice and re-opening with a different casing never forks a
+ * second record.
+ *
+ * `canonicalize` is injected so this stays a pure, platform-independent
+ * transform that is black-box testable without touching disk; production passes
+ * {@link normalizeProjectPath}.
+ */
+export function dedupeProjectsByCanonicalPath(
+    projects: readonly SavedProject[],
+    canonicalize: (projectPath: string) => string,
+): SavedProject[] {
+    const byCanonicalPath: Map<string, SavedProject> = new Map();
+    for (const project of projects) {
+        const key: string = canonicalize(project.path);
+        const existing: SavedProject | undefined = byCanonicalPath.get(key);
+        if (!existing || project.lastOpened >= existing.lastOpened) {
+            byCanonicalPath.set(key, project);
+        }
+    }
+    return [...byCanonicalPath.values()];
+}
 
 function getProjectsFilePath(voicetreeHomePath: string): string {
     return path.join(voicetreeHomePath, 'projects.json');
@@ -64,8 +93,11 @@ export async function loadProjects(): Promise<SavedProject[]> {
     // Filter out projects with missing paths
     const existenceChecks: Promise<boolean>[] = projects.map((p) => pathExists(p.path));
     const exists: boolean[] = await Promise.all(existenceChecks);
+    const present: SavedProject[] = projects.filter((_, index) => exists[index]);
 
-    return projects.filter((_, index) => exists[index]);
+    // Collapse casing/symlink variants so legacy records written before path
+    // normalization still surface as one entry per real directory.
+    return dedupeProjectsByCanonicalPath(present, normalizeProjectPath);
 }
 
 /**
@@ -75,16 +107,17 @@ export async function loadProjects(): Promise<SavedProject[]> {
 export async function saveProject(project: SavedProject): Promise<void> {
     const voicetreeHomePath: string = resolveVoicetreeHomePath();
     const projects: SavedProject[] = await readProjectsFile(voicetreeHomePath);
+    const canonicalPath: string = normalizeProjectPath(project.path);
 
-    const existingIndex: number = projects.findIndex((p) => p.id === project.id);
+    // Drop the prior record of this project — matched by id (an update) or by
+    // canonical path (a casing/symlink variant of the same directory) — so the
+    // freshly-opened project becomes the single entry for that directory.
+    const others: SavedProject[] = projects.filter(
+        (p) => p.id !== project.id && normalizeProjectPath(p.path) !== canonicalPath,
+    );
+    others.push(project);
 
-    if (existingIndex >= 0) {
-        projects[existingIndex] = project;
-    } else {
-        projects.push(project);
-    }
-
-    await writeProjectsFile(voicetreeHomePath, projects);
+    await writeProjectsFile(voicetreeHomePath, others);
 }
 
 /**

--- a/packages/libraries/paths/src/index.ts
+++ b/packages/libraries/paths/src/index.ts
@@ -1,6 +1,7 @@
 export {
     getProjectDotVoicetreePath,
     getVoicetreeHomePath,
+    normalizeProjectPath,
     resolveVoicetreeHomePath,
     VOICETREE_DIRNAME,
     VOICETREE_HOME_PATH_ENV,

--- a/packages/libraries/paths/src/normalize-project-path.test.ts
+++ b/packages/libraries/paths/src/normalize-project-path.test.ts
@@ -1,0 +1,73 @@
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {normalizeProjectPath} from './paths.ts'
+
+// Black-box tests against the real filesystem: `normalizeProjectPath` is an edge
+// function whose whole job is to consult the OS, so it is exercised with real
+// temp directories rather than a stubbed `fs`.
+describe('normalizeProjectPath', () => {
+    let base: string
+
+    beforeEach(() => {
+        base = mkdtempSync(path.join(os.tmpdir(), 'vt-normalize-'))
+    })
+
+    afterEach(() => {
+        rmSync(base, {recursive: true, force: true})
+    })
+
+    it('returns the real on-disk path for an existing directory and is idempotent', () => {
+        const dir: string = path.join(base, 'project')
+        mkdirSync(dir)
+
+        const normalized: string = normalizeProjectPath(dir)
+
+        expect(path.isAbsolute(normalized)).toBe(true)
+        expect(normalized).toBe(realpathSync.native(dir))
+        expect(normalizeProjectPath(normalized)).toBe(normalized)
+    })
+
+    it('resolves a relative path to an absolute one', () => {
+        expect(path.isAbsolute(normalizeProjectPath('.'))).toBe(true)
+    })
+
+    it('falls back to a resolved absolute path when the path does not exist, without throwing', () => {
+        const missing: string = path.join(base, 'does-not-exist')
+
+        expect(() => normalizeProjectPath(missing)).not.toThrow()
+        expect(normalizeProjectPath(missing)).toBe(path.resolve(missing))
+    })
+
+    it('resolves a symlink to its target — one canonical path on every platform', () => {
+        const target: string = path.join(base, 'target')
+        const alias: string = path.join(base, 'alias')
+        mkdirSync(target)
+        symlinkSync(target, alias)
+
+        expect(normalizeProjectPath(alias)).toBe(normalizeProjectPath(target))
+    })
+
+    it('collapses casing variants only when the filesystem is case-insensitive', () => {
+        const dir: string = path.join(base, 'CaseProbe')
+        mkdirSync(dir)
+        const variant: string = path.join(base, 'caseprobe')
+
+        let filesystemIsCaseInsensitive: boolean = false
+        try {
+            filesystemIsCaseInsensitive = realpathSync.native(variant) === realpathSync.native(dir)
+        } catch {
+            // The lower-cased variant does not exist → case-sensitive filesystem.
+        }
+
+        if (filesystemIsCaseInsensitive) {
+            // APFS / NTFS: both casings name one directory, so they normalize equal.
+            expect(normalizeProjectPath(variant)).toBe(normalizeProjectPath(dir))
+        } else {
+            // Case-sensitive filesystem: the variant is a different (absent) path,
+            // so it must NOT be folded into `dir` — it resolves to itself.
+            expect(normalizeProjectPath(variant)).toBe(path.resolve(variant))
+        }
+    })
+})

--- a/packages/libraries/paths/src/paths.ts
+++ b/packages/libraries/paths/src/paths.ts
@@ -1,8 +1,36 @@
+import {realpathSync} from 'node:fs'
 import {homedir} from 'node:os'
-import {join} from 'node:path'
+import {join, resolve} from 'node:path'
 
 export const VOICETREE_HOME_PATH_ENV: string = 'VOICETREE_HOME_PATH'
 export const VOICETREE_DIRNAME: string = '.voicetree'
+
+/**
+ * Canonicalize a project path to its true on-disk form.
+ *
+ * Returns the path exactly as the filesystem stores it (`realpathSync.native`),
+ * which fixes the casing and resolves symlinks. This is the single place where a
+ * project path's identity is decided, so every derived value — the watched dir,
+ * persisted project record, node-ID base, worktree spawn cwd — agrees.
+ *
+ * Why `realpathSync.native` and not a manual `toLowerCase()`: case-folding is a
+ * property of the *filesystem*, not the path string. On a case-insensitive
+ * filesystem (APFS, NTFS) `~/Voicetree` and `~/voicetree` are one directory and
+ * collapse to a single canonical string; on a case-sensitive filesystem (most
+ * Linux) they are genuinely different directories and stay distinct. Delegating
+ * to the OS keeps this correct on every platform without hard-coding case rules.
+ *
+ * Falls back to `path.resolve` when the path cannot be resolved (e.g. it does not
+ * exist yet) so the edge never throws on an absent path.
+ */
+export function normalizeProjectPath(rawPath: string): string {
+    const absolutePath: string = resolve(rawPath)
+    try {
+        return realpathSync.native(absolutePath)
+    } catch {
+        return absolutePath
+    }
+}
 
 export function getVoicetreeHomePath(input: {
     readonly env: NodeJS.ProcessEnv

--- a/packages/measures/src/health/coupling/coupling-budget.ts
+++ b/packages/measures/src/health/coupling/coupling-budget.ts
@@ -164,9 +164,21 @@
 //   vt-daemon-client -> paths:       0 -> 1 (VTD owner discovery)
 //   vt-rpc -> paths:                 0 -> 1 (auth/port files)
 //   webapp -> paths:                 0 -> 2 (Electron build config + project bootstrap)
+//
+// 2026-05-31 [worktree-placement-unload]: add `normalizeProjectPath` to the
+// `@vt/paths` SSOT — it canonicalizes a project path to its true on-disk casing
+// via `realpathSync.native` at the `openProject` edge, plus a recent-projects
+// de-dupe, fixing the `~/Voicetree` vs `~/voicetree` split (case-insensitive APFS
+// treats them as one directory) that scattered worktrees. Both project-path edges
+// were already at the paths ratchet, so each legitimately gains one value symbol —
+// a shared-leaf addition, not reducible coupling: every project-path package
+// (app-config, webapp, graph-db-server) already imports `@vt/paths` at its ratchet,
+// so there is nowhere else to host a new shared path utility.
+//   app-config -> paths:  2 -> 3 (+1 normalizeProjectPath, recent-projects de-dupe)
+//   webapp -> paths:      2 -> 3 (+1 normalizeProjectPath, openProject edge)
 export const CROSS_PACKAGE_VALUE_SYMBOL_BUDGETS: Readonly<Record<string, number>> = {
     'app-config -> graph-model': 4,
-    'app-config -> paths': 2,
+    'app-config -> paths': 3,
     // 2026-05-28 [PR #139]: @vt/code-graph-cli is a thin agent-facing wrapper
     // around `@vt/measures`' `buildCallGraph` — single value symbol
     // (`buildCallGraph`) plus a pair of type re-exports (`CallGraph`,
@@ -302,7 +314,9 @@ export const CROSS_PACKAGE_VALUE_SYMBOL_BUDGETS: Readonly<Record<string, number>
     'webapp -> graph-state': 19,
     'webapp -> graph-tools': 14,
     'webapp -> observability': 1,
-    'webapp -> paths': 2,
+    // 2026-05-31 [worktree-placement-unload]: 2 -> 3 (+1 normalizeProjectPath,
+    // openProject canonicalization edge — see paths header block above).
+    'webapp -> paths': 3,
     // 2026-05-30 [BF-435]: 0 -> 1. The tiered perf-probe is started once at
     // electron-main boot via the single facade `perfProbeFromEnv('vt-electron-main')`
     // and stopped on `will-quit`. electron-main is the impure shell/edge — the

--- a/packages/systems/graph-db-server/src/data/graph/watching/daemonWatcher.test.ts
+++ b/packages/systems/graph-db-server/src/data/graph/watching/daemonWatcher.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import normalizePath from 'normalize-path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import type { FSDelete, FSUpdate } from '@vt/graph-model'
 import { mountWatcher, type Watcher, type MountWatcherDependencies } from './daemonWatcher.ts'
@@ -144,6 +145,11 @@ describe('mountWatcher: excludes .voicetree/ files from the graph', () => {
         }
       },
       logger: { error: () => undefined },
+      // In production the cold scan loads `notes/` before the watcher mounts, so
+      // a loose file appearing there ingests. Seed one loaded node under it so
+      // the "new folders unloaded by default" gate sees `notes/` as loaded —
+      // this test exercises the `.voicetree` IGNORE rule, not the load gate.
+      getGraphNodes: () => ({ [`${normalizePath(join(project, 'notes'))}/seed.md`]: {} }),
     }
 
     const watcher: Watcher = mountWatcher([project], project, deps)
@@ -164,4 +170,87 @@ describe('mountWatcher: excludes .voicetree/ files from the graph', () => {
       await watcher.unmount()
     }
   }, 12000)
+})
+
+/**
+ * "New folders unloaded by default" (the worktree-flood fix). Drives the real
+ * chokidar pipeline and asserts on the OBSERVABLE side effect — which 'add'
+ * events reach the graph handler. A brand-new folder dropped under a loaded
+ * project (e.g. a `git worktree add` checkout) must NOT ingest its markdown;
+ * loose new files in already-loaded folders must still ingest instantly.
+ */
+describe('mountWatcher: new folders are unloaded by default (no flood)', () => {
+  const created: string[] = []
+  const originalHeadlessTest: string | undefined = process.env.HEADLESS_TEST
+
+  beforeEach(() => {
+    // Force polling so watch-time 'add' events are reliably observed in CI/macOS.
+    process.env.HEADLESS_TEST = '1'
+  })
+
+  afterEach(async () => {
+    if (originalHeadlessTest === undefined) delete process.env.HEADLESS_TEST
+    else process.env.HEADLESS_TEST = originalHeadlessTest
+    for (const dir of created.splice(0)) {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('a brand-new folder of many .md does not ingest; loose files in loaded folders do', async () => {
+    const parent: string = await mkdtemp(join(tmpdir(), 'vt-unload-new-folders-'))
+    created.push(parent)
+    const project: string = join(parent, 'project')
+    await mkdir(join(project, 'loaded'), { recursive: true })
+
+    // The loaded project as the daemon sees it after the cold scan: the root is
+    // a watch root, and `loaded/` already holds a node.
+    const graphNodes: Record<string, unknown> = {
+      [`${normalizePath(join(project, 'loaded'))}/existing.md`]: {},
+    }
+
+    const addedPaths: string[] = []
+    const deps: MountWatcherDependencies = {
+      readFileWithRetry: async () => '# content\n',
+      handleFSEvent: (event: FSUpdate | FSDelete) => {
+        if ('eventType' in event && event.eventType === 'Added') {
+          addedPaths.push(normalizePath(event.absolutePath))
+        }
+      },
+      logger: { error: () => undefined },
+      getGraphNodes: () => graphNodes,
+    }
+
+    const watcher: Watcher = mountWatcher([project], project, deps)
+    try {
+      await withTimeout(watcher.ready, 4000, 'watcher.ready did not resolve')
+
+      // A brand-new nested folder tree appears (simulating a worktree checkout).
+      // Written FIRST so its 'add' events are surfaced no later than the loose
+      // files below — making the absence assertion deterministic under polling.
+      await mkdir(join(project, 'wt-feature', 'packages', 'app'), { recursive: true })
+      await writeFile(join(project, 'wt-feature', 'README.md'), '# readme\n')
+      await writeFile(join(project, 'wt-feature', 'architecture.md'), '# arch\n')
+      await writeFile(join(project, 'wt-feature', 'packages', 'app', 'index.md'), '# idx\n')
+
+      // Loose new files that MUST still load: one in an already-loaded subfolder,
+      // one directly at the (watch-root) project root.
+      await writeFile(join(project, 'loaded', 'fresh.md'), '# fresh\n')
+      await writeFile(join(project, 'root-note.md'), '# root\n')
+
+      // Both loose files ingest...
+      await expect
+        .poll(
+          () =>
+            addedPaths.some((p) => p.endsWith('/loaded/fresh.md')) &&
+            addedPaths.some((p) => p.endsWith('/root-note.md')),
+          { timeout: 5000 },
+        )
+        .toBe(true)
+
+      // ...and not a single file from the brand-new folder did.
+      expect(addedPaths.some((p) => p.includes('/wt-feature/'))).toBe(false)
+    } finally {
+      await watcher.unmount()
+    }
+  }, 15000)
 })

--- a/packages/systems/graph-db-server/src/data/graph/watching/daemonWatcher.ts
+++ b/packages/systems/graph-db-server/src/data/graph/watching/daemonWatcher.ts
@@ -1,17 +1,22 @@
 import chokidar from 'chokidar'
 import type { FSWatcher } from 'chokidar'
+import normalizePath from 'normalize-path'
 import {
   isImageNode,
   type FSDelete,
   type FSUpdate,
 } from '@vt/graph-model'
+import { toAbsolutePath } from '@vt/graph-model/folders'
 import { handleFSEventWithStateAndUISides } from './handleFSEvent.ts'
 import {
   readFileWithRetry,
   createWatchIgnorePredicate,
 } from '@vt/graph-db-server/watch-folder/watching/file-watcher-setup'
 import type { FileWatcherLogger } from '@vt/graph-db-server/watch-folder/watching/file-watcher-setup'
+import { shouldIngestAddedFile } from '@vt/graph-db-server/watch-folder/watching/folderLoadGate'
 import { consumeBroadcastSuppression } from '@vt/graph-db-server/watch-folder/pending-writes'
+import { getGraph } from '@vt/graph-db-server/state/graph-store'
+import { getFolderTreeReadModel } from '@vt/graph-db-server/state/folder-tree-read-model-store'
 
 export type Watcher = {
   readonly ready: Promise<void>
@@ -24,6 +29,9 @@ export interface MountWatcherDependencies {
   readonly readFileWithRetry: typeof readFileWithRetry
   readonly handleFSEvent: typeof handleFSEventWithStateAndUISides
   readonly logger: FileWatcherLogger
+  /** The loaded graph's `nodes` record, read fresh per 'add' to decide whether
+   *  an added file's containing folder is already loaded. */
+  readonly getGraphNodes: () => Readonly<Record<string, unknown>>
 }
 
 const defaultMountWatcherDependencies: MountWatcherDependencies = {
@@ -34,6 +42,7 @@ const defaultMountWatcherDependencies: MountWatcherDependencies = {
       console.error(message, ...optionalParams)
     },
   },
+  getGraphNodes: () => getGraph().nodes,
 }
 
 function waitForReady(watcher: FSWatcher): Promise<void> {
@@ -95,7 +104,26 @@ export function mountWatcher(
   const watcher: FSWatcher = chokidar.watch([...readPaths], buildWatcherOptions(readPaths))
   const ready = waitForReady(watcher)
 
+  // The currently-mounted project paths (watch roots), kept in lockstep with
+  // `add`/`unwatch` so the ingestion gate always sees live roots: a folder the
+  // user just loaded becomes a root and its files start ingesting; an unloaded
+  // folder stops being one.
+  const mountedRoots = new Set<string>(readPaths.map((p) => normalizePath(p)))
+
   watcher.on('add', (filePath: string) => {
+    // "New folders unloaded by default": an external file appearing inside a
+    // brand-new, not-yet-loaded folder (e.g. a git worktree checkout) must not
+    // ingest as a graph node — otherwise the whole nested tree floods the
+    // workspace. Skip it and refresh the folder tree so the folder still
+    // surfaces in the sidebar as unloaded (one-click loadable).
+    if (!shouldIngestAddedFile(filePath, mountedRoots, dependencies.getGraphNodes())) {
+      getFolderTreeReadModel().invalidate({
+        kind: 'pathChanged',
+        absolutePath: toAbsolutePath(normalizePath(filePath)),
+      })
+      return
+    }
+
     const suppressBroadcastTo: ReadonlySet<string> = consumeBroadcastSuppression(filePath)
     const contentPromise = isImageNode(filePath)
       ? Promise.resolve('')
@@ -116,6 +144,14 @@ export function mountWatcher(
   })
 
   watcher.on('change', (filePath: string) => {
+    // A 'Changed' event upserts just like 'Added', so the same gate applies:
+    // never pull a file from an unloaded folder into the graph via an edit (an
+    // agent creating then editing a `.md` inside an unloaded worktree must stay
+    // unloaded). Files in loaded folders keep updating normally.
+    if (!shouldIngestAddedFile(filePath, mountedRoots, dependencies.getGraphNodes())) {
+      return
+    }
+
     const suppressBroadcastTo: ReadonlySet<string> = consumeBroadcastSuppression(filePath)
     if (isImageNode(filePath)) {
       return
@@ -150,9 +186,11 @@ export function mountWatcher(
   return {
     ready,
     add(path: string): void {
+      mountedRoots.add(normalizePath(path))
       watcher.add(path)
     },
     unwatch(path: string): void {
+      mountedRoots.delete(normalizePath(path))
       watcher.unwatch(path)
     },
     async unmount(): Promise<void> {

--- a/packages/systems/graph-db-server/src/data/watch-folder/watching/folderLoadGate.test.ts
+++ b/packages/systems/graph-db-server/src/data/watch-folder/watching/folderLoadGate.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { shouldIngestAddedFile } from './folderLoadGate.ts'
+
+/**
+ * Black-box tests for the "new folders unloaded by default" ingestion gate.
+ * Inputs (added file, mounted watch roots, loaded graph nodes) → boolean; no
+ * mocks, no I/O. A graph is modelled as the set of loaded node ids keyed in a
+ * record, exactly as `graph.nodes` is shaped.
+ */
+function graph(...nodeIds: readonly string[]): Record<string, unknown> {
+    return Object.fromEntries(nodeIds.map((id) => [id, {}]))
+}
+
+const ROOT = '/Users/x/project'
+const roots = new Set<string>([ROOT])
+
+describe('shouldIngestAddedFile', () => {
+    it('ingests a file dropped directly into a watch root, even when the root is empty', () => {
+        expect(shouldIngestAddedFile(`${ROOT}/note.md`, roots, graph())).toBe(true)
+    })
+
+    it('ingests a loose new file in a subfolder that already holds a loaded node', () => {
+        const g = graph(`${ROOT}/sun/existing.md`)
+        expect(shouldIngestAddedFile(`${ROOT}/sun/fresh.md`, roots, g)).toBe(true)
+    })
+
+    it('does NOT ingest a file in a brand-new folder with no loaded content', () => {
+        const g = graph(`${ROOT}/sun/existing.md`)
+        expect(shouldIngestAddedFile(`${ROOT}/wt-feature/readme.md`, roots, g)).toBe(false)
+    })
+
+    it('does NOT ingest any file in a brand-new nested folder tree (the worktree flood)', () => {
+        // The graph holds the real project notes; none live under the worktree.
+        const g = graph(`${ROOT}/a.md`, `${ROOT}/notes/b.md`)
+        expect(shouldIngestAddedFile(`${ROOT}/wt-x/packages/app/README.md`, roots, g)).toBe(false)
+        expect(shouldIngestAddedFile(`${ROOT}/wt-x/architecture.md`, roots, g)).toBe(false)
+        expect(shouldIngestAddedFile(`${ROOT}/wt-x/brain/mem/spec.md`, roots, g)).toBe(false)
+    })
+
+    it('stays false across the whole subtree regardless of arrival order (order-independent)', () => {
+        // No node ever lives under the new folder, so a deep file and a shallow
+        // file both gate the same way — proving independence from addDir/add
+        // ordering.
+        const g = graph(`${ROOT}/a.md`)
+        const deepFirst = shouldIngestAddedFile(`${ROOT}/wt/deep/x.md`, roots, g)
+        const shallowSecond = shouldIngestAddedFile(`${ROOT}/wt/y.md`, roots, g)
+        expect(deepFirst).toBe(false)
+        expect(shallowSecond).toBe(false)
+    })
+
+    it('treats a folder loaded only via deep content as loaded for a loose sibling file', () => {
+        // `sun/` has no direct node but a descendant is loaded → sun is loaded.
+        const g = graph(`${ROOT}/sun/deep/x.md`)
+        expect(shouldIngestAddedFile(`${ROOT}/sun/sibling.md`, roots, g)).toBe(true)
+    })
+
+    it('ingests files under a freshly-loaded folder once it becomes a watch root', () => {
+        // Simulates the user clicking "load" on a worktree: it joins watchRoots.
+        const loadedRoots = new Set<string>([ROOT, `${ROOT}/wt-feature`])
+        expect(shouldIngestAddedFile(`${ROOT}/wt-feature/readme.md`, loadedRoots, graph())).toBe(true)
+    })
+
+    it('does not let a sibling subfolder leak loadedness across folders', () => {
+        // `loaded/` has a node; `unloaded/` (its sibling) does not.
+        const g = graph(`${ROOT}/loaded/a.md`)
+        expect(shouldIngestAddedFile(`${ROOT}/unloaded/a.md`, roots, g)).toBe(false)
+        // A path-prefix lookalike must not count as "under": `loaded-2` is not
+        // under `loaded`.
+        expect(shouldIngestAddedFile(`${ROOT}/loaded-2/a.md`, roots, g)).toBe(false)
+    })
+
+    it('matches watch roots regardless of a trailing slash', () => {
+        const trailing = new Set<string>([`${ROOT}/sub/`].map((r) => r.replace(/\/+$/, '')))
+        expect(shouldIngestAddedFile(`${ROOT}/sub/file.md`, trailing, graph())).toBe(true)
+    })
+
+    it('normalizes backslash paths before deciding (cross-platform inputs)', () => {
+        const g = graph(`${ROOT}/sun/existing.md`)
+        expect(shouldIngestAddedFile(`${ROOT}\\sun\\fresh.md`, roots, g)).toBe(true)
+        expect(shouldIngestAddedFile(`${ROOT}\\wt\\fresh.md`, roots, g)).toBe(false)
+    })
+
+    it('does not gate a pathological file at the filesystem root', () => {
+        expect(shouldIngestAddedFile('/x.md', roots, graph())).toBe(true)
+    })
+})

--- a/packages/systems/graph-db-server/src/data/watch-folder/watching/folderLoadGate.ts
+++ b/packages/systems/graph-db-server/src/data/watch-folder/watching/folderLoadGate.ts
@@ -1,0 +1,87 @@
+/**
+ * "New folders unloaded by default" — the ingestion gate for watcher 'add'.
+ *
+ * A folder that newly appears under a watched project (a freshly created git
+ * worktree, or any directory dropped in by an external tool) must NOT auto-load
+ * its markdown as graph nodes — otherwise an entire nested codebase floods the
+ * workspace. Such a folder instead shows up in the folder tree as UNLOADED and
+ * is one-click loadable.
+ *
+ * This module is the single decision point: given an added file, the currently
+ * mounted watch roots, and the loaded graph, it answers whether the file's
+ * containing folder is "already loaded" and therefore whether the file should
+ * ingest.
+ */
+
+import normalizePath from 'normalize-path'
+
+/** The parent directory of `filePath`, normalized to forward slashes with no
+ *  trailing slash, or `null` when `filePath` has no parent segment. */
+function containingFolderOf(filePath: string): string | null {
+    const normalized: string = normalizePath(filePath)
+    const lastSlash: number = normalized.lastIndexOf('/')
+    // `<= 0` covers both "no separator" and a file sitting at the filesystem
+    // root ("/x.md" → parent "" ): neither is a real project folder to gate.
+    if (lastSlash <= 0) return null
+    return normalized.slice(0, lastSlash)
+}
+
+/**
+ * Decide whether a newly-appearing file should be ingested as a graph node.
+ *
+ * The file's containing folder counts as "already loaded" — so the file
+ * ingests — in exactly two cases:
+ *
+ *   1. The folder is itself a watch root (a loaded project path: the write
+ *      folder or an expanded read path). A file dropped directly into a folder
+ *      the user explicitly loaded always loads, even when that folder is
+ *      otherwise empty of nodes.
+ *
+ *   2. The folder already holds at least one loaded node (the graph contains a
+ *      node id located under it). A folder with existing loaded content is, by
+ *      definition, part of the loaded project, so a loose new file dropped into
+ *      it loads instantly.
+ *
+ * A brand-new folder has neither property: none of its descendants are loaded,
+ * and it is not a watch root. Every file under it is therefore skipped — and
+ * because skipping never adds a node, the predicate stays `false` for the
+ * folder's whole subtree no matter what order chokidar surfaces the files in.
+ * This makes the decision deterministic and order-independent (no reliance on
+ * `addDir`-before-`add` event ordering).
+ *
+ * Scope: only EXTERNAL file creation reaches this gate in practice. Notes
+ * written through the app and agent `vt graph create` nodes are applied to the
+ * in-memory graph directly by the daemon write path; their disk writes are
+ * deduped (pending-write / recent-delta), so the feature never affects them.
+ *
+ * Edge case (accepted): a folder that existed at mount but held no `.md`/image
+ * nodes is treated as unloaded until its first node loads — an external file
+ * dropped into such an empty folder must be loaded with a click rather than
+ * appearing instantly. This never causes a flood and never affects app/agent
+ * writes; it is the price of a stateless, race-free rule.
+ *
+ * Pure: no I/O, no module state.
+ *
+ * @param filePath     Absolute path of the added file (any slash style).
+ * @param watchRoots   Normalized (`normalizePath`) absolute paths of the
+ *                     currently mounted project paths.
+ * @param graphNodes   The loaded graph's `nodes` record. Only its keys (node
+ *                     ids: absolute, forward-slash-normalized file paths) are
+ *                     read; iterated in place so no array is allocated per call.
+ */
+export function shouldIngestAddedFile(
+    filePath: string,
+    watchRoots: ReadonlySet<string>,
+    graphNodes: Readonly<Record<string, unknown>>,
+): boolean {
+    const folder: string | null = containingFolderOf(filePath)
+    if (folder === null) return true
+
+    if (watchRoots.has(folder)) return true
+
+    const descendantPrefix: string = `${folder}/`
+    for (const nodeId in graphNodes) {
+        if (nodeId.startsWith(descendantPrefix)) return true
+    }
+    return false
+}

--- a/scripts/dev-setup/git-gate/install.sh
+++ b/scripts/dev-setup/git-gate/install.sh
@@ -35,9 +35,12 @@ case "$(uname -s)" in
     # shadowed too, so $HOME/bin is placed ahead of it.
     SHELL_INIT_FILES=("$HOME/.zshrc" "$HOME/.zprofile")
     PATH_LINE='export PATH="$HOME/bin:/opt/homebrew/bin:$PATH:$HOME/.claude/local"'
-    # Mac-authored worktrees join the mutagen mirror, so they live under the
-    # `-synced` root (same basename on both ends of the sync).
-    VT_WORKTREE_ROOT_VALUE="$HOME/repos/vt-wts-synced"
+    # Mac-authored worktrees live at the canonical sibling root $HOME/vt-wts —
+    # this is the live mutagen `vt-wts` alpha (Mac $HOME/vt-wts ↔ devbox
+    # /root/vt-wts-synced; mutagen syncs CONTENTS, so the two ends differ in
+    # basename) AND git-gate's own built-in default. The app computes the same
+    # root when git-gate is absent, so app / git-gate / mirror all converge here.
+    VT_WORKTREE_ROOT_VALUE="$HOME/vt-wts"
     ;;
   *)
     # Linux/dev boxes default to bash; the real git already lives on PATH under

--- a/scripts/run-remote.mjs
+++ b/scripts/run-remote.mjs
@@ -35,9 +35,12 @@ const execFileAsync = promisify(execFile)
 const REPO_ROOT = pathResolve(dirname(fileURLToPath(import.meta.url)), '..')
 const REMOTE_ROOT = '/root/vtrepo-synced'
 const REMOTE_WTS_ROOT = '/root/vt-wts-synced'
-// Mac-side worktree root basename. Mirrors the remote end (same `-synced`
-// basename); the local Mac path is `<parent>/vt-wts-synced/<name>`.
-const WORKTREE_SIBLING_DIR_NAME = 'vt-wts-synced'
+// Mac-side worktree root basename — the local Mac path is `<parent>/vt-wts`,
+// the live mutagen `vt-wts` alpha AND where the app / git-gate place worktrees.
+// The basename DIFFERS across the mirror (Mac `vt-wts` ↔ devbox `vt-wts-synced`,
+// REMOTE_WTS_ROOT above); mutagen syncs contents, not names. Must equal the
+// session alpha, else a worktree cwd fails to map and run-remote throws.
+const WORKTREE_SIBLING_DIR_NAME = 'vt-wts'
 const MUTAGEN_SESSION_MAIN = 'vt-remote'
 const MUTAGEN_SESSION_WTS = 'vt-wts'
 const RECURSION_GUARD = 'VT_REMOTE_EXEC'

--- a/webapp/src/shell/edge/main/graph/watch_folder/openProject.ts
+++ b/webapp/src/shell/edge/main/graph/watch_folder/openProject.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { promises as fs } from 'node:fs'
 import log from 'electron-log'
 import { getCallbacks } from '@vt/graph-model'
+import { normalizeProjectPath } from '@vt/paths'
 import { initializeProject } from '@vt/app-config/project'
 import {
     getProjectConfigForDirectory,
@@ -110,7 +111,16 @@ export async function getStartupProjectHint(): Promise<StartupProjectHint> {
     return { kind: 'none' }
 }
 
-export async function openProject(projectRoot: string): Promise<OpenProjectResponse> {
+export async function openProject(rawProjectRoot: string): Promise<OpenProjectResponse> {
+    // Single normalization edge: fix the path to its true on-disk casing (and
+    // resolve symlinks) so the watched dir, the daemon's node-ID base, the
+    // worktree spawn cwd, the persisted project record (derived downstream from
+    // `response.projectState.projectRoot`), and the project:* events the
+    // renderer matches against all agree. `/Users/x/Voicetree` and
+    // `/Users/x/voicetree` are one directory on a case-insensitive filesystem;
+    // without this they string-compare as two projects and scatter worktrees.
+    const projectRoot: string = normalizeProjectPath(rawProjectRoot)
+
     if (!(await pathIsDirectory(projectRoot))) {
         throw new Error(`Path is not a directory: ${projectRoot}`)
     }

--- a/webapp/src/shell/edge/main/workspace/worktree/gitWorktreeCommands.test.ts
+++ b/webapp/src/shell/edge/main/workspace/worktree/gitWorktreeCommands.test.ts
@@ -1,21 +1,23 @@
 /**
- * Black-box coverage for the placement-convention-free `gitWorktreeCommands`.
+ * Black-box coverage for `gitWorktreeCommands`.
  *
- * The app makes NO claim about where a worktree lives: `createWorktree` passes a
- * bare name to `git worktree add` and reads the real path back from git. These
- * tests run against a throwaway repo with PLAIN git (no git-gate wrapper on
- * PATH), so worktrees land nested under the repo — and the suite asserts the
- * observable outcome (worktree exists at the path git reports, branch created,
- * listing reflects it) without hardcoding any directory convention.
+ * Placement: when git-gate (the machine-level git wrapper) is on PATH it owns
+ * where worktrees live and `createWorktree` passes the bare name through; when
+ * git-gate is absent the app owns placement and creates the worktree at an
+ * absolute path under `VT_WORKTREE_ROOT ?? <parent-of-main-checkout>/vt-wts`.
+ * The decision is unit-tested via the pure `isGitGateActive` /
+ * `planWorktreePlacement`; the impure `createWorktree` is exercised against
+ * throwaway repos (with HOME pinned to a git-gate-free temp so the app-owned
+ * path is deterministic), reading the real path back from git.
  */
 
 import {afterEach, describe, expect, it} from 'vitest';
 import {execFileSync} from 'node:child_process';
-import {mkdtempSync, mkdirSync, realpathSync, rmSync, statSync, writeFileSync} from 'node:fs';
+import {mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
-import {join} from 'node:path';
+import {basename, delimiter, dirname, join} from 'node:path';
 
-import {createWorktree, listWorktrees} from './gitWorktreeCommands';
+import {createWorktree, isGitGateActive, listWorktrees, planWorktreePlacement} from './gitWorktreeCommands';
 
 const cleanups: Array<() => void> = [];
 
@@ -25,6 +27,27 @@ afterEach(() => {
 
 function git(repoRoot: string, args: readonly string[]): string {
     return execFileSync('git', args, {cwd: repoRoot, stdio: 'pipe', encoding: 'utf-8'});
+}
+
+// Set an env var for the duration of one test, restoring it in afterEach.
+function setEnvUntilCleanup(key: string, value: string | undefined): void {
+    const had: boolean = key in process.env;
+    const prev: string | undefined = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+    cleanups.push(() => {
+        if (had) process.env[key] = prev as string;
+        else delete process.env[key];
+    });
+}
+
+// A temp HOME with no `bin/git`, so isGitGateActive() is deterministically false
+// regardless of whether the test machine actually has git-gate installed (e.g. a
+// dev with ~/bin/git). This pins createWorktree onto the app-owned placement path.
+function gitGateFreeHome(): string {
+    const home: string = realpathSync(mkdtempSync(join(tmpdir(), 'vt-wt-home-')));
+    cleanups.push(() => rmSync(home, {recursive: true, force: true}));
+    return home;
 }
 
 function makeRepo(): string {
@@ -99,5 +122,143 @@ describe('listWorktrees (git-driven)', () => {
     it('returns an empty array when there are no linked worktrees', async () => {
         const repoRoot: string = makeRepo();
         expect(await listWorktrees(repoRoot)).toEqual([]);
+    });
+});
+
+describe('isGitGateActive (resolves git on PATH like execFile does)', () => {
+    const homeDir = '/Users/dev';
+    const shim = '/Users/dev/bin/git';
+    const execIn = (paths: readonly string[]) => {
+        const set: Set<string> = new Set(paths);
+        return (candidate: string): boolean => set.has(candidate);
+    };
+
+    it('true when ~/bin/git resolves first on PATH', () => {
+        expect(isGitGateActive({
+            pathEnv: ['/Users/dev/bin', '/opt/homebrew/bin', '/usr/bin'].join(delimiter),
+            homeDir,
+            isExecutable: execIn([shim, '/opt/homebrew/bin/git', '/usr/bin/git']),
+        })).toBe(true);
+    });
+
+    it('false when the real git resolves first and the shim is absent', () => {
+        expect(isGitGateActive({
+            pathEnv: ['/opt/homebrew/bin', '/usr/bin'].join(delimiter),
+            homeDir,
+            isExecutable: execIn(['/opt/homebrew/bin/git', '/usr/bin/git']),
+        })).toBe(false);
+    });
+
+    it('false when a stale ~/bin/git exists but is shadowed earlier on PATH', () => {
+        // /opt/homebrew/bin precedes ~/bin → execFile would run the real git.
+        expect(isGitGateActive({
+            pathEnv: ['/opt/homebrew/bin', '/Users/dev/bin'].join(delimiter),
+            homeDir,
+            isExecutable: execIn(['/opt/homebrew/bin/git', shim]),
+        })).toBe(false);
+    });
+
+    it('false when PATH is empty or undefined', () => {
+        expect(isGitGateActive({pathEnv: '', homeDir, isExecutable: () => true})).toBe(false);
+        expect(isGitGateActive({pathEnv: undefined, homeDir, isExecutable: () => true})).toBe(false);
+    });
+
+    it('false when no git is found anywhere on PATH', () => {
+        expect(isGitGateActive({
+            pathEnv: ['/Users/dev/bin', '/usr/bin'].join(delimiter),
+            homeDir,
+            isExecutable: () => false,
+        })).toBe(false);
+    });
+});
+
+describe('planWorktreePlacement', () => {
+    const mainCheckout = '/Users/dev/voicetree';
+
+    // No-op proof: when git-gate is active the destination argument passed to
+    // `git worktree add` is the BARE name, unchanged — placement is delegated to
+    // git-gate exactly as before, so git-gate users (Manu) see no change.
+    it('git-gate active → bare name, app does not own placement', () => {
+        expect(planWorktreePlacement({
+            gitGateActive: true,
+            worktreeName: 'wt-x-abc',
+            mainCheckout,
+            worktreeRootEnv: '/whatever/ignored',
+        })).toEqual({destination: 'wt-x-abc', appOwned: false});
+    });
+
+    it('git-gate absent → absolute dest under <parent-of-main>/vt-wts', () => {
+        expect(planWorktreePlacement({
+            gitGateActive: false,
+            worktreeName: 'wt-x-abc',
+            mainCheckout,
+            worktreeRootEnv: undefined,
+        })).toEqual({destination: '/Users/dev/vt-wts/wt-x-abc', appOwned: true});
+    });
+
+    it('git-gate absent + VT_WORKTREE_ROOT → absolute dest under that root', () => {
+        expect(planWorktreePlacement({
+            gitGateActive: false,
+            worktreeName: 'wt-x-abc',
+            mainCheckout,
+            worktreeRootEnv: '/custom/wts',
+        })).toEqual({destination: '/custom/wts/wt-x-abc', appOwned: true});
+    });
+
+    it('git-gate absent + blank VT_WORKTREE_ROOT → treated as unset', () => {
+        expect(planWorktreePlacement({
+            gitGateActive: false,
+            worktreeName: 'wt-x-abc',
+            mainCheckout,
+            worktreeRootEnv: '   ',
+        })).toEqual({destination: '/Users/dev/vt-wts/wt-x-abc', appOwned: true});
+    });
+});
+
+describe('createWorktree placement (no git-gate → app owns placement)', () => {
+    it('lands under VT_WORKTREE_ROOT, never nested inside the watched repo', async () => {
+        const repoRoot: string = makeRepo();
+        const parent: string = dirname(repoRoot);
+        const wtsRoot: string = join(parent, 'custom-wts');
+        setEnvUntilCleanup('HOME', gitGateFreeHome());
+        setEnvUntilCleanup('VT_WORKTREE_ROOT', wtsRoot);
+
+        const worktreePath: string = await createWorktree(repoRoot, 'wt-placed');
+
+        expect(basename(worktreePath)).toBe('wt-placed');
+        expect(basename(dirname(worktreePath))).toBe('custom-wts');
+        // NOT nested under the watched repo — the bug this change fixes.
+        expect(worktreePath.startsWith(repoRoot + '/')).toBe(false);
+        expect(statSync(worktreePath).isDirectory()).toBe(true);
+        expect((await listWorktrees(repoRoot)).map(w => w.branch)).toContain('wt-placed');
+    });
+
+    it('defaults to <parent-of-main-checkout>/vt-wts when VT_WORKTREE_ROOT is unset', async () => {
+        const repoRoot: string = makeRepo();
+        const parent: string = dirname(repoRoot);
+        setEnvUntilCleanup('HOME', gitGateFreeHome());
+        setEnvUntilCleanup('VT_WORKTREE_ROOT', undefined);
+
+        const worktreePath: string = await createWorktree(repoRoot, 'wt-default');
+
+        // main checkout = repoRoot; parent-of-main = parent; root = parent/vt-wts.
+        expect(worktreePath).toBe(join(parent, 'vt-wts', 'wt-default'));
+        expect(statSync(worktreePath).isDirectory()).toBe(true);
+    });
+
+    it('normalizes the new worktree git pointer to a relative (host-portable) path', async () => {
+        const repoRoot: string = makeRepo();
+        const parent: string = dirname(repoRoot);
+        setEnvUntilCleanup('HOME', gitGateFreeHome());
+        setEnvUntilCleanup('VT_WORKTREE_ROOT', join(parent, 'wts'));
+
+        const worktreePath: string = await createWorktree(repoRoot, 'wt-relative');
+
+        // App-owned placement runs `worktree repair --relative-paths`, so the
+        // worktree's `.git` gitdir pointer is relative, not an absolute
+        // host-specific path that would break the mutagen mac↔devbox mirror.
+        const gitPointer: string = readFileSync(join(worktreePath, '.git'), 'utf-8').trim();
+        expect(gitPointer.startsWith('gitdir: ')).toBe(true);
+        expect(gitPointer.startsWith('gitdir: /')).toBe(false);
     });
 });

--- a/webapp/src/shell/edge/main/workspace/worktree/gitWorktreeCommands.ts
+++ b/webapp/src/shell/edge/main/workspace/worktree/gitWorktreeCommands.ts
@@ -8,6 +8,8 @@
 import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 /** Shell-quote a single argument for POSIX-style hook commands. */
 export function shellQuote(arg: string): string {
@@ -72,6 +74,132 @@ export function generateWorktreeName(nodeTitle: string): string {
 }
 
 /**
+ * Decide whether the `git` binary this process will invoke is the git-gate
+ * shim, by replicating Node's PATH lookup (`execFile('git', …)` runs the first
+ * executable `git` on PATH) and comparing the winner to git-gate's install
+ * location, `$HOME/bin/git`.
+ *
+ * git-gate (scripts/dev-setup/git-gate) is the machine-level wrapper that owns
+ * worktree PLACEMENT: it rewrites a bare worktree name to its per-machine root.
+ * When it is the resolved `git`, this app must NOT also compute a path — it
+ * passes the bare name through and lets git-gate place the tree (a strict
+ * no-op vs. the wrapper-owns-placement design). When it is absent, this app
+ * owns placement instead.
+ *
+ * Resolving the binary — rather than merely testing whether `$HOME/bin/git`
+ * exists — is deliberate: a stale `$HOME/bin/git` shadowed by an earlier PATH
+ * entry is correctly reported inactive, because `execFile` would run that
+ * earlier real git, not the shim.
+ *
+ * Pure: the filesystem probe is injected via `isExecutable`.
+ */
+export function isGitGateActive({
+    pathEnv,
+    homeDir,
+    isExecutable,
+}: {
+    pathEnv: string | undefined;
+    homeDir: string;
+    isExecutable: (candidate: string) => boolean;
+}): boolean {
+    const shim: string = path.join(homeDir, 'bin', 'git');
+    const dirs: string[] = (pathEnv ?? '').split(path.delimiter).filter((dir: string) => dir !== '');
+    for (const dir of dirs) {
+        const candidate: string = path.join(dir, 'git');
+        if (isExecutable(candidate)) {
+            // First match wins, exactly as execFile's PATH search does.
+            return candidate === shim;
+        }
+    }
+    return false;
+}
+
+/**
+ * Decide the destination passed to `git worktree add`, and whether THIS app
+ * owns placement (and must therefore normalize the worktree's git metadata
+ * afterwards):
+ *
+ *   git-gate active → BARE name (argv unchanged): git-gate rewrites it to its
+ *                     per-machine root. `appOwned` is false.
+ *   git-gate absent → ABSOLUTE path under `VT_WORKTREE_ROOT`, or — absent that
+ *                     shared override — the canonical sibling of the main
+ *                     checkout, `<parent-of-main-checkout>/vt-wts`. Never nested
+ *                     inside the watched project. `appOwned` is true.
+ *
+ * Pure.
+ */
+export function planWorktreePlacement({
+    gitGateActive,
+    worktreeName,
+    mainCheckout,
+    worktreeRootEnv,
+}: {
+    gitGateActive: boolean;
+    worktreeName: string;
+    mainCheckout: string;
+    worktreeRootEnv: string | undefined;
+}): { destination: string; appOwned: boolean } {
+    if (gitGateActive) {
+        return { destination: worktreeName, appOwned: false };
+    }
+    const root: string = (worktreeRootEnv !== undefined && worktreeRootEnv.trim() !== '')
+        ? worktreeRootEnv
+        : path.join(path.dirname(mainCheckout), 'vt-wts');
+    return { destination: path.join(root, worktreeName), appOwned: true };
+}
+
+/**
+ * Probe whether `candidate` is an executable regular file. Impure (fs);
+ * injected into the pure `isGitGateActive`.
+ */
+function isExecutableFile(candidate: string): boolean {
+    try {
+        if (!fs.statSync(candidate).isFile()) return false;
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Resolve the absolute path of the repository's MAIN checkout from any path
+ * inside the repo — the watched dir, which may be a subdirectory of the
+ * checkout or even a linked worktree. `--path-format=absolute` is required: a
+ * bare `--git-common-dir` may be returned relative to cwd (or, from a linked
+ * worktree, surface the per-worktree git dir on some setups). With the flag,
+ * git always yields the shared `<main>/.git`, whose parent is the main checkout.
+ */
+async function resolveMainCheckout(repoDir: string): Promise<string> {
+    const { stdout }: { stdout: string } = await execFileAsync(
+        'git',
+        ['-C', repoDir, 'rev-parse', '--path-format=absolute', '--git-common-dir'],
+    );
+    return path.dirname(stdout.trim());
+}
+
+/**
+ * Make the new worktree's admin pointers relative, so they are host-portable
+ * across the mutagen mac↔devbox mirror — the same normalization git-gate does
+ * after its own add. `--relative-paths` needs git >= 2.48; fall back to a plain
+ * repair on older git (absolute pointers are fine for trees that never sync).
+ * Best-effort: a repair failure never fails worktree creation.
+ */
+async function repairWorktreeMetadata(worktreePath: string): Promise<void> {
+    try {
+        await execFileAsync('git', ['-C', worktreePath, 'worktree', 'repair', '--relative-paths']);
+        return;
+    } catch {
+        // Older git without --relative-paths — fall through to a plain repair.
+    }
+    try {
+        await execFileAsync('git', ['-C', worktreePath, 'worktree', 'repair']);
+    } catch {
+        // Best-effort: leave pointers exactly as `git worktree add` wrote them.
+    }
+}
+
+/**
  * Discover the absolute path of the worktree checked out on `branch`, by asking
  * git itself rather than computing it from any placement convention.
  *
@@ -106,20 +234,32 @@ async function discoverWorktreePathForBranch(repoRoot: string, branch: string): 
  * Create a new git worktree with a corresponding branch, then return the
  * absolute path git actually placed it at.
  *
- * The app makes NO claim about WHERE the worktree lives. We pass a BARE name as
- * the destination path and let the layer below decide placement:
- *   - the machine-level git wrapper (git-gate) rewrites the bare name to its
- *     per-machine worktree root, or
- *   - plain git (external users, no wrapper) creates it nested under the repo.
+ * Placement depends on whether git-gate is the resolved `git`:
+ *   - git-gate ACTIVE → pass the BARE name through unchanged; git-gate rewrites
+ *     it to its per-machine worktree root and normalizes the metadata. A strict
+ *     no-op vs. the wrapper-owns-placement design.
+ *   - git-gate ABSENT → THIS app owns placement: the worktree is created at an
+ *     absolute path under `VT_WORKTREE_ROOT ?? <parent-of-main-checkout>/vt-wts`
+ *     (a sibling of the main checkout, never nested inside the watched project),
+ *     with `VT_GIT_GATE_NO_PLACEMENT=1` set so a git-gate we failed to detect
+ *     would still honour the explicit path. The app then runs
+ *     `worktree repair --relative-paths` itself — the normalization git-gate
+ *     would otherwise have done.
+ *
  * Either way we read the resulting path back from git via
- * `discoverWorktreePathForBranch` rather than computing it here.
+ * `discoverWorktreePathForBranch` rather than trusting the computed path.
+ *
+ * `repoRoot` may be any directory inside the repository (the watched dir, a
+ * subdirectory of it, or a linked worktree); the true main checkout is resolved
+ * from it for placement.
  *
  * `VT_GIT_GATE_SKIP_WORKTREE_PREWARM=1`: this caller owns the worktree
  * lifecycle hooks (the async hook installs deps + links .env), so the wrapper
  * must NOT also run its own dependency bootstrap — that would double-install
  * and race on `node_modules`. The flag is a no-op for plain git.
  *
- * @param repoRoot - The root directory of the git repository
+ * @param repoRoot - A directory inside the git repository (placement is
+ *   resolved against the repo's main checkout)
  * @param worktreeName - The name for the worktree and branch
  * @param blockingHookCommand - Optional command awaited after creation, before returning
  * @param asyncHookCommand - Optional fire-and-forget command run after creation
@@ -132,20 +272,47 @@ export async function createWorktree(
     blockingHookCommand?: string,
     asyncHookCommand?: string,
 ): Promise<string> {
-    // -b creates a new branch with the worktree name; the bare name is the
-    // destination path argument (placement is decided one layer down).
+    const mainCheckout: string = await resolveMainCheckout(repoRoot);
+    const gitGateActive: boolean = isGitGateActive({
+        pathEnv: process.env.PATH,
+        homeDir: os.homedir(),
+        isExecutable: isExecutableFile,
+    });
+    const placement: { destination: string; appOwned: boolean } = planWorktreePlacement({
+        gitGateActive,
+        worktreeName,
+        mainCheckout,
+        worktreeRootEnv: process.env.VT_WORKTREE_ROOT,
+    });
+
+    // SKIP_WORKTREE_PREWARM: the app owns the worktree hooks (below), so git-gate
+    // must not also bootstrap deps. NO_PLACEMENT (app-owned only): pins our
+    // explicit path so an undetected git-gate would still honour it.
+    const env: NodeJS.ProcessEnv = placement.appOwned
+        ? { ...process.env, VT_GIT_GATE_SKIP_WORKTREE_PREWARM: '1', VT_GIT_GATE_NO_PLACEMENT: '1' }
+        : { ...process.env, VT_GIT_GATE_SKIP_WORKTREE_PREWARM: '1' };
+
+    // -b creates a new branch named after the worktree; `placement.destination`
+    // is either the bare name (git-gate places it) or an absolute path (app
+    // places it). Run from the main checkout so placement is anchored there.
     try {
         await execFileAsync(
             'git',
-            ['worktree', 'add', '-b', worktreeName, worktreeName],
-            { cwd: repoRoot, env: { ...process.env, VT_GIT_GATE_SKIP_WORKTREE_PREWARM: '1' } },
+            ['worktree', 'add', '-b', worktreeName, placement.destination],
+            { cwd: mainCheckout, env },
         );
     } catch (error) {
         const errorMessage: string = error instanceof Error ? error.message : String(error);
         throw new Error(`Failed to create git worktree: ${errorMessage}`);
     }
 
-    const worktreePath: string = await discoverWorktreePathForBranch(repoRoot, worktreeName);
+    const worktreePath: string = await discoverWorktreePathForBranch(mainCheckout, worktreeName);
+
+    // App-owned placement: normalize the metadata git-gate would have normalized
+    // (host-portable relative pointers for the mutagen mirror).
+    if (placement.appOwned) {
+        await repairWorktreeMetadata(worktreePath);
+    }
 
     // Blocking hook: awaited after creation, before returning worktreePath to caller
     if (blockingHookCommand) {


### PR DESCRIPTION
## What
Fixes the bug where **"New Worktree" created a worktree nested inside the watched project**, flooding the VoiceTree session with the entire codebase as graph nodes. Three coordinated changes:

1. **App-owned worktree placement → `~/vt-wts`** (`createWorktree`): when git-gate is absent, the app resolves the main checkout and places the worktree at `VT_WORKTREE_ROOT ?? <parent-of-main-checkout>/vt-wts/<name>` (a sibling, never nested) and runs `worktree repair --relative-paths` for the mutagen mirror. **Strict no-op when git-gate is the resolved `git`** (verified incl. the shadowed-stale-shim case) — existing git-gate setups are unaffected.
2. **New folders unloaded by default** (`daemonWatcher`): a folder newly appearing under a watched project no longer auto-loads its `.md` as nodes; it shows unloaded and is one-click loadable.
3. **Project-path case normalization** (`openProject` edge): `realpathSync.native` canonicalizes the path (fixes `~/Voicetree` vs `~/voicetree` on case-insensitive APFS) plus a recent-projects de-dupe — removes a source of worktree scatter.

Also reconciles the canonical Mac worktree root to `~/vt-wts` across `install.sh` and `run-remote.mjs` (matches the live mutagen `vt-wts` alpha; `REMOTE_WTS_ROOT` unchanged).

## Verification
- **45 unit/integration tests green**: folderLoadGate 11, daemonWatcher 5 (real chokidar), gitWorktreeCommands 17 (real git), paths 5, project-store 7.
- **Real-git placement smoke**: no git-gate → worktree at `<parent>/vt-wts`, not nested, relative pointers; `VT_WORKTREE_ROOT` override honored.

## Known follow-ups (out of scope — flagged, not done)
- **Cold-load (reopen) gap**: the live watcher is gated, but `loadGraphFromDisk` (runs on project reopen) isn't — a project that *already* contains a nested worktree would still flood on reopen. Aligned fix: make cold-load respect persisted `readPaths`.
- **Dead-watcher cleanup**: `file-watcher-setup.setupWatcher` / `watcherRebuild.ts` have no callers (the live watcher is `daemonWatcher`); recommend deletion after a caller re-check.

Implemented by 3 parallel agents (graph-db-server / workspace / paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
