### PR TITLE
security: gitleaks secret-scan gate (pre-commit + CI)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,56 @@
+name: Secret Scan
+
+# Server-side mirror of the local scripts/hooks/pre-commit gitleaks gate.
+# A developer can bypass the local hook with --no-verify; this cannot be
+# bypassed and is the authoritative gate. It scans only the commits a PR/push
+# introduces (not full history), so it blocks NEW secrets without tripping on
+# pre-existing legacy findings that are handled separately (rotation + scrub).
+
+on:
+  pull_request:
+  push:
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          VERSION=8.30.1
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp gitleaks
+          sudo install /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Determine scan range
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "log_opts=${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            # push: scan the pushed range; on first push of a branch before is all-zeros.
+            before="${{ github.event.before }}"
+            if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+              echo "log_opts=${{ github.sha }}~1..${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            else
+              echo "log_opts=${before}..${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Scan introduced commits for secrets
+        run: |
+          gitleaks git . \
+            --redact --no-banner --exit-code 1 \
+            --config .gitleaks.toml \
+            --log-opts="${{ steps.range.outputs.log_opts }}"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,25 @@
+# Gitleaks config for voicetreelab/voicetree.
+# Extends the bundled default ruleset; adds repo-specific allowlisting for
+# synthetic test fixtures so the secret gate has zero false positives.
+title = "voicetree gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Paths that legitimately contain key-shaped or path-shaped test data, not real secrets."
+paths = [
+  # Example graph + onboarding fixtures shipped with the webapp (demo data).
+  '''webapp/example_folder_fixtures/.*''',
+  '''webapp/public/onboarding/.*''',
+  # E2E fixtures that hardcode synthetic /Users/<name> paths (bob, example, test…).
+  '''webapp/e2e-tests/.*''',
+  # This config + the ignore list themselves.
+  '''\.gitleaks\.toml$''',
+  '''\.gitleaksignore$''',
+]
+# Synthetic usernames used throughout test fixtures — never real credentials.
+regexTarget = "match"
+regexes = [
+  '''/Users/(bob|example|test|user|x)(/|"|$)''',
+]

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,11 +1,15 @@
 #!/bin/bash
-# Pre-commit gate. Two hard checks, in order:
-#   1. tier-0 static checks (typecheck/lint/etc) via pnpm run test:t0
-#   2. subgraph-scoped codebase-health gate via pnpm --filter @vt/measures run health:subgraph-gate
-# Both route through scripts/run-remote.mjs (via the bin/npm shim). When
+# Pre-commit gate. Three hard checks, in order:
+#   1. secret scan (gitleaks) over the staged tree — blocks credentials from
+#      ever entering history. Runs first because it is fast and the cheapest
+#      mistake to make irreversible (a pushed secret is a rotated secret).
+#   2. tier-0 static checks (typecheck/lint/etc) via pnpm run test:t0
+#   3. subgraph-scoped codebase-health gate via pnpm --filter @vt/measures run health:subgraph-gate
+# Checks 2-3 route through scripts/run-remote.mjs (via the bin/npm shim). When
 # VT_REMOTE_HOST is set, they execute on the devbox — the local .git/index is
 # mutagen-synced (see scripts/dev-setup/remote/mutagen-vt-remote.yml) so the
-# devbox sees the same staged tree as local git.
+# devbox sees the same staged tree as local git. The secret scan runs locally
+# (gitleaks is a self-contained binary reading the local staged tree).
 set -e
 repo_root="$(git rev-parse --show-toplevel)"
 export PATH="$repo_root/bin:$PATH"
@@ -30,6 +34,28 @@ is_merge_commit() {
 }
 
 staged_files="$(git diff --cached --name-only --diff-filter=ACM)"
+
+# --- Check 1: secret scan ------------------------------------------------
+# Block any commit whose staged changes contain a credential. Mirrors the
+# server-side .github/workflows/secret-scan.yml so a secret is caught locally
+# before it ever reaches a (possibly public) remote. Allowlisting for
+# synthetic test fixtures lives in .gitleaks.toml.
+if ! command -v gitleaks >/dev/null 2>&1; then
+    echo "❌ gitleaks is required by the pre-commit secret gate but is not installed."
+    echo "   Install it once:  brew install gitleaks   (or see https://github.com/gitleaks/gitleaks)"
+    echo "   This gate exists because credentials have leaked into public history before."
+    exit 1
+fi
+if ! gitleaks git "$repo_root" --staged --redact --no-banner -l error \
+        --config "$repo_root/.gitleaks.toml"; then
+    echo ""
+    echo "❌ gitleaks detected a secret in your staged changes — commit blocked."
+    echo "   • Move the value into an env var / .env file (\`.env\` is gitignored)."
+    echo "   • Genuine false positive? add a \`gitleaks:allow\` comment on the line,"
+    echo "     or allowlist the path/regex in .gitleaks.toml."
+    echo "   • Last resort (NOT for real secrets): git commit --no-verify"
+    exit 1
+fi
 
 # Keep pnpm-lock.yaml in sync with every package.json edit. Only runs when
 # the repo is on pnpm (pnpm-workspace.yaml present) — no-op on npm branches.


### PR DESCRIPTION
Adds a gitleaks secret-scan gate to the pre-commit hook plus a CI workflow, with a `.gitleaks.toml` config (allowlists synthetic test fixtures). Standard credential-hygiene: blocks key-shaped strings from being committed, locally and in CI.