### PR TITLE
feat(packaging): ship a standalone Node 22 so graphd/vtd run in the packaged app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,9 @@ jobs:
         run: |
           npx electron-vite build
           npm run stage:daemons
+          # Bundle the standalone Node ≥22 that hosts vtd/vt-graphd (Resources/node/node).
+          # --arch is authoritative (the matrix target), not the runner's reported arch.
+          npm run stage:node -- --arch ${{ matrix.arch }}
           # Notarization talks to Apple's live notary service and needs an in-effect
           # Developer Program agreement; it is irrelevant to build correctness. Skip it on
           # dry-runs (publish=false) so they validate build+sign+package without the Apple
@@ -353,6 +356,11 @@ jobs:
           }
           npm run stage:daemons
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          # Bundle the standalone Node ≥22 host (Resources/node/node.exe). Windows is
+          # out of scope for the app, but the node extraResource is shared, so stage it
+          # to keep the build green.
+          npm run stage:node -- --arch x64
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           npx electron-builder --win --publish=${{ (github.event_name == 'push' || inputs.publish) && 'always' || 'never' }} -c.electronVersion="$(node -p 'require("electron/package.json").version')"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -437,6 +445,8 @@ jobs:
         run: |
           npx electron-vite build
           npm run stage:daemons
+          # Bundle the standalone Node ≥22 that hosts vtd/vt-graphd (resources/node/node).
+          npm run stage:node -- --arch ${{ matrix.arch }}
           npx electron-builder --linux --${{ matrix.arch }} --publish=${{ (github.event_name == 'push' || inputs.publish) && 'always' || 'never' }} -c.electronVersion="$(node -p 'require("electron/package.json").version')"
 
       # Backward-compat alias: keep `voicetree.AppImage` (no arch suffix)

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -49,9 +49,10 @@
     "electron:persist-state": "VOICETREE_PERSIST_STATE=1 electron-vite build && VOICETREE_PERSIST_STATE=1 electron .",
     "electron:build": "electron-vite build",
     "stage:daemons": "node scripts/stage-daemon-bundles.mjs",
