### PR TITLE
fix(webapp): re-anchor terminals to the collapsed folder instead of orphaning them

### DIFF
--- a/webapp/src/shell/edge/UI-edge/floating-windows/anchoring/reconcile-terminal-anchors.ts
+++ b/webapp/src/shell/edge/UI-edge/floating-windows/anchoring/reconcile-terminal-anchors.ts
@@ -1,0 +1,99 @@
+import type { Core } from 'cytoscape'
+import * as O from 'fp-ts/lib/Option.js'
+
+import type { FolderId } from '@vt/graph-state/contract'
+import type { ProjectedGraph } from '@vt/graph-state/contract'
+import { findVisibleCollapsedAncestorForNode } from '@vt/graph-state/project-helpers'
+
+import { getTerminals } from '@/shell/edge/UI-edge/state/stores/TerminalStore'
+import { getShadowNodeId, getTerminalId } from '@/shell/edge/UI-edge/floating-windows/anchoring/types'
+
+// The structural tether between a terminal's shadow node and the graph node it
+// is anchored to (the visible line; it also participates in Cola layout). Class
+// matches the edge anchorToNode creates.
+const ANCHOR_EDGE_CLASS = 'terminal-indicator'
+
+/** A terminal's shadow node and the logical graph node it is anchored to. */
+export interface ShadowAnchor {
+    readonly shadowNodeId: string
+    readonly anchoredNodeId: string
+}
+
+/** Anchored terminals currently in the store, paired with their shadow node id. */
+export function collectShadowAnchors(): readonly ShadowAnchor[] {
+    const anchors: ShadowAnchor[] = []
+    for (const terminal of getTerminals().values()) {
+        if (!O.isSome(terminal.anchoredToNodeId)) continue
+        anchors.push({
+            shadowNodeId: getShadowNodeId(getTerminalId(terminal)),
+            anchoredNodeId: terminal.anchoredToNodeId.value,
+        })
+    }
+    return anchors
+}
+
+// The folders the projection rendered as collapsed proxies ARE graph-state's
+// `visibleCollapsedFolders` (a folder with a collapsed ancestor is itself
+// dropped from the projection). Feeding them to the same resolver the
+// projection uses reproduces its node→endpoint mapping without re-deriving
+// folder ancestry from path strings here.
+function visibleCollapsedFolders(graph: ProjectedGraph): ReadonlySet<FolderId> {
+    const folders = new Set<FolderId>()
+    for (const node of graph.nodes) {
+        if (node.kind === 'folder-collapsed') folders.add(node.id as FolderId)
+    }
+    return folders
+}
+
+/**
+ * Re-point each anchored terminal's structural anchor edge at the *visible*
+ * endpoint of its logical node: the node itself when visible, else the collapsed
+ * ancestor folder it now lives inside.
+ *
+ * Anchor edges are renderer-only, so the projection's edge rerouting never
+ * touches them. Without this, collapsing a folder deletes the anchored node and
+ * cytoscape cascades away its anchor edge, orphaning the terminal in empty
+ * space. Mirrors how the projection reroutes real edges onto a collapsed folder.
+ *
+ * Idempotent; mutates `cy`. Shadow-node lifecycle (creation / teardown) is owned
+ * elsewhere — this only reconciles the edge, and skips terminals whose shadow is
+ * absent or whose endpoint is not yet in the graph.
+ */
+export function reconcileTerminalAnchorEdges(
+    cy: Core,
+    graph: ProjectedGraph,
+    anchors: readonly ShadowAnchor[] = collectShadowAnchors(),
+): void {
+    const collapsedFolders = visibleCollapsedFolders(graph)
+    for (const { shadowNodeId, anchoredNodeId } of anchors) {
+        if (cy.getElementById(shadowNodeId).length === 0) continue
+        const endpoint: string =
+            findVisibleCollapsedAncestorForNode(anchoredNodeId, collapsedFolders) ?? anchoredNodeId
+        if (cy.getElementById(endpoint).length === 0) continue
+        ensureAnchorEdge(cy, endpoint, shadowNodeId)
+    }
+}
+
+// Guarantee exactly one anchor edge into the shadow, sourced at `anchorNodeId`.
+// Removes any stale anchor edges (wrong source) and adds the correct one if
+// missing — so re-anchoring on collapse/expand never duplicates or orphans.
+function ensureAnchorEdge(cy: Core, anchorNodeId: string, shadowNodeId: string): void {
+    let alreadyCorrect = false
+    cy.getElementById(shadowNodeId)
+        .incomers(`edge.${ANCHOR_EDGE_CLASS}`)
+        .forEach((edge) => {
+            if (edge.data('source') === anchorNodeId) alreadyCorrect = true
+            else edge.remove()
+        })
+    if (alreadyCorrect) return
+
+    cy.add({
+        group: 'edges',
+        data: {
+            id: `edge-${anchorNodeId}-${shadowNodeId}`,
+            source: anchorNodeId,
+            target: shadowNodeId,
+        },
+        classes: ANCHOR_EDGE_CLASS,
+    })
+}

