### PR TITLE
fix(devbox+worktree): stop mirroring dead .git/worktrees, align mac worktree root to $HOME/vt-wts, + placement regression guards

### DIFF
--- a/scripts/dev-setup/common/configure-base.sh
+++ b/scripts/dev-setup/common/configure-base.sh
@@ -52,7 +52,7 @@ ALERT_PARENT_NODE="${VT_ALERT_PARENT_NODE:-}"
 [ -d "$BASE/.git" ] || { echo "configure-base: $BASE is not a git repository" >&2; exit 1; }
 
 case "$(uname -s)" in
-  Darwin) ROLE="mac"; WT_ROOT_DEFAULT="$HOME/repos/vt-wts-synced" ;;
+  Darwin) ROLE="mac"; WT_ROOT_DEFAULT="$HOME/vt-wts" ;;
   *)      ROLE="vm";  WT_ROOT_DEFAULT="$HOME/vt-wts" ;;
 esac
 WT_ROOT="${VT_WORKTREE_ROOT:-$WT_ROOT_DEFAULT}"

--- a/scripts/dev-setup/git-gate/git-gate.sh
+++ b/scripts/dev-setup/git-gate/git-gate.sh
@@ -159,7 +159,7 @@ esac
 # Per-machine worktree root. This wrapper is the ONE place that owns worktree
 # PLACEMENT: callers pass a bare name and we put the tree here. The default
 # matches the admission checker's default basename (vt-wts); install.sh writes
-# the per-machine value (Linux: $HOME/vt-wts, macOS: $HOME/repos/vt-wts-synced).
+# the per-machine value ($HOME/vt-wts on both Linux and macOS).
 gate_worktree_root() {
   printf '%s' "${VT_WORKTREE_ROOT:-$HOME/vt-wts}"
 }

--- a/scripts/dev-setup/remote/mutagen-vt-remote.yml
+++ b/scripts/dev-setup/remote/mutagen-vt-remote.yml
@@ -112,7 +112,15 @@ sync:
         # from the devbox. The matching .lock paths stay ignored — they're
         # atomic-write tempfiles, and syncing them would race with local git.
         - ".git/index.lock"
-        - ".git/worktrees/*/index.lock"
+        # The whole .git/worktrees/ admin tree is Mac-local: every entry's gitdir
+        # points at a Mac path, so mirrored into the devbox replica all entries
+        # are dead/prunable (a devbox-side `worktree prune` is re-resurrected on
+        # the next one-way-replica sync). Linked worktrees reach the devbox via
+        # the separate vt-wts session, not through this main checkout's .git, so
+        # the devbox never needs this dir. Ignore it entirely (supersedes the
+        # old `.git/worktrees/*/index.lock` entry).
+        - ".git/worktrees"
+        - ".git/worktrees/**"
         - ".git/*.lock"
         - ".git/refs/**/*.lock"
         - ".git/hooks"

--- a/scripts/dev-setup/remote/mutagen-vt-wts.yml
+++ b/scripts/dev-setup/remote/mutagen-vt-wts.yml
@@ -1,12 +1,12 @@
-# One-way-replica sync for the Mac-owned `vt-wts-synced/` worktree root.
+# One-way-replica sync for the Mac-owned worktree root (`$HOME/vt-wts/`).
 #
 # Why a SECOND session (not a config on `vt-remote`):
-#   - `vt-remote` syncs the Mac checkout `~/repos/vtrepo/` ↔ `/root/vtrepo-synced/`.
+#   - `vt-remote` syncs the Mac checkout `<repo>/` ↔ `/root/vtrepo-synced/`.
 #     A single mutagen session can only sync one path pair.
-#   - Worktrees live OUTSIDE the main checkout, under a dedicated root. The
-#     `-synced` suffix marks "part of this mirror" — the SAME basename on both
-#     ends. That second tree needs its own pair:
-#         ~/repos/vt-wts-synced       ↔ /root/vt-wts-synced
+#   - Worktrees live OUTSIDE the main checkout, under a dedicated sibling root.
+#     mutagen syncs CONTENTS, so the two ends differ in basename (Mac `vt-wts`
+#     ↔ devbox `vt-wts-synced`). That second tree needs its own pair:
+#         $HOME/vt-wts                ↔ /root/vt-wts-synced
 #   - Same mode as vt-remote (one-way-replica) because `scripts/run-remote.mjs`
 #     enforces that mode before remote execution.
 #   - Tuning knob: worktrees see heavier churn than the main checkout, so the