-    "electron:pack": "electron-vite build && npm run stage:daemons && electron-builder",
-    "electron:dist": "export CSC_IDENTITY_AUTO_DISCOVERY=false && electron-vite build && npm run stage:daemons && electron-builder --mac --config -c.mac.identity=null --publish=never",
-    "electron:dist-and-publish": "export $(cat .env | grep -v '^#' | xargs) && electron-vite build && npm run stage:daemons && electron-builder --mac --publish=always",
+    "stage:node": "node scripts/stage-node-runtime.mjs",
+    "electron:pack": "electron-vite build && npm run stage:daemons && npm run stage:node && electron-builder",
+    "electron:dist": "export CSC_IDENTITY_AUTO_DISCOVERY=false && electron-vite build && npm run stage:daemons && npm run stage:node && electron-builder --mac --config -c.mac.identity=null --publish=never",
+    "electron:dist-and-publish": "export $(cat .env | grep -v '^#' | xargs) && electron-vite build && npm run stage:daemons && npm run stage:node && electron-builder --mac --publish=always",
     "setup-cli": "bash scripts/setup-cli.sh"
   },
   "optionalDependencies": {
@@ -209,6 +210,10 @@
       {
         "from": "../out/resources/server",
         "to": "server"
+      },
+      {
+        "from": "../out/resources/node",
+        "to": "node"
       },
       {
         "from": "../out/resources/tools",

--- a/webapp/scripts/stage-node-runtime.mjs
+++ b/webapp/scripts/stage-node-runtime.mjs
@@ -1,0 +1,161 @@
+/**
+ * Stage a standalone Node runtime into the Electron resources so it ships inside
+ * the packaged app.
+ *
+ * The packaged app spawns two Node daemons (vtd + its vt-graphd sibling) as
+ * separate child processes. They need `node:sqlite` (Node ≥22) and must NOT run
+ * on the Electron binary (its node ABI can't host node:sqlite — see
+ * @vt/graph-db-client resolveDaemonRuntimeCommand, which deliberately excludes
+ * the Electron binary). A normal user's machine may have no `node` on PATH, so
+ * the app carries its own. main.ts points VT_GRAPHD_NODE_BIN at it
+ * (Resources/node/node); the resolver — shared by graphd AND vtd — selects it.
+ *
+ * This downloads the official nodejs.org build for the target platform/arch,
+ * verifies it against the published SHASUMS256.txt, extracts just `bin/node`,
+ * and (when the target is the host arch) runs a node:sqlite probe so a bad pin
+ * fails the build LOUDLY rather than shipping a daemon that can't open its DB.
+ *
+ * Usage:
+ *   node scripts/stage-node-runtime.mjs                 # host platform/arch → out/resources/node
+ *   node scripts/stage-node-runtime.mjs --dest <dir>    # custom destination dir
+ *   node scripts/stage-node-runtime.mjs --platform linux --arch arm64 --dest <dir>
+ *
+ * Must run BEFORE `electron-builder` (which copies out/resources/node via
+ * extraResources). Mirrors stage-daemon-bundles.mjs.
+ */
+import { createHash } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Pinned standalone Node runtime for the bundled daemons. Bump deliberately;
+// the SHA is fetched from the official SHASUMS256.txt for this exact version, so
+// only this constant changes. Must be a version whose `node:sqlite` DatabaseSync
+// is usable without an --experimental flag (the probe below enforces it).
+const NODE_VERSION = '22.22.2'
+const DIST_BASE = `https://nodejs.org/dist/v${NODE_VERSION}`
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const webappDir = resolve(__dirname, '..')
+const repoRoot = resolve(webappDir, '..')
+
+function parseArgs(argv) {
+  const args = { platform: process.platform, arch: process.arch, dest: resolve(repoRoot, 'out/resources/node') }
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i]
+    if (flag === '--platform') args.platform = argv[++i]
+    else if (flag === '--arch') args.arch = argv[++i]
+    else if (flag === '--dest') args.dest = resolve(argv[++i])
+    else throw new Error(`[stage-node-runtime] unknown argument: ${flag}`)
+  }
+  return args
+}
+
+async function download(url) {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`[stage-node-runtime] GET ${url} → ${res.status} ${res.statusText}`)
+  return Buffer.from(await res.arrayBuffer())
+}
+
+function sha256(buf) {
+  return createHash('sha256').update(buf).digest('hex')
+}
+
+function verifyChecksum(buf, want, label) {
+  const got = sha256(buf)
+  if (got !== want) {
+    throw new Error(`[stage-node-runtime] checksum mismatch for ${label}\n  expected ${want}\n  got      ${got}`)
+  }
+  console.log(`[stage-node-runtime] sha256 verified (${label}): ${got}`)
+}
+
+// SHASUMS256.txt is a list of `<sha256>  <filename>` lines for the release.
+function expectedSha(shasums, filename) {
+  for (const line of shasums.split('\n')) {
+    const [sha, name] = line.trim().split(/\s+/)
+    if (name === filename) return sha
+  }
+  throw new Error(`[stage-node-runtime] ${filename} not found in SHASUMS256.txt`)
+}
+
+async function main() {
+  const { platform, arch, dest } = parseArgs(process.argv.slice(2))
+
+  // nodejs.org uses the same platform/arch tokens Node reports (darwin/linux/win32
+  // → win, arm64/x64). darwin/linux ship a .tar.gz holding bin/node; win ships the
+  // bare node.exe at win-<arch>/node.exe (no archive to extract).
+  const binaryName = platform === 'win32' ? 'node.exe' : 'node'
+  mkdirSync(dest, { recursive: true })
+  const stagedBinary = join(dest, binaryName)
+
+  // Idempotency: a 113 MB download on every local `electron:dist` is wasteful.
+  // Skip ONLY when a host-arch binary already reports the exact pinned version
+  // (so we know it ran and is correct). Cross-arch binaries can't be probed, so
+  // they always re-stage; CI runs on fresh runners and re-downloads regardless.
+  if (existsSync(stagedBinary) && platform === process.platform && arch === process.arch) {
+    try {
+      const version = execFileSync(stagedBinary, ['--version'], { encoding: 'utf8' }).trim()
+      if (version === `v${NODE_VERSION}`) {
+        console.log(`[stage-node-runtime] ${binaryName} already staged at the pinned version (${version}); skipping download`)
+        return
+      }
+    } catch {
+      // Unrunnable/corrupt — fall through and re-stage.
+    }
+  }
+
+  const shasums = (await download(`${DIST_BASE}/SHASUMS256.txt`)).toString('utf8')
+
+  if (platform === 'win32') {
+    const remote = `win-${arch}/node.exe`
+    console.log(`[stage-node-runtime] fetching ${remote} (node:sqlite host for the packaged daemons)…`)
+    const binary = await download(`${DIST_BASE}/${remote}`)
+    verifyChecksum(binary, expectedSha(shasums, remote), remote)
+    writeFileSync(stagedBinary, binary)
+  } else {
+    const tag = `node-v${NODE_VERSION}-${platform}-${arch}`
+    const tarball = `${tag}.tar.gz`
+    console.log(`[stage-node-runtime] fetching ${tarball} (node:sqlite host for the packaged daemons)…`)
+    const archive = await download(`${DIST_BASE}/${tarball}`)
+    verifyChecksum(archive, expectedSha(shasums, tarball), tarball)
+    const work = mkdtempSync(join(tmpdir(), 'vt-node-runtime-'))
+    try {
+      const archivePath = join(work, tarball)
+      writeFileSync(archivePath, archive)
+      // Extract ONLY bin/node, flattening it directly into dest/.
+      execFileSync('tar', ['-xzf', archivePath, '-C', dest, '--strip-components=2', `${tag}/bin/${binaryName}`], {
+        stdio: 'inherit',
+      })
+    } finally {
+      rmSync(work, { force: true, recursive: true })
+    }
+  }
+
+  if (!existsSync(stagedBinary)) {
+    throw new Error(`[stage-node-runtime] expected ${stagedBinary} after staging, but it is missing`)
+  }
+  chmodSync(stagedBinary, 0o755)
+  console.log(`[stage-node-runtime] staged ${binaryName} → ${stagedBinary}`)
+
+  // Probe node:sqlite, but only when the staged binary matches the host (a
+  // cross-arch binary can't execute here). CI jobs are native per arch, so the
+  // probe runs in CI; local cross-staging skips it with a notice.
+  if (platform === process.platform && arch === process.arch) {
+    const probe = "const { DatabaseSync } = require('node:sqlite'); new DatabaseSync(':memory:').close()"
+    try {
+      execFileSync(stagedBinary, ['-e', probe], { stdio: 'pipe' })
+      console.log(`[stage-node-runtime] node:sqlite probe passed on Node ${NODE_VERSION} (${platform}-${arch})`)
+    } catch (err) {
+      throw new Error(
+        `[stage-node-runtime] node:sqlite probe FAILED on the staged Node ${NODE_VERSION} (${platform}-${arch}). ` +
+          `This version cannot host vt-graphd. ${err.stderr ? err.stderr.toString() : err.message}`,
+      )
+    }
+  } else {
+    console.log(`[stage-node-runtime] skipping node:sqlite probe (staged ${platform}-${arch} ≠ host ${process.platform}-${process.arch})`)
+  }
+}
+
+await main()

