### PR TITLE
fix(webapp): clear the two real tier-4 dead-code findings (getDaemonClient, ctxmenu.d.ts)

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -37,6 +37,10 @@ const config: KnipConfig = {
                 'vite.web.config.ts',
                 'src/utils/empty-node-module.ts',
                 'src/utils/types/*.d.ts',
+                // Sidecar type declaration for the vendored ctxmenu.js (imported as
+                // ctxmenu.js + via window.ctxmenu). Knip tracks the .js import, not the
+                // co-located .d.ts, so without this it false-flags the file as unused.
+                'src/shell/UI/lib/ctxmenu.d.ts',
                 'src/web-main.tsx',
                 'src/shell/edge/main/runtime/electron/app/main.ts',
                 'src/shell/edge/main/runtime/electron/app/preload.ts',

--- a/webapp/src/shell/edge/main/runtime/electron/daemon/lifecycle/graph-daemon.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/daemon/lifecycle/graph-daemon.ts
@@ -111,13 +111,6 @@ export async function setActiveProjectAndEnsureDaemon(project: string): Promise<
   return await ensureDaemonForActiveProject()
 }
 
-export function getDaemonClient(): GraphDbClient {
-  if (activeOwner === null) {
-    throw new Error('Graph daemon client is not connected. Open a project first.')
-  }
-  return activeOwner.client
-}
-
 export function getActiveDaemonClient(): GraphDbClient | null {
   return activeOwner?.client ?? null
 }


### PR DESCRIPTION
Sibling to #208. #208 excluded vendored/transient data (Grafana, Stryker sandboxes) from the tier-4 analyzers. This clears the **two remaining dead-code findings that are NOT vendored data** — the real reason #207's dead-code gate is red.

## 1. `getDaemonClient` — genuinely dead, removed
Exported in `graph-daemon.ts` with **zero callers** across webapp/packages (the only other matches were a *different* function `getDaemonClientForCurrentVault` inside stale `.cpuprofile` artifacts, plus the definition itself). Removed it. `getActiveDaemonClient` remains and still references the `GraphDbClient` type, so nothing is orphaned.

## 2. `ctxmenu.d.ts` — knip false positive, suppressed properly
`webapp/src/shell/UI/lib/ctxmenu.d.ts` is a sidecar type declaration for the vendored `ctxmenu.js` (imported as `ctxmenu.js` and via `window.ctxmenu`, and unit-tested in `ctxmenu.test.ts`). Knip tracks the `.js` import, not the co-located `.d.ts`, so it false-flagged the file as unused. Declared it as a webapp knip `entry` (matching the existing `src/utils/types/*.d.ts` convention) with a one-line rationale. **Not a budget bump** — a correct false-positive suppression.

## Verification (local)
- `capture-ci-checks --tier-max=4 --only=dead-code,duplication` → **0 failing** (dead-code clean; duplication 1.9%).
- `pnpm --filter voicetree-webapp run check` (`tsc --noEmit` + e2e-taxonomy) → clean.
- daemon-lifecycle tests pass. (3 `daemon-watch-sync` timing-test failures reproduce identically on clean dev with these changes stashed — pre-existing local real-timer flakiness, unrelated.)

Together with #208, this should make #207's full tier-4 (dead-code + duplication) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)