### PR TITLE
fix(ci): run Main CI under pnpm (mirror release.yml #194)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,17 +25,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       # The tier-1 duplication health gates shell out to the native vt-dup
       # binary; build it (cached) before running the suite. ubuntu-latest ships


### PR DESCRIPTION
## What

`.github/workflows/main.yml`'s `full` job still set up **npm** caching keyed on a non-existent `package-lock.json` and ran `npm ci`, while its *own* later steps already invoke `pnpm --filter @vt/measures ...`. The repo migrated to pnpm (`pnpm-lock.yaml` + `pnpm-workspace.yaml` at the root; no `package-lock.json` exists), so `npm ci` fails outright.

This is the **same npm→pnpm bug** that #194 fixed in `release.yml`, applied here so the scheduled `Main CI / Full` drift signal — and the `tier4-precheck` staleness denominator that queries its check-runs — can actually run.

## Change

Mirror the exact pnpm setup #194 applied to `release.yml`'s build jobs:
- add `pnpm/action-setup@v4` (version `10.32.1`, matching the root `packageManager` pin) before `actions/setup-node`
- switch `setup-node` to `cache: 'pnpm'` + `cache-dependency-path: pnpm-lock.yaml`
- replace `npm ci` with `pnpm install --frozen-lockfile`

`main.yml` is `schedule` + `workflow_dispatch` only (no `on.push.paths`), so there is no dead trigger path to fix here — unlike `release.yml`.

Scope: pnpm migration only. No other behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)