### PR TITLE
fix(release): resolve linux AppImage by glob, not hardcoded arch token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,7 +445,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           VERSION="${{ needs.check-version.outputs.version }}"
-          cp out/electron/voicetree-x64.AppImage out/electron/voicetree.AppImage
+          # electron-builder names the linux AppImage with the kernel arch
+          # token (x64 -> x86_64), unlike the mac DMG (x64). Resolve the real
+          # file rather than hardcoding the token so this no-arch-suffix compat
+          # alias stays correct across electron-builder arch-naming.
+          appimage=$(ls out/electron/voicetree-*.AppImage)
+          cp "$appimage" out/electron/voicetree.AppImage
           gh release upload "v${VERSION}" out/electron/voicetree.AppImage \
             --clobber --repo voicetreelab/voicetree
 


### PR DESCRIPTION
## Problem
`build-linux (x64)` failed the v3.0.0 cut on the *legacy AppImage alias* step:
```
cp: cannot stat 'out/electron/voicetree-x64.AppImage': No such file or directory
```
electron-builder's `${arch}` macro maps **x64 → x86_64** for the linux AppImage target (but `x64` for the mac DMG), so the real artifact is `voicetree-x86_64.AppImage`. It built and uploaded fine — only the hand-written compat-alias step assumed the mac-style `x64` token. Since `publish-release` needs `build-linux`, this held the release as an unpublished draft.

(arm64 stays `arm64`, so the token is inconsistent *per arch* — a glob is the robust fix.)

## Fix
Resolve the actual AppImage filename via glob instead of hardcoding the arch token.

## Note
The 3.0.0 release itself was shipped by dispatching this fixed workflow from this branch with `publish=true` (artifacts byte-identical to main; tag `v3.0.0` stays pinned to main HEAD via the existing draft). This PR lands the fix on `main` so future cuts work from the push trigger. Needs the same fix cherry-picked to `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)