### PR TITLE
fix(resume): align native-session resolver recency window to the 7-day discovery horizon and give Claude outside-recency-window diagnostic parity

### DIFF
--- a/packages/systems/vt-daemon/src/agent-runtime/recovery/resolvers/resolveClaudeNativeSession.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/recovery/resolvers/resolveClaudeNativeSession.ts
@@ -14,20 +14,22 @@ export type ResolveClaudeRequest = {
 /**
  * Discriminant explaining a Claude native-session resolver miss.
  *
- * - `projects-dir-missing` — `~/.claude/projects` does not exist
- * - `no-jsonl-matches`     — no transcript JSONLs survived the recency filter
- * - `marker-mismatch`      — JSONLs were scanned but none contained all three VoiceTree markers
- * - `scan-timeout`         — scan exceeded its time budget before completing
+ * - `projects-dir-missing`   — `~/.claude/projects` does not exist
+ * - `no-jsonl-matches`       — no transcript carries our markers, in or out of window
+ * - `outside-recency-window` — our transcript exists but its mtime is older than the window
+ * - `marker-mismatch`        — in-window JSONLs were scanned but none contained all three VoiceTree markers
+ * - `scan-timeout`           — scan exceeded its time budget before completing
  */
 export type ClaudeMissReason =
     | 'projects-dir-missing'
     | 'no-jsonl-matches'
+    | 'outside-recency-window'
     | 'marker-mismatch'
     | 'scan-timeout'
 
 export type ResolveClaudeResult =
     | {readonly kind: 'found'; readonly sessionId: string; readonly providerStorePath: string}
-    | {readonly kind: 'not-found'; readonly reason: ClaudeMissReason}
+    | {readonly kind: 'not-found'; readonly reason: ClaudeMissReason; readonly diagnosticSessionId?: string}
 
 export type ClaudeTranscriptsList =
     | {readonly kind: 'transcripts'; readonly paths: readonly string[]}
@@ -43,17 +45,54 @@ export type ResolveClaudeDeps = {
 const DEFAULT_RECENCY_WINDOW_MS = 24 * 60 * 60 * 1000
 const DEFAULT_SCAN_TIMEOUT_MS = 10 * 1000
 
+type ScanCandidate = {readonly path: string; readonly mtime: number}
+
+type ScanOutcome =
+    | {readonly kind: 'match'; readonly sessionId: string; readonly path: string}
+    | {readonly kind: 'no-match'}
+    | {readonly kind: 'scan-timeout'}
+
+/**
+ * Reads each candidate transcript (newest first) and runs the pure marker
+ * matcher, returning the first match. Polls `deadlineMs` between files: a single
+ * hung `readFileSync` cannot be preempted, but realistic transcript scans
+ * terminate per-file in microseconds, so an O(files) deadline check is
+ * sufficient to bound total wall time.
+ */
+function scanForSession(
+    candidates: readonly ScanCandidate[],
+    request: ResolveClaudeRequest,
+    deps: ResolveClaudeDeps,
+    deadlineMs: number,
+): ScanOutcome {
+    for (const {path: filePath} of candidates) {
+        if (deps.now() > deadlineMs) return {kind: 'scan-timeout'}
+        const records: readonly ClaudeTranscriptRecord[] = deps.readJsonlLines(filePath)
+        const sessionId: string | null = matchClaudeSessionId({
+            records,
+            terminalId: request.terminalId,
+            projectRoot: request.projectRoot,
+            taskNodePath: request.taskNodePath,
+        })
+        if (sessionId) return {kind: 'match', sessionId, path: filePath}
+    }
+    return {kind: 'no-match'}
+}
+
 /**
  * Scans recently-modified Claude transcript files under `~/.claude/projects/**\/*.jsonl`,
  * runs the pure marker matcher over each, returns the first match.
  *
  * Recency filtering happens BEFORE file reads so we never `readFileSync` a transcript
- * older than the window — large `.claude/projects` trees would otherwise dominate IO.
+ * older than the window on the common path — large `.claude/projects` trees would
+ * otherwise dominate IO.
  *
- * On miss returns a structured `reason`. `scan-timeout` is enforced via a
- * deadline polled between files; a single hung `readFileSync` cannot be
- * preempted but realistic transcript scans terminate per-file in microseconds,
- * so an O(files) deadline check is sufficient to bound total wall time.
+ * When nothing is in the window, a single unwindowed 2nd pass scans the
+ * remaining (older) transcripts — mirroring the Codex resolver — so an
+ * out-of-window match still yields an actionable `outside-recency-window` miss
+ * carrying `diagnosticSessionId`, letting the UI offer a copy-`claude --resume
+ * <id>` escape hatch instead of a dead-end `no-jsonl-matches`. Both passes share
+ * the same `scan-timeout` deadline, which also bounds the unwindowed pass.
  */
 export async function resolveClaudeNativeSession(
     request: ResolveClaudeRequest,
@@ -68,26 +107,25 @@ export async function resolveClaudeNativeSession(
     const list: ClaudeTranscriptsList = deps.listProjectTranscripts()
     if (list.kind === 'projects-dir-missing') return {kind: 'not-found', reason: 'projects-dir-missing'}
 
-    const recent: Array<{readonly path: string; readonly mtime: number}> = []
-    for (const filePath of list.paths) {
-        const mtime: number = deps.fileModifiedAt(filePath)
-        if (mtime >= cutoff) recent.push({path: filePath, mtime})
-    }
-    if (recent.length === 0) return {kind: 'not-found', reason: 'no-jsonl-matches'}
-    recent.sort((a, b) => b.mtime - a.mtime)
+    const byMtimeDesc = (a: ScanCandidate, b: ScanCandidate): number => b.mtime - a.mtime
+    const all: ScanCandidate[] = list.paths.map((filePath) => ({path: filePath, mtime: deps.fileModifiedAt(filePath)}))
+    const recent: ScanCandidate[] = all.filter((c) => c.mtime >= cutoff).sort(byMtimeDesc)
 
-    for (const {path: filePath} of recent) {
-        if (deps.now() > deadlineMs) return {kind: 'not-found', reason: 'scan-timeout'}
-        const records: readonly ClaudeTranscriptRecord[] = deps.readJsonlLines(filePath)
-        const sessionId: string | null = matchClaudeSessionId({
-            records,
-            terminalId: request.terminalId,
-            projectRoot: request.projectRoot,
-            taskNodePath: request.taskNodePath,
-        })
-        if (sessionId) return {kind: 'found', sessionId, providerStorePath: filePath}
+    if (recent.length === 0) {
+        const outOfWindow: ScanCandidate[] = [...all].sort(byMtimeDesc)
+        if (outOfWindow.length === 0) return {kind: 'not-found', reason: 'no-jsonl-matches'}
+        const diagnostic: ScanOutcome = scanForSession(outOfWindow, request, deps, deadlineMs)
+        if (diagnostic.kind === 'scan-timeout') return {kind: 'not-found', reason: 'scan-timeout'}
+        return diagnostic.kind === 'match'
+            ? {kind: 'not-found', reason: 'outside-recency-window', diagnosticSessionId: diagnostic.sessionId}
+            : {kind: 'not-found', reason: 'no-jsonl-matches'}
     }
-    return {kind: 'not-found', reason: 'marker-mismatch'}
+
+    const outcome: ScanOutcome = scanForSession(recent, request, deps, deadlineMs)
+    if (outcome.kind === 'scan-timeout') return {kind: 'not-found', reason: 'scan-timeout'}
+    return outcome.kind === 'match'
+        ? {kind: 'found', sessionId: outcome.sessionId, providerStorePath: outcome.path}
+        : {kind: 'not-found', reason: 'marker-mismatch'}
 }
 
 function listJsonlFilesRecursive(root: string): readonly string[] {

--- a/packages/systems/vt-daemon/src/agent-runtime/recovery/resolvers/resolveNativeSession.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/recovery/resolvers/resolveNativeSession.ts
@@ -12,6 +12,7 @@ import {
     type ResolveCodexResult,
     type CodexMissReason,
 } from './resolveCodexNativeSession'
+import {getRecoveryHorizonMs} from '../horizon'
 
 export type NativeSessionRequest = {
     readonly cliType: 'claude' | 'codex'
@@ -50,26 +51,33 @@ export type ResolveNativeSession = (request: NativeSessionRequest) => Promise<Na
  *
  * - `VOICETREE_CLAUDE_PROJECTS_DIR`  → defaults to `~/.claude/projects`
  * - `VOICETREE_CODEX_STATE_DB`       → defaults to `~/.codex/state_5.sqlite`
+ *
+ * The resolver recency window is the discovery horizon (`getRecoveryHorizonMs()`,
+ * default 7d, `VOICETREE_RECOVERY_HORIZON_DAYS`) — a single source of truth, so
+ * every row that discovery surfaces a Resume button for is actually resolvable.
  */
 export async function defaultResolveNativeSession(
     request: NativeSessionRequest,
 ): Promise<NativeSessionResult> {
+    const recencyWindowMs: number = getRecoveryHorizonMs()
     if (request.cliType === 'claude') {
         const root: string = process.env.VOICETREE_CLAUDE_PROJECTS_DIR
             ?? path.join(os.homedir(), '.claude', 'projects')
         const result: ResolveClaudeResult = await resolveClaudeNativeSession(
-            {terminalId: request.terminalId, projectRoot: request.projectRoot, taskNodePath: request.taskNodePath},
+            {terminalId: request.terminalId, projectRoot: request.projectRoot, taskNodePath: request.taskNodePath, recencyWindowMs},
             defaultResolveClaudeDeps(root),
         )
         if (result.kind === 'found') {
             return {kind: 'found', sessionId: result.sessionId, providerStorePath: result.providerStorePath}
         }
-        return {kind: 'not-found', reason: result.reason}
+        return result.diagnosticSessionId !== undefined
+            ? {kind: 'not-found', reason: result.reason, diagnosticSessionId: result.diagnosticSessionId}
+            : {kind: 'not-found', reason: result.reason}
     }
     const dbPath: string = process.env.VOICETREE_CODEX_STATE_DB
         ?? path.join(os.homedir(), '.codex', 'state_5.sqlite')
     const result: ResolveCodexResult = resolveCodexNativeSession(
-        {terminalId: request.terminalId, projectRoot: request.projectRoot, taskNodePath: request.taskNodePath},
+        {terminalId: request.terminalId, projectRoot: request.projectRoot, taskNodePath: request.taskNodePath, recencyWindowMs},
         defaultResolveCodexDeps(dbPath),
     )
     if (result.kind === 'found') {

--- a/packages/systems/vt-daemon/src/agent-runtime/recovery/resolvers/tests/resolveClaudeNativeSession.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/recovery/resolvers/tests/resolveClaudeNativeSession.test.ts
@@ -57,15 +57,35 @@ describe('resolveClaudeNativeSession', () => {
         expect(result).toEqual({kind: 'found', sessionId: 'sess-old', providerStorePath: '/x/old.jsonl'})
     })
 
-    it('returns no-jsonl-matches when all candidates are older than the recency window', async () => {
+    it('returns outside-recency-window with diagnosticSessionId when the only match is older than the window', async () => {
+        // Mirrors the Codex resolver's unwindowed 2nd pass: when nothing is in
+        // the window but an out-of-window transcript carries our markers, surface
+        // an actionable `outside-recency-window` miss carrying the session id so
+        // the UI can offer a copy-`claude --resume <id>` escape hatch.
         const result = await resolveClaudeNativeSession(
             {terminalId: TERMINAL, projectRoot: PROJECT, taskNodePath: TASK, recencyWindowMs: 60_000},
             makeDeps({
                 listProjectTranscripts: () => transcripts(['/x/stale.jsonl']),
                 fileModifiedAt: () => NOW - 3_600_000,  // 1 hour ago, outside 1-minute window
-                readJsonlLines: () => {
-                    throw new Error('should not read files outside window')
-                },
+                readJsonlLines: () => [markerRecord('sess-stale')],
+            }),
+        )
+        expect(result).toEqual({
+            kind: 'not-found',
+            reason: 'outside-recency-window',
+            diagnosticSessionId: 'sess-stale',
+        })
+    })
+
+    it('returns no-jsonl-matches when an out-of-window transcript exists but carries no markers', async () => {
+        const result = await resolveClaudeNativeSession(
+            {terminalId: TERMINAL, projectRoot: PROJECT, taskNodePath: TASK, recencyWindowMs: 60_000},
+            makeDeps({
+                listProjectTranscripts: () => transcripts(['/x/stale.jsonl']),
+                fileModifiedAt: () => NOW - 3_600_000,  // outside the window
+                readJsonlLines: () => [
+                    {sessionId: 'unrelated', message: {role: 'user', content: 'no markers here'}} as ClaudeTranscriptRecord,
+                ],
             }),
         )
         expect(result).toEqual({kind: 'not-found', reason: 'no-jsonl-matches'})

--- a/packages/systems/vt-daemon/src/agent-runtime/recovery/resolvers/tests/resolveNativeSession.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/recovery/resolvers/tests/resolveNativeSession.test.ts
@@ -1,0 +1,117 @@
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {DatabaseSync} from 'node:sqlite'
+import {mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync} from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import {defaultResolveNativeSession} from '../resolveNativeSession'
+
+/**
+ * End-to-end coverage for the native-session dispatcher against REAL on-disk
+ * fixtures (no resolver mocking). The point of these tests is B1: the resolver
+ * recency window must equal the 7-day discovery horizon, so a transcript/thread
+ * that died ~3 days ago (within 7d, beyond the old hardcoded 24h) still
+ * resolves on a Resume click instead of silently failing.
+ */
+
+const TERMINAL = 'BigHead'
+const PROJECT = '/project/root'
+const TASK = '/project/root/task.md'
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+const THREE_DAYS_MS = 3 * MS_PER_DAY
+
+const MARKER_BLOCK =
+    `VOICETREE_TERMINAL_ID = ${TERMINAL}\nVOICETREE_PROJECT_PATH = ${PROJECT}\nTASK_NODE_PATH = ${TASK}`
+
+const envSnapshot: Record<string, string | undefined> = {}
+const TOUCHED_ENV = [
+    'VOICETREE_CLAUDE_PROJECTS_DIR',
+    'VOICETREE_CODEX_STATE_DB',
+    'VOICETREE_RECOVERY_HORIZON_DAYS',
+] as const
+
+let tmpDir: string
+
+beforeEach(() => {
+    for (const key of TOUCHED_ENV) envSnapshot[key] = process.env[key]
+    // Pin the horizon to its 7-day default so the assertion does not depend on
+    // an ambient VOICETREE_RECOVERY_HORIZON_DAYS in the runner's environment.
+    process.env.VOICETREE_RECOVERY_HORIZON_DAYS = '7'
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'resolve-native-'))
+})
+
+afterEach(() => {
+    for (const key of TOUCHED_ENV) {
+        if (envSnapshot[key] === undefined) delete process.env[key]
+        else process.env[key] = envSnapshot[key]
+    }
+    rmSync(tmpDir, {recursive: true, force: true})
+})
+
+describe('defaultResolveNativeSession — recency window aligns with the 7-day horizon', () => {
+    it('resolves a Claude transcript whose pane died ~3 days ago (within 7d, beyond the old 24h)', async () => {
+        const projectsDir: string = path.join(tmpDir, 'claude-projects')
+        const encoded: string = path.join(projectsDir, 'encoded-project')
+        mkdirSync(encoded, {recursive: true})
+        const transcript: string = path.join(encoded, 'session-aged.jsonl')
+        const record = {
+            sessionId: 'claude-aged-session',
+            type: 'user',
+            message: {role: 'user', content: `task prompt\n${MARKER_BLOCK}`},
+        }
+        writeFileSync(transcript, `${JSON.stringify(record)}\n`, 'utf8')
+        const threeDaysAgoSec: number = (Date.now() - THREE_DAYS_MS) / 1000
+        utimesSync(transcript, threeDaysAgoSec, threeDaysAgoSec)
+        process.env.VOICETREE_CLAUDE_PROJECTS_DIR = projectsDir
+
+        const result = await defaultResolveNativeSession({
+            cliType: 'claude',
+            terminalId: TERMINAL,
+            projectRoot: PROJECT,
+            taskNodePath: TASK,
+        })
+
+        expect(result).toEqual({
+            kind: 'found',
+            sessionId: 'claude-aged-session',
+            providerStorePath: transcript,
+        })
+    })
+
+    it('resolves a Codex thread last updated ~3 days ago (within 7d, beyond the old 24h)', async () => {
+        const dbPath: string = path.join(tmpDir, 'state_5.sqlite')
+        const db = new DatabaseSync(dbPath)
+        db.exec(
+            'CREATE TABLE threads (id TEXT, first_user_message TEXT, cwd TEXT, ' +
+            'created_at_ms INTEGER, updated_at_ms INTEGER, rollout_path TEXT)',
+        )
+        const updatedAt: number = Date.now() - THREE_DAYS_MS
+        const insert = db.prepare(
+            'INSERT INTO threads (id, first_user_message, cwd, created_at_ms, updated_at_ms, rollout_path) ' +
+            'VALUES (?, ?, ?, ?, ?, ?)',
+        )
+        insert.run(
+            'codex-aged-thread',
+            `header\n${MARKER_BLOCK}`,
+            PROJECT,
+            updatedAt - 60_000,
+            updatedAt,
+            '/rollouts/aged.jsonl',
+        )
+        db.close()
+        process.env.VOICETREE_CODEX_STATE_DB = dbPath
+
+        const result = await defaultResolveNativeSession({
+            cliType: 'codex',
+            terminalId: TERMINAL,
+            projectRoot: PROJECT,
+            taskNodePath: TASK,
+        })
+
+        expect(result).toEqual({
+            kind: 'found',
+            sessionId: 'codex-aged-thread',
+            providerStorePath: '/rollouts/aged.jsonl',
+        })
+    })
+})


### PR DESCRIPTION
B1 — The resolver hardcoded a 24h recency window that was never reconciled
with the 7-day discovery horizon, so any agent whose pane died 1-7 days ago
showed a Resume button that silently failed on click. defaultResolveNativeSession
now threads getRecoveryHorizonMs() into both the Claude and Codex resolver
calls as recencyWindowMs — a single source of truth.

B2 — The Claude resolver lacked the unwindowed 2nd-pass + diagnosticSessionId
that Codex already had: it returned a misleading no-jsonl-matches with no
copy-`claude --resume <id>` escape hatch. It now mirrors Codex — when nothing
is in the window, a single unwindowed pass over the older transcripts yields an
outside-recency-window miss carrying diagnosticSessionId, bounded by the same
scan-timeout deadline. The renderer copy-command path was already CLI-agnostic,
so wiring the diagnostic through the dispatcher completes it.

TDD: added resolveNativeSession.test.ts (e2e through the dispatcher against real
on-disk Claude transcript + Codex sqlite fixtures aged ~3 days), corrected the
bug-enshrining "older than the recency window" case to assert the new
horizon-aligned behaviour, and added a Claude outside-recency-window parity case.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