--- a/webapp/src/shell/edge/main/runtime/electron/app/build-config.test.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/app/build-config.test.ts
@@ -77,6 +77,13 @@ describe('build-config', () => {
 
       expect(config.shouldCopyTools).toBe(true);
     });
+
+    it('should not pin a daemon node binary in development', () => {
+      const config: BuildConfig = getBuildConfig();
+
+      // Dev runs the daemons from the dev `node` on PATH; nothing to pin.
+      expect(config.graphdNodeBinaryPath).toBeNull();
+    });
   });
 
   describe('getBuildConfig - Production Mode (Unpackaged)', () => {
@@ -102,6 +109,13 @@ describe('build-config', () => {
       expect(config.pythonCwd).toBe(repoRoot);
       expect(config.shouldCompilePython).toBe(true);
       expect(config.serverBinaryPath).toBe(expectedBinaryPath);
+    });
+
+    it('should not pin a daemon node binary when unpackaged', () => {
+      const config: BuildConfig = getBuildConfig();
+
+      // No bundled node ships in an unpackaged prod build; resolver uses PATH node.
+      expect(config.graphdNodeBinaryPath).toBeNull();
     });
   });
 
@@ -132,6 +146,13 @@ describe('build-config', () => {
       const expectedBinaryPath: string = path.join(mockResourcesPath, 'server', 'voicetree-server');
       expect(config.serverBinaryPath).toBe(expectedBinaryPath);
       expect(config.pythonCommand).toBe(expectedBinaryPath);
+    });
+
+    it('should pin the bundled daemon node binary under Resources/node', () => {
+      const config: BuildConfig = getBuildConfig();
+
+      // win32 is out of scope; on this CI (darwin/linux) the binary is `node`.
+      expect(config.graphdNodeBinaryPath).toBe(path.join(mockResourcesPath, 'node', 'node'));
     });
   });
 

