### PR TITLE
fix(terminal): pass request object to spawnPlainTerminalWithNode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "scikit-learn>=1.3.0",
     "fastapi>=0.100.0",
     "uvicorn[standard]>=0.23.0",
+    "websockets>=13.0",
     "pydantic>=2.0.0",
     "pytest>=8.4.2",
     "requests>=2.32.5",

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/VerticalMenuService.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/VerticalMenuService.ts
@@ -1,4 +1,4 @@
-import type {Core, Position as CyPosition, EventObject, NodeSingular} from 'cytoscape';
+import type {Core, NodeCollection, Position as CyPosition, EventObject, NodeSingular} from 'cytoscape';
 import ctxmenu from '@/shell/UI/lib/ctxmenu.js';
 import {mergeSelectedNodesFromUI} from "@/shell/edge/UI-edge/graph/actions/mergeSelectedNodesFromUI";
 import {extractIntoFolderFromUI} from "@/shell/edge/UI-edge/graph/actions/extractIntoFolderFromUI";
@@ -100,10 +100,10 @@ export class VerticalMenuService {
         const menuItems: MenuItem[] = [];
 
         // Check if click position is inside a folder node's bounding box
-        const folderAtPosition: NodeSingular = this.cy!.nodes('[?isFolderNode]').filter(node => {
+        const folderAtPosition: NodeSingular = (this.cy!.nodes('[?isFolderNode]') as NodeCollection).filter(node => {
             const bb: ReturnType<NodeSingular['boundingBox']> = node.boundingBox()
             return position.x >= bb.x1 && position.x <= bb.x2 && position.y >= bb.y1 && position.y <= bb.y2
-        }).sort((a, b) => b.ancestors().length - a.ancestors().length).first()
+        }).sort((a, b) => (b as NodeSingular).ancestors().length - (a as NodeSingular).ancestors().length).first() as NodeSingular
 
         if (folderAtPosition.length) {
             const folderId: string = folderAtPosition.id()

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/VerticalMenuService.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/VerticalMenuService.ts
@@ -257,7 +257,7 @@ export class VerticalMenuService {
             action: async () => {
                 const terminalsMap: Map<TerminalId, TerminalData> = getTerminals();
                 const terminalCount: number = getNextTerminalCount(terminalsMap, 'plain-terminal');
-                await window.electronAPI?.main.spawnPlainTerminalWithNode(position, terminalCount);
+                await window.electronAPI?.main.spawnPlainTerminalWithNode({ position, terminalCount });
             },
         });
 

--- a/webapp/src/shell/UI/lib/ctxmenu.d.ts
+++ b/webapp/src/shell/UI/lib/ctxmenu.d.ts
@@ -1,0 +1,25 @@
+export interface ActionMenuItem {
+    text?: string
+    html?: string
+    element?: HTMLElement
+    action?: () => void | Promise<void>
+    href?: string
+    disabled?: boolean | (() => boolean)
+    isDivider?: boolean
+    subMenu?: ActionMenuItem[]
+    subMenuAttributes?: Record<string, string>
+}
+
+interface CtxMenu {
+    show(items: ActionMenuItem[], event: MouseEvent): void
+    hide(): void
+}
+
+declare global {
+    interface Window {
+        ctxmenu: CtxMenu
+    }
+}
+
+declare const ctxmenu: CtxMenu
+export default ctxmenu


### PR DESCRIPTION
## Summary

- Fix `spawnPlainTerminalWithNode` RPC validation error (-32602): the call site in `VerticalMenuService.ts` was passing `(position, terminalCount)` as two positional args through the Electron IPC bridge, causing `position` to be received as the entire request and `terminalCount` to be dropped. The daemon received `{x, y}` but expected `{position: {x, y}, terminalCount: n}`.
- Add missing `ctxmenu.d.ts` type declaration and fix pre-existing Cytoscape `NodeSingular` cast errors in `VerticalMenuService.ts` and `FolderTreeNode.tsx`.

## Test plan

- [x] Right-click on canvas in the graph → click "Plain Terminal" → terminal should open without RPC error
- [ ] TypeScript compiles cleanly (`tsc --project tsconfig.app.json --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)