### PR TITLE
feat(packaging): make vt-graphd launchable in the packaged app — entrypoint + runtime wiring (B1 + B2 wiring)

### DIFF
--- a/packages/systems/graph-db-server/build.mjs
+++ b/packages/systems/graph-db-server/build.mjs
@@ -1,57 +1,85 @@
 import * as esbuild from 'esbuild'
 import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, '../../..')
 const perfProbePath = resolve(repoRoot, 'packages/libraries/perf-analysis/src/perf-probe.mjs')
 
-await esbuild.build({
-  entryPoints: ['bin/vt-graphd.ts'],
-  outfile: 'dist/vt-graphd.mjs',
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  target: 'node22',
-  external: [
-    'fsevents',
-    'chokidar',
-    // @vscode/ripgrep uses __dirname to locate its native binary, which
-    // breaks when bundled into ESM. Keep it external so it resolves at runtime.
-    '@vscode/ripgrep',
-    // @pyroscope/nodejs loads @datadog/pprof native bindings via __dirname.
-    // Bundling it into ESM breaks that lookup; leave the package boundary
-    // intact so Node's CommonJS loader provides the expected runtime globals.
-    '@pyroscope/nodejs',
-  ],
-  plugins: [
-    {
-      name: 'workspace-perf-analysis',
-      setup(build) {
-        build.onResolve({ filter: /^@vt\/perf-analysis\/perf-probe$/ }, () => ({
-          path: perfProbePath,
-        }))
-      },
-    },
-  ],
-  banner: {
-    js: [
-      // gray-matter and other CJS deps use require() for Node built-ins.
-      // esbuild's ESM __require shim throws for those. Provide a real require
-      // via createRequire so bundled CJS code works in ESM output.
-      'import { createRequire as __bundleCreateRequire } from "node:module";',
-      'const require = __bundleCreateRequire(import.meta.url);',
-    ].join('\n'),
-  },
-})
+const DEFAULT_OUTFILE = resolve(__dirname, 'dist/vt-graphd.mjs')
 