--- a/webapp/src/shell/edge/main/runtime/electron/app/build-config.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/app/build-config.ts
@@ -51,6 +51,16 @@ export type BuildConfig = {
 
   // Server binary absolutePath (production only)
   readonly serverBinaryPath: string | null;
+
+  // Absolute path to the bundled standalone Node ≥22 that hosts the per-project
+  // daemons (vtd + its vt-graphd sibling), or null when this build ships none.
+  // Those daemons need node:sqlite (Node ≥22) and must NOT run on Electron's own
+  // node (architecture.md), so the packaged app carries its own node under
+  // Resources/node/. Null in dev and unpackaged builds: the runtime resolver
+  // then falls back to a `node` on PATH. main.ts exports this as
+  // VT_GRAPHD_NODE_BIN, which graph-db-client's resolver selects first — and
+  // which vt-daemon-client reuses for vtd (both go through the same resolver).
+  readonly graphdNodeBinaryPath: string | null;
 };
 
 // ============================================================================
@@ -105,6 +115,8 @@ function getBuildConfigDev(commonEnv: CommonEnv): BuildConfig {
     pythonCwd: rootDir,
     shouldCompilePython: false,
     serverBinaryPath: null,
+    // Dev runs the daemons from source via the dev `node` on PATH (already ≥22).
+    graphdNodeBinaryPath: null,
 
     // Tools: Copy from repo source
     toolsSource: path.join(rootDir, 'tools'),
@@ -136,6 +148,14 @@ function getBuildConfigProd(commonEnv: CommonEnv): BuildConfig {
   const serverBinaryPath: string = commonEnv.isPackaged
     ? path.join(process.resourcesPath, 'server', serverBinaryName)
     : path.join(rootDir, 'out', 'resources', 'server', serverBinaryName);
+
+  // Standalone Node ≥22 hosting the daemons. Only the packaged app ships one
+  // (under Resources/node/, placed there by extraResources + stage:node); an
+  // unpackaged prod build has none, so the daemons resolve a `node` from PATH.
+  const nodeBinaryName: string = process.platform === 'win32' ? 'node.exe' : 'node';
+  const graphdNodeBinaryPath: string | null = commonEnv.isPackaged
+    ? path.join(process.resourcesPath, 'node', nodeBinaryName)
+    : null;
 
   // Tools source depends on packaging state
   const toolsSource: string = commonEnv.isPackaged
@@ -169,6 +189,7 @@ function getBuildConfigProd(commonEnv: CommonEnv): BuildConfig {
     pythonCwd: rootDir,
     shouldCompilePython: true,
     serverBinaryPath,
+    graphdNodeBinaryPath,
 
     // Tools: Copy from packaged resources or build output
     toolsSource,

--- a/webapp/src/shell/edge/main/runtime/electron/app/main.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/app/main.ts
@@ -114,6 +114,19 @@ if (electronVtBinDir !== null) {
     process.env.PATH = `${electronVtBinDir}${path.delimiter}${process.env.PATH ?? ''}`;
 }
 
+// Point the daemon runtime resolver at the bundled standalone Node ≥22 in
+// packaged builds. vtd and vt-graphd need node:sqlite and must not run on
+// Electron's node (architecture.md); the packaged app ships its own node under
+// Resources/node/. Set on Electron-main, this propagates to every resolver: the
+// graphd resolver reads it directly, and it is inherited by the spawned vtd
+// (which uses the same resolver for its own host and for the graphd it spawns).
+// build-config returns null in dev/unpackaged, where the resolver falls back to
+// a `node` on PATH. An explicit override (launcher/test) wins — we only fill the gap.
+const graphdNodeBinaryPath: string | null = getBuildConfig().graphdNodeBinaryPath;
+if (graphdNodeBinaryPath !== null && process.env.VT_GRAPHD_NODE_BIN === undefined) {
+    process.env.VT_GRAPHD_NODE_BIN = graphdNodeBinaryPath;
+}
+
 configureEnvironment();
 // Pin the VoiceTree home before tracing so it (and the daemon/CLI it spawns)
 // share one settings root. The OTLP gRPC exporter only attaches when


### PR DESCRIPTION
## The gap this closes

dev already bundles the daemon **entrypoints** (`vtd.mjs` + `vt-graphd.mjs`, via PR #213) and unpacks them from asar. But it ships **no Node runtime to run them**. Those daemons need `node:sqlite` (Node ≥22) and must not run on Electron's node (architecture.md), so the resolver deliberately excludes the Electron binary — leaving only a `node` on `PATH`. A normal user who installs the `.dmg`/AppImage has no Node, so graphd/vtd can't start and graph features break.

This ships an official **Node 22** inside the app and points the daemons at it.

```
   packaged app:  [entrypoints ✅ (dev)] + [Node 22 ❌]   →  graphd can't start without user's own Node
   this PR:       + [Node 22 ✅ at Resources/node + VT_GRAPHD_NODE_BIN]  →  runs on every machine
```

## What it does (2 commits)

1. **`feat(packaging)` — wire `VT_GRAPHD_NODE_BIN`.** `build-config` gains `graphdNodeBinaryPath` (packaged → `Resources/node/node`, null in dev/unpackaged). `main.ts` exports it as `VT_GRAPHD_NODE_BIN` on Electron-main. Set once there, it propagates to **every** resolver: graphd reads it directly, and the spawned vtd inherits it (vt-daemon-client reuses graphd's resolver for vtd's own host *and* for the graphd vtd spawns). So one var + one Node covers **both** daemons. Dev/unpackaged unchanged (falls back to PATH node).
2. **`feat(packaging)` — ship the Node 22 binary.** `scripts/stage-node-runtime.mjs` downloads the official nodejs.org build for the target platform/arch, **verifies it against the published `SHASUMS256.txt`**, extracts just the binary into `out/resources/node`, and runs a **`node:sqlite` probe** (on the host arch) so a bad version pin fails the build loudly. Wired as `stage:node` into `electron:pack`/`dist`/`dist-and-publish` (so local packaged builds bundle it) and into the mac/linux/windows release jobs (`--arch <matrix.arch>`). On mac it's signed automatically with the app identity via `entitlementsInherit` (the needed entitlements — `allow-jit` etc. — are already present). Version pinned via one constant.

## Verification

**Proven locally on an unsigned arm64 package (`electron-builder --dir`):**
- the bundled node lands at `Contents/Resources/node/node` (arm64, executable),
- it runs `node:sqlite` (v22.22.2),
- **the packaged `vt-graphd.mjs` boots on the bundled node and serves its port** — the real runtime scenario.

Plus: `stage-node-runtime.mjs` verified end-to-end (real download + sha256 + extract + probe) for darwin-arm64 and darwin-x64; build-config unit tests (packaged → `Resources/node/node`, null otherwise); webapp `tsc` clean; lint clean.

**Needs a release dry-run** (`workflow_dispatch`, `publish=false`) — inherently not checkable on PR CI: mac code-signing/notarization of the bundled node, and the x64 / linux-arm64 matrix arches.

## Notes
- **Footprint:** ~113 MB per installer (Node statically links V8/ICU). The honest cost of a self-contained runtime; each per-arch installer ships only its own.
- Node 22.x prints an `ExperimentalWarning` for `node:sqlite` — functional, and the same API dev already depends on (not a regression).
- No `after-pack.cjs` change needed: the node is staged per native arch and copied via `extraResources`; after-pack's existing timestamp touch covers it for signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)