--- a/webapp/src/shell/edge/UI-edge/graph/actions/applyGraphDeltaToUI.ts
+++ b/webapp/src/shell/edge/UI-edge/graph/actions/applyGraphDeltaToUI.ts
@@ -16,6 +16,7 @@ import {getNodeTitle} from "@vt/graph-model/pure/graph/markdown-parsing";
 import type {TerminalData} from "@/shell/edge/UI-edge/floating-windows/terminals/terminalDataType";
 import * as O from "fp-ts/lib/Option.js";
 import {anchorToNode} from "@/shell/edge/UI-edge/floating-windows/anchoring/anchor-to-node";
+import {reconcileTerminalAnchorEdges} from "@/shell/edge/UI-edge/floating-windows/anchoring/reconcile-terminal-anchors";
 import {getCurrentIndex} from "@/shell/UI/cytoscape-graph-ui/services/layout/spatialIndexSync";
 
 function isValidCSSColor(color: string): boolean {
@@ -403,6 +404,13 @@ export function applyGraphDeltaToUI(cy: Core, graph: ProjectedGraph): ApplyGraph
     for (const nodeId of newNodeIds) {
         repairTerminalAnchorsForNode(cy, nodeId)
     }
+
+    // Keep every anchored terminal tethered to the visible endpoint of its node:
+    // the node itself, or — when a folder collapses and hides it — the collapsed
+    // ancestor folder. Runs over ALL terminals (not just newNodeIds) because a
+    // collapse REMOVES nodes rather than adding them, so a newNodeIds-keyed pass
+    // would never fire for the node that just got hidden.
+    reconcileTerminalAnchorEdges(cy, graph)
 
     // Terminal→node indicator edges driven by agent_name YAML (new + updated nodes).
     // createTerminalIndicatorEdge is idempotent, so re-running it for already-edged

--- a/webapp/src/shell/edge/UI-edge/graph/integration-tests/applyGraphDeltaToUI-terminal-anchor-collapse.test.ts
+++ b/webapp/src/shell/edge/UI-edge/graph/integration-tests/applyGraphDeltaToUI-terminal-anchor-collapse.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { Core } from 'cytoscape'
+import cytoscape from 'cytoscape'
+import type { GraphNode } from '@vt/graph-model/graph'
+import { syncProjectStateFromMain } from '@/shell/edge/UI-edge/state/stores/ProjectPathStore'
+import {
+    resetTestProjectionState,
+    setTestCollapseSet,
+    projectTestProjectionState,
+} from '@/shell/edge/UI-edge/graph/integration-tests/projectGraphDelta'
+import { addTerminal, clearTerminals } from '@/shell/edge/UI-edge/state/stores/TerminalStore'
+import { createTerminalData, getShadowNodeId, getTerminalId } from '@/shell/edge/UI-edge/floating-windows/anchoring/types'
+import type { TerminalId, NodeIdAndFilePath } from '@/shell/edge/UI-edge/floating-windows/anchoring/types'
+import { O, upsert, applyDeltaToUI, applySpecToUI, syncFolderTree } from './applyGraphDeltaToUI.test-utils'
+
+vi.mock('@/shell/edge/UI-edge/graph/popups/userEngagementPrompts', () => ({
+    checkEngagementPrompts: vi.fn(),
+}))
+
+// A node that lives inside the `internal` folder, plus the folder that contains
+// it (folder ids carry a trailing slash by convention — see project-helpers).
+const NODE_ID = '/project/auth/internal/refresh-token.md'
+const FOLDER_ID = '/project/auth/internal/'
+const TERMINAL_ID = `${NODE_ID}-terminal-0` as TerminalId
+
+const ANCHOR_EDGE = 'edge.terminal-indicator'
+
+function nodeInsideFolder(): GraphNode {
+    return {
+        absoluteFilePathIsID: NODE_ID,
+        contentWithoutYamlOrLinks: '# Refresh Token',
+        outgoingEdges: [],
+        nodeUIMetadata: {
+            color: O.none,
+            position: O.some({ x: 200, y: 100 }),
+            additionalYAMLProps: {},
+            isContextNode: false,
+        },
+    }
+}
+
+/**
+ * Regression: a terminal anchored to a node inside a folder must stay tethered
+ * when that folder is collapsed.
+ *
+ * A terminal hangs off an invisible "shadow node" joined to its anchor node by a
+ * structural `terminal-indicator` edge (the visible line; it also feeds Cola
+ * layout). That edge is renderer-only — the projection never sees it. When the
+ * folder collapses, the projection drops the anchored node, cytoscape cascades
+ * away the node's edges (including the anchor edge), and the terminal is left
+ * floating in empty space with no tether.
+ *
+ * The graph already reroutes *real* node→node edges onto the collapsed folder
+ * (synthetic edges). The anchor edge must follow the same rule: re-point at the
+ * visible collapsed-ancestor folder while the node is hidden, and back to the
+ * node on expand.
+ */
+describe('applyGraphDeltaToUI — terminal anchor survives folder collapse', () => {
+    let cy: Core
+    const shadowNodeId: string = getShadowNodeId(TERMINAL_ID)
+
+    function anchorEdgesIntoShadow(): cytoscape.EdgeCollection {
+        return cy.getElementById(shadowNodeId).incomers(ANCHOR_EDGE)
+    }
+
+    beforeEach(() => {
+        resetTestProjectionState()
+        clearTerminals()
+        cy = cytoscape({ headless: true, elements: [] })
+
+        syncProjectStateFromMain({ readPaths: [], writeFolderPath: '/project', starredFolders: [] })
+        syncFolderTree('/project')
+
+        // A terminal anchored to the node inside the folder.
+        addTerminal(createTerminalData({
+            terminalId: TERMINAL_ID,
+            attachedToNodeId: NODE_ID as NodeIdAndFilePath,
+            anchoredToNodeId: NODE_ID as NodeIdAndFilePath,
+            terminalCount: 0,
+            title: 'agent',
+            agentName: 'agent',
+        }))
+
+        // Project + render the node while the folder is expanded.
+        setTestCollapseSet(new Set())
+        applyDeltaToUI(cy, [upsert(nodeInsideFolder())])
+        expect(cy.getElementById(NODE_ID).length).toBe(1)
+
+        // Stand in for anchorToNode's output: the shadow node and the structural
+        // anchor edge from the node to the shadow.
+        cy.add({ group: 'nodes', data: { id: shadowNodeId, isShadowNode: true } })
+        cy.add({
+            group: 'edges',
+            data: { id: `edge-${NODE_ID}-${shadowNodeId}`, source: NODE_ID, target: shadowNodeId },
+            classes: 'terminal-indicator',
+        })
+
+        expect(anchorEdgesIntoShadow().length).toBe(1)
+        expect(anchorEdgesIntoShadow()[0].data('source')).toBe(NODE_ID)
+    })
+
+    afterEach(() => {
+        cy.destroy()
+        clearTerminals()
+        setTestCollapseSet(new Set())
+        syncProjectStateFromMain({ readPaths: [], writeFolderPath: null, starredFolders: [] })
+    })
+
+    function collapseInternalFolder(): void {
+        setTestCollapseSet(new Set([FOLDER_ID]))
+        applySpecToUI(cy, projectTestProjectionState())
+    }
+
+    function expandInternalFolder(): void {
+        setTestCollapseSet(new Set())
+        applySpecToUI(cy, projectTestProjectionState())
+    }
+
+    it('reroutes the anchor edge onto the collapsed folder instead of orphaning it', () => {
+        collapseInternalFolder()
+
+        // The node is hidden and the folder is rendered as a collapsed proxy.
+        expect(cy.getElementById(NODE_ID).length).toBe(0)
+        expect(cy.getElementById(FOLDER_ID).length).toBe(1)
+
+        // The shadow node (and thus the terminal window) survives...
+        expect(cy.getElementById(shadowNodeId).length).toBe(1)
+
+        // ...and stays tethered — to the collapsed folder, not floating in space.
+        const anchors: cytoscape.EdgeCollection = anchorEdgesIntoShadow()
+        expect(anchors.length).toBe(1)
+        expect(anchors[0].data('source')).toBe(FOLDER_ID)
+    })
+
+    it('re-points the anchor edge back to the node when the folder expands', () => {
+        collapseInternalFolder()
+        expandInternalFolder()
+
+        expect(cy.getElementById(NODE_ID).length).toBe(1)
+        const anchors: cytoscape.EdgeCollection = anchorEdgesIntoShadow()
+        expect(anchors.length).toBe(1)
+        expect(anchors[0].data('source')).toBe(NODE_ID)
+    })
+
+    it('does not duplicate the anchor edge across repeated collapsed re-projections', () => {
+        collapseInternalFolder()
+        collapseInternalFolder()
+        collapseInternalFolder()
+
+        const anchors: cytoscape.EdgeCollection = anchorEdgesIntoShadow()
+        expect(anchors.length).toBe(1)
+        expect(anchors[0].data('source')).toBe(FOLDER_ID)
+    })
+})


### PR DESCRIPTION
A terminal anchors to its graph node via an invisible shadow node joined by a
renderer-only "terminal-indicator" edge. The projection never sees that edge,
so when a folder collapses and its child node is dropped, cytoscape cascades the
anchor edge away and the terminal floats in empty space.

Reconcile every anchored terminal's anchor edge after each projection apply:
re-point it at the visible endpoint of its logical node — the node itself, or
the collapsed ancestor folder it now lives inside — reusing graph-state's own
findVisibleCollapsedAncestorForNode so renderer and projection agree. Mirrors
how the projection already reroutes real node->node edges onto a collapsed
folder. Restores the node anchor on expand; idempotent across re-projections.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
