### PR TITLE
fix(daemon): arm the parent-pid watchdog by propagating VOICETREE_PARENT_PID into project VTD/graphd spawns

### DIFF
--- a/packages/libraries/daemon-lifecycle/src/__tests__/spawnDaemon.parentPid.test.ts
+++ b/packages/libraries/daemon-lifecycle/src/__tests__/spawnDaemon.parentPid.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Parent-pid watchdog arming: the child env built for a project daemon spawn
+ * must always carry `VOICETREE_PARENT_PID` so the daemon's (already-tested)
+ * parent-pid watchdog can arm and self-exit when the launching app dies.
+ *
+ * Two cases, black-boxed on the pure env builder:
+ *
+ *   1. ROOT (electron / CLI): the launcher's own env has no
+ *      VOICETREE_PARENT_PID, so the builder stamps the launcher's own pid —
+ *      the daemon's watchdog then points at the launcher.
+ *
+ *   2. PROPAGATION (VTD-spawns-graphd): the launcher (a VTD) already inherited
+ *      VOICETREE_PARENT_PID=<app pid> from the app that spawned it. The builder
+ *      must PROPAGATE that inherited value unchanged — NOT overwrite it with the
+ *      VTD's own pid — so graphd's watchdog points at the APP, not the VTD.
+ *      This preserves the BF-346 invariant: graphd outlives VTD restarts and
+ *      must only die when the app dies.
+ */
+
+import { describe, expect, test } from 'vitest'
+
+import { buildDaemonChildEnv } from '../spawnDaemon.ts'
+
+describe('buildDaemonChildEnv — parent-pid watchdog arming', () => {
+  test('ROOT case: stamps the launcher pid when no ancestor VOICETREE_PARENT_PID is present', () => {
+    const env = buildDaemonChildEnv({
+      env: { PATH: '/usr/bin' },
+      daemonKind: 'vtd',
+      caller: 'electron-main',
+      launcherPid: 4242,
+    })
+
+    expect(env.VOICETREE_PARENT_PID).toBe('4242')
+  })
+
+  test('PROPAGATION invariant: keeps the inherited VOICETREE_PARENT_PID, never overwrites with the launcher pid', () => {
+    const env = buildDaemonChildEnv({
+      // A VTD process carries the app pid it inherited at its own spawn.
+      env: { PATH: '/usr/bin', VOICETREE_PARENT_PID: '9999' },
+      daemonKind: 'graphd',
+      caller: 'vtd',
+      launcherPid: 4242,
+    })
+
+    // graphd points at the app (9999), NOT the spawning VTD (4242).
+    expect(env.VOICETREE_PARENT_PID).toBe('9999')
+  })
+
+  test('still threads the daemon-kind caller env var alongside the parent pid', () => {
+    const graphd = buildDaemonChildEnv({
+      env: {},
+      daemonKind: 'graphd',
+      caller: 'electron-main',
+      launcherPid: 7,
+    })
+    const vtd = buildDaemonChildEnv({
+      env: {},
+      daemonKind: 'vtd',
+      caller: 'cli',
+      launcherPid: 7,
+    })
+
+    expect(graphd.VT_GRAPHD_CALLER_KIND).toBe('electron-main')
+    expect(vtd.VT_DAEMON_CALLER_KIND).toBe('cli')
+  })
+
+  test('preserves the rest of the launcher env (full pass-through for OTLP etc.)', () => {
+    const env = buildDaemonChildEnv({
+      env: { PATH: '/usr/bin', VOICETREE_OTLP_ENDPOINT: 'http://127.0.0.1:4318' },
+      daemonKind: 'graphd',
+      caller: 'electron-main',
+      launcherPid: 1,
+    })
+
+    expect(env.PATH).toBe('/usr/bin')
+    expect(env.VOICETREE_OTLP_ENDPOINT).toBe('http://127.0.0.1:4318')
+  })
+})

--- a/packages/libraries/daemon-lifecycle/src/index.ts
+++ b/packages/libraries/daemon-lifecycle/src/index.ts
@@ -92,8 +92,9 @@ export type { ProbeHealthOptions } from './healthIdentityProbe.ts'
 
 // Generic detached spawn (no client class — that stays in graph-db-client
 // / vt-daemon-client).
-export { spawnDaemon } from './spawnDaemon.ts'
+export { buildDaemonChildEnv, spawnDaemon } from './spawnDaemon.ts'
 export type {
+  DaemonChildEnvInput,
   SpawnDaemonInput,
   SpawnedDaemonHandle,
   SpawnEnvVarShape,

--- a/packages/libraries/daemon-lifecycle/src/spawnDaemon.ts
+++ b/packages/libraries/daemon-lifecycle/src/spawnDaemon.ts
@@ -21,6 +21,22 @@
  * `daemonKind` selects which env-var name the caller kind is propagated
  * through, so a single bin can introspect "who launched me?" without
  * sharing an env-var with the other daemon kind.
+ *
+ * `launcherPid` arms the daemon's parent-pid watchdog (vtd.ts / vt-graphd.ts
+ * / parent_pid_watchdog.py): the child env always carries
+ * `VOICETREE_PARENT_PID`, so an orphaned daemon self-exits when the app dies
+ * instead of leaking until reboot. The value PROPAGATES — if the launcher
+ * already inherited a `VOICETREE_PARENT_PID` it is kept verbatim, otherwise
+ * the launcher's own pid is stamped:
+ *
+ *   - app -> VTD: app has no ancestor var → stamps the app pid; VTD's
+ *     watchdog points at the app. ✓
+ *   - VTD -> graphd: the VTD inherited `VOICETREE_PARENT_PID=<app pid>` →
+ *     PROPAGATES it; graphd points at the APP, not the VTD. This preserves
+ *     the BF-346 invariant (graphd is a sibling that outlives VTD restarts —
+ *     it must only die when the app dies). Stamping the VTD's own pid here
+ *     would tie graphd's life to the spawning VTD and break that. ✓
+ *   - CLI -> VTD: stamps the CLI pid; the daemon dies with the CLI. ✓
  */
 
 import { spawn, type ChildProcess } from 'node:child_process'
