### PR TITLE
docs(dev-flow): base-branch wording per-developer (not hardcoded dev-manu)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-⛔ The main checkout is a READ-ONLY cache of origin/dev-manu — never edit/commit in it (worktrees ARE writable). `vt-worktree <name>` to work → `vt-land "msg"` to ship; `vt-sync` to update (never `git pull`). More: `scripts/dev-setup/worktree-readme.md`.
+⛔ The base checkout is a READ-ONLY fast-forward cache of `origin/$VT_BASE_BRANCH` — your personal integration base (lochlan → `dev-lochlan`, manu → `dev-manu`), each continuously fed from `dev`. Never edit/commit in the base (worktrees ARE writable). `vt-worktree <name>` to work → `vt-land "msg"` to ship; `vt-sync` to update (never `git pull`). More: `scripts/dev-setup/worktree-readme.md`.
 
 THIS PROJECT AIMS TO FOLLOW FUNCTIONAL DESIGN. NOT OOP.
 EVERYTHING SHOULD BE MODELLED AS FUNCTIONS & types. PUSH IMPURITY TO EDGE / SHELL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-⛔ The main checkout is a READ-ONLY cache of origin/dev-manu — never edit/commit in it (worktrees ARE writable). `vt-worktree <name>` to work → `vt-land "msg"` to ship; `vt-sync` to update (never `git pull`). More: `scripts/dev-setup/worktree-readme.md`.
+⛔ The base checkout is a READ-ONLY fast-forward cache of `origin/$VT_BASE_BRANCH` — your personal integration base (lochlan → `dev-lochlan`, manu → `dev-manu`), each continuously fed from `dev`. Never edit/commit in the base (worktrees ARE writable). `vt-worktree <name>` to work → `vt-land "msg"` to ship; `vt-sync` to update (never `git pull`). More: `scripts/dev-setup/worktree-readme.md`.
 
 THIS PROJECT AIMS TO FOLLOW FUNCTIONAL DESIGN. NOT OOP.
 EVERYTHING SHOULD BE MODELLED AS FUNCTIONS & types. PUSH IMPURITY TO EDGE / SHELL.


### PR DESCRIPTION
The top-line workflow note in CLAUDE.md / AGENTS.md hardcoded "READ-ONLY cache of origin/dev-manu" — but that's only manu's machine. Each developer pins their own integration base via `$VT_BASE_BRANCH` (lochlan → `dev-lochlan`, manu → `dev-manu`), both continuously fed from `dev`.

Reworded to be branch-neutral so the instruction is correct for everyone and nobody mistakes manu's personal lane for their own. Pure docs — no code/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)