### PR TITLE
fix(voicetree-cli): declare the @vt/daemon-lifecycle dependency it imports

### DIFF
--- a/packages/systems/voicetree-cli/package.json
+++ b/packages/systems/voicetree-cli/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@vt/app-config": "*",
+    "@vt/daemon-lifecycle": "*",
     "@vt/graph-db-client": "*",
     "@vt/graph-db-protocol": "*",
     "@vt/graph-db-server": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,9 @@ importers:
       '@vt/app-config':
         specifier: '*'
         version: link:../../libraries/app-config
+      '@vt/daemon-lifecycle':
+        specifier: '*'
+        version: link:../../libraries/daemon-lifecycle
       '@vt/graph-db-client':
         specifier: '*'
         version: link:../graph-db-client


### PR DESCRIPTION
## Problem

`packages/systems/voicetree-cli/src/__tests__/serveOwner.e2e.harness.ts` imports
`@vt/daemon-lifecycle`:

```ts
import type {CallerKind} from '@vt/daemon-lifecycle'
```

…but `@vt/daemon-lifecycle` was **never declared** in `voicetree-cli`'s
`package.json`. It resolved at runtime only by borrowing the dependency hoisted
via a neighbouring package. Under `tsc` (`moduleResolution: bundler`, which
needs the per-package `node_modules/@vt/*` symlink that pnpm creates **only for
declared deps**) it fails:

```
serveOwner.e2e.harness.ts: error TS2307: Cannot find module '@vt/daemon-lifecycle'
```

This is a latent undeclared-dependency bug — invisible until the file is
typechecked in isolation (e.g. a per-file pre-commit/stop hook), at which point
the borrow is no longer available.

## Fix

Declare it in `devDependencies` (the import is test-only and type-only), so the
package honours its own dependency contract and pnpm creates the resolving
symlink on install.

## Verification

- `pnpm install` creates `voicetree-cli/node_modules/@vt/daemon-lifecycle`.
- `tsc --noEmit` in `voicetree-cli` → exit 0 (was TS2307 before).

Found incidentally while investigating the packaged-app `Cannot find module 'tsx'`
issue (see #213); split out as an independent, unrelated fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)