-// esbuild preserves the original source shebang (#!/usr/bin/env -S node --import tsx).
-// Replace it with a clean shebang for the compiled bundle.
-const outPath = 'dist/vt-graphd.mjs'
-const src = await readFile(outPath, 'utf8')
-const lines = src.split('\n')
-while (lines.length > 0 && lines[0].startsWith('#!')) {
-  lines.shift()
+/**
+ * Bundle `bin/vt-graphd.ts` into a single self-contained ESM file runnable by a
+ * standalone Node ≥22 (`node:sqlite`). The entrypoint is the daemon the Electron
+ * app and the published CLI both spawn.
+ *
+ * `outfile` lets callers redirect the bundle — the Electron build emits it into
+ * `webapp/dist-electron/main/vt-graphd.mjs` so the runtime resolver's sibling
+ * lookup finds it in the packaged app (see graph-db-client autoLaunch/runtime).
+ * All input paths are resolved from this module's directory, so the bundle is
+ * identical regardless of the caller's cwd.
+ */
+export async function bundleVtGraphd({ outfile = DEFAULT_OUTFILE } = {}) {
+  const resolvedOutfile = resolve(outfile)
+
+  await esbuild.build({
+    absWorkingDir: __dirname,
+    entryPoints: [resolve(__dirname, 'bin/vt-graphd.ts')],
+    outfile: resolvedOutfile,
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node22',
+    external: [
+      'fsevents',
+      'chokidar',
+      // @vscode/ripgrep uses __dirname to locate its native binary, which
+      // breaks when bundled into ESM. Keep it external so it resolves at runtime.
+      '@vscode/ripgrep',
+      // @pyroscope/nodejs loads @datadog/pprof native bindings via __dirname.
+      // Bundling it into ESM breaks that lookup; leave the package boundary
+      // intact so Node's CommonJS loader provides the expected runtime globals.
+      '@pyroscope/nodejs',
+    ],
+    plugins: [
+      {
+        name: 'workspace-perf-analysis',
+        setup(build) {
+          build.onResolve({ filter: /^@vt\/perf-analysis\/perf-probe$/ }, () => ({
+            path: perfProbePath,
+          }))
+        },
+      },
+    ],
+    banner: {
+      js: [
+        // gray-matter and other CJS deps use require() for Node built-ins.
+        // esbuild's ESM __require shim throws for those. Provide a real require
+        // via createRequire so bundled CJS code works in ESM output.
+        'import { createRequire as __bundleCreateRequire } from "node:module";',
+        'const require = __bundleCreateRequire(import.meta.url);',
+      ].join('\n'),
+    },
+  })
+
+  // esbuild preserves the original source shebang (#!/usr/bin/env -S node --import tsx).
+  // Replace it with a clean shebang for the compiled bundle.
+  const src = await readFile(resolvedOutfile, 'utf8')
+  const lines = src.split('\n')
+  while (lines.length > 0 && lines[0].startsWith('#!')) {
+    lines.shift()
+  }
+  await writeFile(resolvedOutfile, '#!/usr/bin/env node\n' + lines.join('\n'))
+
+  return resolvedOutfile
 }
-await writeFile(outPath, '#!/usr/bin/env node\n' + lines.join('\n'))
+
+// CLI entrypoint: `node build.mjs [outfile]` (used by `npm run build`).
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+if (invokedDirectly) {
+  const outfileArg = process.argv[2]
+  await bundleVtGraphd(outfileArg ? { outfile: outfileArg } : {})
+}

--- a/packages/systems/graph-db-server/tests/bundle-boot.test.ts
+++ b/packages/systems/graph-db-server/tests/bundle-boot.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { spawn, type ChildProcessByStdio } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import type { Readable } from 'node:stream'
+import { fileURLToPath } from 'node:url'
+// @ts-expect-error — build.mjs is a plain ESM script with no type declarations.
+import { bundleVtGraphd } from '../build.mjs'
+import { CONTRACT_VERSION, HealthResponseSchema } from '@vt/graph-db-server/contract'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// `spawn(..., { stdio: ['ignore', 'pipe', 'pipe'] })` — stdin ignored, stdout/stderr piped.
+type DaemonChild = ChildProcessByStdio<null, Readable, Readable>
+
+// The single most valuable B1 guard: prove the esbuild bundle that ships in the
+// packaged app actually BOOTS under a standalone Node — node:sqlite loads, the
+// watch-folder (chokidar, kept external) resolves, the server binds a port, and
+// /health answers with the contract version. A bundling regression (a wrongly
+// inlined native dep, a broken shebang/banner, a missing external) fails here
+// without needing a real Electron package.
+//
+// The bundle is emitted into the package's own dist/ — the SAME resolution depth
+// as the production bundle — so Node finds graph-db-server's node_modules for the
+// runtime externals exactly as it does in the published CLI layout.
+describe('vt-graphd bundle boots', () => {
+  const outfile = resolve(__dirname, '..', 'dist', `vt-graphd.boot-test.${process.pid}.mjs`)
+  let project: string
+
+  beforeAll(async () => {
+    await bundleVtGraphd({ outfile })
+    project = await mkdtemp(join(tmpdir(), 'vt-graphd-boot-'))
+  }, 60_000)
+
+  afterAll(async () => {
+    await rm(outfile, { force: true })
+    await rm(project, { force: true, recursive: true })
+  })
+
+  test('the bundled entrypoint serves /health with the contract version', async () => {
+    const child = spawn(process.execPath, [outfile, '--project-root', project], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    try {
+      const port = await waitForListeningPort(child)
+      const res = await fetch(`http://127.0.0.1:${port}/health`)
+      expect(res.status).toBe(200)
+      const body = HealthResponseSchema.parse(await res.json())
+      expect(body.version).toBe(CONTRACT_VERSION)
+      expect(body.project).toBe(project)
+    } finally {
+      await stopChild(child)
+    }
+  }, 30_000)
+})
+
+/**
+ * Resolve the port the daemon prints once it is fully up
+ * (`vt-graphd: listening on http://127.0.0.1:<port> ...`), or reject if the
+ * process dies / never announces within the timeout. stderr is captured so a
+ * boot failure surfaces as the rejection reason instead of an opaque timeout.
+ */
+function waitForListeningPort(child: DaemonChild): Promise<number> {
+  return new Promise<number>((resolvePort, reject) => {
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => {
+      reject(new Error(`vt-graphd did not announce a port within 15s. stderr:\n${stderr}`))
+    }, 15_000)
+    timer.unref()
+
+    const settle = (fn: () => void): void => {
+      clearTimeout(timer)
+      child.stdout.removeAllListeners('data')
+      child.stderr.removeAllListeners('data')
+      child.removeAllListeners('exit')
+      fn()
+    }
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+      const match = /listening on http:\/\/127\.0\.0\.1:(\d+)/.exec(stdout)
+      if (match) settle(() => resolvePort(Number.parseInt(match[1], 10)))
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+    child.on('exit', (code) => {
+      settle(() => reject(new Error(`vt-graphd exited (code ${code}) before listening. stderr:\n${stderr}`)))
+    })
+  })
+}
+
+function stopChild(child: DaemonChild): Promise<void> {
+  return new Promise<void>((resolveStop) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolveStop()
+      return
+    }
+    child.once('exit', () => resolveStop())
+    child.kill('SIGTERM')
+  })
+}