--- a/scripts/dev-setup/remote/vt-remote.sh
+++ b/scripts/dev-setup/remote/vt-remote.sh
@@ -63,10 +63,12 @@ VT_BRAIN_REPO_URL="${VT_BRAIN_REPO_URL:-git@github.com:voicetreelab/brain.git}"
 VT_BRAIN_LOCAL="${VT_BRAIN_LOCAL:-$HOME/brain-real}"
 VT_BRAIN_REMOTE="${VT_BRAIN_REMOTE:-/root/brain-real}"
 VT_WTS_CONFIG="$SCRIPT_DIR/mutagen-vt-wts.yml"
-# Mac-authored worktrees live under the `-synced` root (the mutagen mirror uses
-# the SAME basename on both ends). Matches VT_WORKTREE_ROOT written by
-# scripts/dev-setup/git-gate/install.sh on macOS.
-VT_WTS_LOCAL="$HOME/repos/vt-wts-synced"
+# Mac-authored worktrees live at the canonical sibling root $HOME/vt-wts — the
+# value VT_WORKTREE_ROOT is set to by scripts/dev-setup/git-gate/install.sh on
+# macOS, and where the app places worktrees when git-gate is absent. mutagen
+# syncs CONTENTS, so the two ends differ in basename ($HOME/vt-wts ↔ the devbox
+# /root/vt-wts-synced below).
+VT_WTS_LOCAL="$HOME/vt-wts"
 VT_WTS_REMOTE="/root/vt-wts-synced"
 ARTIFACT_ROOT="${ARTIFACT_ROOT:-/root/.voicetree/artifacts}"
 

--- a/scripts/run-remote.mjs
+++ b/scripts/run-remote.mjs
@@ -11,11 +11,12 @@
 //
 // Two mutagen sessions back this script:
 //   * `vt-remote`  — main checkout ↔ /root/vtrepo-synced  (one-way-replica)
-//   * `vt-wts`     — Mac /Users/.../vt-wts-synced/ ↔ /root/vt-wts-synced/  (one-way-replica)
+//   * `vt-wts`     — Mac <parent>/vt-wts/ ↔ /root/vt-wts-synced/  (one-way-replica)
 //
-// Worktrees live OUTSIDE the main checkout, under the Mac `-synced` worktree
-// root `<parent>/vt-wts-synced/<name>/` (the `-synced` basename is shared with
-// the remote end of the mirror). The session is picked based on which root the
+// Worktrees live OUTSIDE the main checkout, under the Mac sibling worktree
+// root `<parent>/vt-wts/<name>/`. mutagen syncs CONTENTS, so the basename
+// DIFFERS across the mirror (Mac `vt-wts` ↔ devbox `vt-wts-synced`). The
+// session is picked based on which root the
 // cwd falls under. Blocks on the chosen session reaching `Status: Watching for
 // changes` before invoking ssh.
 //
