### PR TITLE
fix(release): resolve linux AppImage by glob, not hardcoded arch token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,7 +445,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           VERSION="${{ needs.check-version.outputs.version }}"
-          cp out/electron/voicetree-x64.AppImage out/electron/voicetree.AppImage
+          # electron-builder names the linux AppImage with the kernel arch
+          # token (x64 -> x86_64), unlike the mac DMG (x64). Resolve the real
+          # file rather than hardcoding the token so this no-arch-suffix compat
+          # alias stays correct across electron-builder arch-naming.
+          appimage=$(ls out/electron/voicetree-*.AppImage)
+          cp "$appimage" out/electron/voicetree.AppImage
           gh release upload "v${VERSION}" out/electron/voicetree.AppImage \
             --clobber --repo voicetreelab/voicetree
 


### PR DESCRIPTION
Ports the v3.0.0 release hotfix (already on `main` via #210) to `dev` so the branches stay consistent.

electron-builder maps `${arch}` x64 → x86_64 for the linux AppImage (but x64 for the mac DMG, and arm64 stays arm64), so the legacy compat-alias step's hardcoded `voicetree-x64.AppImage` failed `cp`. Resolve the real filename via glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)