@@ -35,6 +51,13 @@ export type SpawnDaemonInput = {
   readonly args: readonly string[]
   readonly env: SpawnEnvVarShape
   readonly caller: CallerKind
+  /**
+   * The launching process's pid, threaded in from the shell boundary (the
+   * spawn coordinator reads `process.pid`). Used as the fallback
+   * `VOICETREE_PARENT_PID` when the launcher's env carries no inherited
+   * value — see {@link buildDaemonChildEnv}.
+   */
+  readonly launcherPid: number
   /**
    * Optional path the daemon's stdout and stderr are appended to. When
    * omitted, both streams are discarded — preserves the original silent
@@ -56,16 +79,12 @@ export type SpawnedDaemonHandle = {
 // gate flags any `process.*` read in a function body, so callers thread
 // the env in from the shell boundary.
 export function spawnDaemon(input: SpawnDaemonInput): SpawnedDaemonHandle {
-  const callerEnvName = envVarNameFor(input.daemonKind)
   const stdio: ('ignore' | number)[] = input.logPath
     ? ['ignore', openSync(input.logPath, 'a'), openSync(input.logPath, 'a')]
     : ['ignore', 'ignore', 'ignore']
   const child = spawn(input.cmd, [...input.args], {
     detached: true,
-    env: {
-      ...input.env,
-      [callerEnvName]: input.caller,
-    },
+    env: buildDaemonChildEnv(input),
     stdio,
   })
   child.unref()
@@ -74,6 +93,27 @@ export function spawnDaemon(input: SpawnDaemonInput): SpawnedDaemonHandle {
     // is the right boundary: we want one launch-failure shape, not two.
   })
   return { pid: child.pid ?? null, process: child }
+}
+
+export type DaemonChildEnvInput = {
+  readonly env: SpawnEnvVarShape
+  readonly daemonKind: DaemonKind
+  readonly caller: CallerKind
+  readonly launcherPid: number
+}
+
+/**
+ * Build the child environment for a daemon spawn: the launcher's env plus the
+ * daemon-kind caller var and the propagated `VOICETREE_PARENT_PID`. Pure —
+ * the impure `process.pid` read is the caller's; the value is threaded in as
+ * `launcherPid`. See {@link spawnDaemon} for the propagation rationale.
+ */
+export function buildDaemonChildEnv(input: DaemonChildEnvInput): NodeJS.ProcessEnv {
+  return {
+    ...input.env,
+    [envVarNameFor(input.daemonKind)]: input.caller,
+    VOICETREE_PARENT_PID: input.env.VOICETREE_PARENT_PID ?? String(input.launcherPid),
+  }
 }
 
 function envVarNameFor(daemonKind: DaemonKind): 'VT_GRAPHD_CALLER_KIND' | 'VT_DAEMON_CALLER_KIND' {

--- a/packages/systems/graph-db-client/src/autoLaunch/spawnCoordinator.ts
+++ b/packages/systems/graph-db-client/src/autoLaunch/spawnCoordinator.ts
@@ -183,6 +183,11 @@ export async function attemptSpawnAndWait<TClient>(
       args: command.args,
       env: command.env,
       caller,
+      // Arms the daemon's parent-pid watchdog. `process.pid` is this
+      // launcher (electron-main, the CLI, or a VTD spawning graphd);
+      // buildDaemonChildEnv propagates an inherited VOICETREE_PARENT_PID
+      // over this fallback so a VTD-spawned graphd still points at the app.
+      launcherPid: process.pid,
       logPath: daemonLogPath(canonicalProject, options.daemonKind),
     })
     emitOwnerDiagnostic({


### PR DESCRIPTION
The project-scoped VTD spawn (and graphd, which VTD spawns) never injected
VOICETREE_PARENT_PID into the child env, so the daemons' parent-pid watchdogs
(vtd.ts, vt-graphd.ts, parent_pid_watchdog.py) could never arm. Every project
opened leaked a VTD + graphd that survived app quit AND crash, holding loopback
HTTP + OTLP ports until reboot.

Inject once at the single shared spawn seam — spawnDaemon, the sole spawn
primitive both the vtd and graphd project ensure-paths flow through. A new pure
buildDaemonChildEnv stamps VOICETREE_PARENT_PID with the PROPAGATION pattern:
keep an inherited value, else fall back to the launcher's own pid (threaded in
as launcherPid from the coordinator's process.pid, keeping the read at the edge).

This preserves the BF-346 invariant: a VTD inherited VOICETREE_PARENT_PID=<app
pid>, so it propagates the app pid to graphd — graphd points at the app, not at
the spawning VTD, and survives VTD restarts. electron/CLI roots have no ancestor
var, so they stamp their own pid and the daemon dies with them.

Black-box tested on the pure env builder: root-case stamping and the
propagation invariant (inherited value never overwritten with launcherPid).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