--- a/webapp/electron.vite.config.ts
+++ b/webapp/electron.vite.config.ts
@@ -46,7 +46,6 @@ export default defineConfig({
     },
     build: {
       outDir: 'dist-electron/main',
-      logLevel: 'error',
       externalizeDeps: { exclude: ELECTRON_VITE_EXTERNALIZE_EXCLUDE },
       rolldownOptions: {
         input: {
@@ -73,7 +72,6 @@ export default defineConfig({
     },
     build: {
       outDir: 'dist-electron/preload',
-      logLevel: 'error',
       externalizeDeps: { exclude: ELECTRON_VITE_EXTERNALIZE_EXCLUDE },
       rolldownOptions: {
         input: {
@@ -129,7 +127,6 @@ export default defineConfig({
     build: {
       outDir: 'dist',
       target: 'esnext',
-      logLevel: 'error',
       rolldownOptions: {
         input: {
           main: path.resolve(webappDir, 'index.html')

--- a/webapp/electron.vite.config.ts
+++ b/webapp/electron.vite.config.ts
@@ -12,6 +12,7 @@ import {
   externalNativePlugin,
 } from './electron.vite.config/externals'
 import {
+  bundleGraphdEntrypointPlugin,
   graphStateFixtureFilenameShimPlugin,
   litCssPlugin,
   mainCommonjsPackageBoundaryPlugin,
@@ -37,6 +38,7 @@ export default defineConfig({
       mainCommonjsPackageBoundaryPlugin,
       externalNativePlugin,
       externalMainDepsPlugin,
+      bundleGraphdEntrypointPlugin(webappDir),
     ],
     logLevel: 'error',
     resolve: {

--- a/webapp/electron.vite.config/plugins.ts
+++ b/webapp/electron.vite.config/plugins.ts
@@ -1,4 +1,34 @@
 import type { Plugin } from 'vite'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+/**
+ * Emit the standalone `vt-graphd.mjs` entrypoint next to the main bundle.
+ *
+ * graphd is spawned as a SEPARATE Node ≥22 process (it needs node:sqlite and must
+ * not run on Electron's node — see architecture.md). The runtime resolver
+ * (graph-db-client autoLaunch/runtime) locates the entrypoint via a sibling lookup
+ * relative to its own `import.meta.url`; because graph-db-client is bundled INLINE
+ * into electron-main, that resolves to `dist-electron/main/vt-graphd.mjs`. Nothing
+ * else writes that file, so the packaged app would have no entrypoint to spawn.
+ *
+ * Running graph-db-server's own esbuild bundler on `closeBundle` of the main build
+ * keeps the entrypoint regenerated on every `electron-vite build`, in lockstep with
+ * the inlined resolver. The file must also be listed in `build.asarUnpack`
+ * (webapp/package.json) so the standalone node can read it from app.asar.unpacked.
+ */
+export function bundleGraphdEntrypointPlugin(webappDir: string): Plugin {
+  const buildScript = resolve(webappDir, '..', 'packages/systems/graph-db-server/build.mjs')
+  const outfile = resolve(webappDir, 'dist-electron/main/vt-graphd.mjs')
+  return {
+    name: 'bundle-graphd-entrypoint',
+    apply: 'build' as const,
+    async closeBundle() {
+      const { bundleVtGraphd } = await import(pathToFileURL(buildScript).href)
+      await bundleVtGraphd({ outfile })
+    },
+  }
+}
 
 export const graphStateFixtureFilenameShimPlugin = {
   name: 'graph-state-fixture-filename-shim',

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -192,7 +192,8 @@
     "afterPack": "./scripts/after-pack.cjs",
     "asarUnpack": [
       "node_modules/@vscode/ripgrep/bin/**/*",
-      "node_modules/node-pty/**/*"
+      "node_modules/node-pty/**/*",
+      "dist-electron/main/vt-graphd.mjs"
     ],
     "files": [
       "dist/**/*",

--- a/webapp/src/graphd-entrypoint-inlining.test.ts
+++ b/webapp/src/graphd-entrypoint-inlining.test.ts
@@ -1,0 +1,38 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+import {
+  ELECTRON_VITE_EXTERNALIZE_EXCLUDE,
+  MAIN_RUNTIME_EXTERNALS,
+} from '../electron.vite.config/externals'
+
+const require = createRequire(import.meta.url)
+const webappPkg = require('../package.json') as {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+const PKG = '@vt/graph-db-client'
+
+// Ratchet for the B1 entrypoint mechanism. graph-db-client's runtime resolver
+// locates the spawned `vt-graphd.mjs` via a sibling lookup relative to its OWN
+// `import.meta.url`. That resolves to `dist-electron/main/vt-graphd.mjs` (where
+// bundleGraphdEntrypointPlugin emits it) ONLY because graph-db-client is bundled
+// INLINE into electron-main — so its `import.meta.url` points at the main bundle.
+// Externalizing it would move that URL into node_modules and silently break the
+// packaged app's ability to find graphd. This test pins the two ways it could be
+// externalized: a rolldown `external` entry, or being promoted to a production
+// `dependency` (which electron-vite's externalizeDepsPlugin externalizes unless
+// it is also in the exclude list).
+describe('graphd entrypoint resolution invariant: graph-db-client stays inlined', () => {
+  it('is not a rolldown main-runtime external', () => {
+    expect(MAIN_RUNTIME_EXTERNALS).not.toContain(PKG)
+  })
+
+  it('is not externalized by externalizeDepsPlugin (dev-dep, or excluded if promoted)', () => {
+    const isProdDependency = webappPkg.dependencies?.[PKG] !== undefined
+    const isExcludedFromExternalizing = ELECTRON_VITE_EXTERNALIZE_EXCLUDE.includes(PKG)
+    // Inlined when it is NOT a production dependency, or — if it ever becomes one —
+    // it is force-excluded from externalizing. Either keeps it in the bundle.
+    expect(!isProdDependency || isExcludedFromExternalizing).toBe(true)
+  })
+})

--- a/webapp/src/shell/edge/main/runtime/electron/app/build-config.test.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/app/build-config.test.ts
@@ -77,6 +77,13 @@ describe('build-config', () => {
 
       expect(config.shouldCopyTools).toBe(true);
     });
+
+    it('should not pin a graphd node binary in development', () => {
+      const config: BuildConfig = getBuildConfig();
+
+      // Dev runs graphd from source via the dev `node` on PATH; nothing to pin.
+      expect(config.graphdNodeBinaryPath).toBeNull();
+    });
   });
 
   describe('getBuildConfig - Production Mode (Unpackaged)', () => {
@@ -102,6 +109,13 @@ describe('build-config', () => {
       expect(config.pythonCwd).toBe(repoRoot);
       expect(config.shouldCompilePython).toBe(true);
       expect(config.serverBinaryPath).toBe(expectedBinaryPath);
+    });
+
+    it('should not pin a graphd node binary when unpackaged', () => {
+      const config: BuildConfig = getBuildConfig();
+
+      // No bundled node ships in an unpackaged prod build; resolver uses PATH node.
+      expect(config.graphdNodeBinaryPath).toBeNull();
     });
   });
 
@@ -132,6 +146,13 @@ describe('build-config', () => {
       const expectedBinaryPath: string = path.join(mockResourcesPath, 'server', 'voicetree-server');
       expect(config.serverBinaryPath).toBe(expectedBinaryPath);
       expect(config.pythonCommand).toBe(expectedBinaryPath);
+    });
+
+    it('should pin the bundled graphd node binary under Resources/node', () => {
+      const config: BuildConfig = getBuildConfig();
+
+      // win32 is out of scope; on this CI (darwin/linux) the binary is `node`.
+      expect(config.graphdNodeBinaryPath).toBe(path.join(mockResourcesPath, 'node', 'node'));
     });
   });
 

--- a/webapp/src/shell/edge/main/runtime/electron/app/build-config.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/app/build-config.ts
@@ -51,6 +51,14 @@ export type BuildConfig = {
 
   // Server binary absolutePath (production only)
   readonly serverBinaryPath: string | null;
+
+  // Absolute path to the bundled standalone Node ≥22 used to host vt-graphd, or
+  // null when this build ships none. graphd needs node:sqlite (Node ≥22) and must
+  // NOT run on Electron's own node (architecture.md), so the packaged app carries
+  // its own node binary under Resources/node/. Null in dev and unpackaged builds:
+  // the runtime resolver then falls back to a `node` on PATH. main.ts exports this
+  // as VT_GRAPHD_NODE_BIN so graph-db-client's resolver selects it first.
+  readonly graphdNodeBinaryPath: string | null;
 };
 
 // ============================================================================
@@ -105,6 +113,8 @@ function getBuildConfigDev(commonEnv: CommonEnv): BuildConfig {
     pythonCwd: rootDir,
     shouldCompilePython: false,
     serverBinaryPath: null,
+    // Dev runs graphd from source via the dev `node` on PATH (already ≥22).
+    graphdNodeBinaryPath: null,
 
     // Tools: Copy from repo source
     toolsSource: path.join(rootDir, 'tools'),
@@ -136,6 +146,14 @@ function getBuildConfigProd(commonEnv: CommonEnv): BuildConfig {
   const serverBinaryPath: string = commonEnv.isPackaged
     ? path.join(process.resourcesPath, 'server', serverBinaryName)
     : path.join(rootDir, 'out', 'resources', 'server', serverBinaryName);
+
+  // Standalone Node ≥22 to host vt-graphd. Only the packaged app ships one
+  // (under Resources/node/, placed there by extraResources + after-pack); an
+  // unpackaged prod build has none, so graphd resolves a `node` from PATH.
+  const nodeBinaryName: string = process.platform === 'win32' ? 'node.exe' : 'node';
+  const graphdNodeBinaryPath: string | null = commonEnv.isPackaged
+    ? path.join(process.resourcesPath, 'node', nodeBinaryName)
+    : null;
 
   // Tools source depends on packaging state
   const toolsSource: string = commonEnv.isPackaged
@@ -169,6 +187,7 @@ function getBuildConfigProd(commonEnv: CommonEnv): BuildConfig {
     pythonCwd: rootDir,
     shouldCompilePython: true,
     serverBinaryPath,
+    graphdNodeBinaryPath,
 
     // Tools: Copy from packaged resources or build output
     toolsSource,

--- a/webapp/src/shell/edge/main/runtime/electron/app/main.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/app/main.ts
@@ -114,6 +114,17 @@ if (electronVtBinDir !== null) {
     process.env.PATH = `${electronVtBinDir}${path.delimiter}${process.env.PATH ?? ''}`;
 }
 
+// Point graphd's runtime resolver at the bundled standalone Node ≥22 in packaged
+// builds. graphd needs node:sqlite and must not run on Electron's node
+// (architecture.md); the packaged app ships its own node under Resources/node/.
+// build-config returns null in dev/unpackaged, where the resolver falls back to a
+// `node` on PATH. The spawned graphd inherits this via the launcher env. An
+// explicit override (set by a launcher/test) wins, so we only fill the gap.
+const graphdNodeBinaryPath: string | null = getBuildConfig().graphdNodeBinaryPath;
+if (graphdNodeBinaryPath !== null && process.env.VT_GRAPHD_NODE_BIN === undefined) {
+    process.env.VT_GRAPHD_NODE_BIN = graphdNodeBinaryPath;
+}
+
 configureEnvironment();
 // Pin the VoiceTree home before tracing so it (and the daemon/CLI it spawns)
 // share one settings root. The OTLP gRPC exporter only attaches when


### PR DESCRIPTION
## What & why

The packaged Electron app spawns **vt-graphd** (the graph DB server) as a separate Node ≥22 process, but the build never bundled its entrypoint and never told the app which Node to run it on — so in a packaged `.dmg`/AppImage graphd cannot launch (graph features break). This is the **verifiable half** of fixing that (plan "B"); the release-engineering half (shipping a standalone Node 22 + ripgrep + mac signing) follows in a separate PR.

## Commits (each atomic, tested)

1. **`refactor(graph-db-server)`** — export `bundleVtGraphd({outfile})` from `build.mjs` so the Electron build can reuse the daemon bundler. Inputs resolve from the module dir, so the bundle is cwd-independent. CLI (`npm run build`) unchanged.
2. **`feat(packaging)` — B1** — an electron-vite main-build plugin emits `dist-electron/main/vt-graphd.mjs` on every build (in lockstep with the inlined resolver's `import.meta.url`, verified against the compiled bundle), and it's `asarUnpack`'d so a standalone node can read it from `app.asar.unpacked`.
3. **`feat(packaging)` — B2 wiring** — `build-config` gains `graphdNodeBinaryPath` (packaged → `Resources/node/node`, null in dev/unpackaged); `main.ts` exports it as `VT_GRAPHD_NODE_BIN` before the prewarm so the resolver selects the bundled node first. Dev/unpackaged unchanged (falls back to a `node` on PATH).
4. **`fix(electron-vite)`** — drop invalid `build`-level `logLevel` (3 pre-existing latent TS2769 errors surfaced when this branch first edited the config; each section already has a valid top-level `logLevel`, so the change is inert at runtime).

## Verification

- **Boot smoke test** (new): bundles `vt-graphd.mjs` and proves it **boots** under real Node 22 — `node:sqlite` loads, server binds, `/health` returns the contract version. Catches bundling regressions without packaging.
- **build-config tests** (new cases): node binary pinned only when packaged; null otherwise.
- **Inlining ratchet** (new): graph-db-client must stay bundled inline (the sibling-path resolution depends on it).
- Existing resolver tests (12/12) green; webapp `tsc --noEmit` clean; real `electron-vite build` emits a valid entrypoint.

## Deliberately NOT here — the release half (separate PR)

Shipping the standalone Node 22 (per-arch download + `extraResources` + `after-pack` swap + mac code-signing) and ripgrep placement. That's release-pipeline work only verifiable on a real packaged build, so it's kept out of this proven, CI-verifiable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)