@@ -98,7 +99,7 @@ function localWtsRoot(mainCheckoutRoot = localMainCheckoutRoot()) {
 
 // Pick the sync session + roots that govern `cwd`.
 //   - cwd inside `<main>/`                  → vt-remote session, REMOTE_ROOT
-//   - cwd inside `<parent>/vt-wts-synced/`  → vt-wts session, REMOTE_WTS_ROOT
+//   - cwd inside `<parent>/vt-wts/`         → vt-wts session, REMOTE_WTS_ROOT
 //   - cwd elsewhere                         → null (caller throws)
 function resolveSyncContext(cwd = process.cwd()) {
   const mainCheckoutRoot = localMainCheckoutRoot()

--- a/webapp/src/shell/edge/main/workspace/worktree/gitWorktreeCommands.test.ts
+++ b/webapp/src/shell/edge/main/workspace/worktree/gitWorktreeCommands.test.ts
@@ -246,6 +246,44 @@ describe('createWorktree placement (no git-gate → app owns placement)', () => 
         expect(statSync(worktreePath).isDirectory()).toBe(true);
     });
 
+    // ROOT-CAUSE REGRESSION GUARD. The pre-fix code computed placement as
+    // `path.resolve(repoRoot, '..', 'vt-wts')` — a pure-string operation keyed off
+    // the WATCHED dir handed in. When that dir was a SUBDIRECTORY of the checkout
+    // (or a case-variant), the worktree scattered to `<repo>/vt-wts` (nested) or a
+    // case-variant sibling. The fix resolves the true main checkout via git first,
+    // so placement is anchored to `<parent-of-MAIN-checkout>/vt-wts` no matter which
+    // path inside the repo `createWorktree` is invoked from.
+    it('anchors placement to the MAIN checkout when called from a subdirectory', async () => {
+        const repoRoot: string = makeRepo();
+        const parent: string = dirname(repoRoot);
+        const subDir: string = join(repoRoot, 'nested', 'deep');
+        mkdirSync(subDir, {recursive: true});
+        setEnvUntilCleanup('HOME', gitGateFreeHome());
+        setEnvUntilCleanup('VT_WORKTREE_ROOT', undefined);
+
+        const worktreePath: string = await createWorktree(subDir, 'wt-from-subdir');
+
+        // Sibling of MAIN — not `<subDir>/../vt-wts` and not nested inside the repo.
+        expect(worktreePath).toBe(join(parent, 'vt-wts', 'wt-from-subdir'));
+        expect(worktreePath.startsWith(repoRoot + '/')).toBe(false);
+    });
+
+    it('anchors placement to the MAIN checkout when called from a linked worktree', async () => {
+        const repoRoot: string = makeRepo();
+        const parent: string = dirname(repoRoot);
+        setEnvUntilCleanup('HOME', gitGateFreeHome());
+        setEnvUntilCleanup('VT_WORKTREE_ROOT', undefined);
+
+        // A linked worktree's git-common-dir still resolves to the MAIN checkout, so
+        // a worktree spawned from inside another worktree lands as a sibling of MAIN,
+        // never relative to (or nested under) the linked worktree it was spawned from.
+        const firstWt: string = await createWorktree(repoRoot, 'wt-first');
+        const secondWt: string = await createWorktree(firstWt, 'wt-second');
+
+        expect(secondWt).toBe(join(parent, 'vt-wts', 'wt-second'));
+        expect(secondWt.startsWith(firstWt + '/')).toBe(false);
+    });
+
     it('normalizes the new worktree git pointer to a relative (host-portable) path', async () => {
         const repoRoot: string = makeRepo();
         const parent: string = dirname(repoRoot);


### PR DESCRIPTION
## What & why

Two fixes that came out of the **vt-wts worktree placement + cleanup** investigation.

### 1. Worktree-placement regression guards (`0f217af4f`)
The historical worktree scatter (`~/Voicetree/vt-wts`, `~/voicetree/vt-wts` nested inside the checkout) was already fixed on `dev` by `60a5d4050` (placement anchored to the git-resolved main checkout). This adds 2 black-box regression tests reproducing both scatter modes — spawn from a **subdirectory** and from a **linked worktree** — asserting placement always lands at `<parent-of-MAIN-checkout>/vt-wts`. No production code change; the fix already shipped.

### 2. Devbox / mutagen config fixes (`375e2137a`)
- **`mutagen-vt-remote.yml`**: ignore the whole `.git/worktrees` admin tree (was only `*/index.lock`). Each entry's gitdir points at a Mac path, so mirrored into the one-way-replica all entries are dead/prunable on the devbox — and a remote-side `worktree prune` is re-resurrected on the next sync. Ignoring the dir is the durable fix.
- **Align every Mac-side worktree-root reference to the canonical `$HOME/vt-wts`** (the SSOT documented in `git-gate/install.sh` and used by the live mutagen session + the app's git-gate-absent placement), removing stale `$HOME/repos/vt-wts-synced` drift:
  - `vt-remote.sh` `VT_WTS_LOCAL` (functional — `vt-wts-recreate` would otherwise mirror a non-existent `~/repos/...`)
  - `configure-base.sh` Darwin `WT_ROOT_DEFAULT` (functional)
  - `git-gate.sh`, `mutagen-vt-wts.yml`, `run-remote.mjs` — corrected stale/contradictory comments (run-remote *logic* already used `vt-wts`)

## Verification

- `scripts/run-remote.test.mjs` — **24/24 pass**
- Placement regression tests — **19/19 pass** (17 existing + 2 new)
- `bash -n` + YAML parse — clean on all changed scripts/configs
- Full unit suite run on the devbox (`npm run test`, tier ≤1): every behavioral/structural/shape/blackbox/timing/e2e-tier1 check passes. **4 git-dependent health checks** (`change-coupling`, `readme-line-budget`, `agent-instructions-line-budget`, `project-vocabulary`) fail there with `fatal: not a git repository` — a **pre-existing devbox linked-worktree env defect** (the worktree's relative `.git` pointer resolves to `/root/voicetree/...`, which doesn't exist; the devbox main checkout is `/root/vtrepo-synced`). Those exact 4 checks **pass locally** where git is functional. The defect is independent of this diff (config/comments only; none of the 4 checks import the changed files).

## ⚠️ Activation note (post-merge)
The mutagen `.git/worktrees` ignore takes effect only after recreating the session from a checkout that has this config. After merge:
```bash
cd ~/voicetree
./scripts/dev-setup/remote/vt-remote.sh sync-recreate
ssh root@216.176.239.218 'git -C /root/vtrepo-synced worktree prune -v'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
