### PR TITLE
perf(worktree): pin -c core.hooksPath so a stale base can't reintroduce blocking pnpm install during spawn-in-worktree

### DIFF
--- a/webapp/src/shell/edge/main/workspace/worktree/gitWorktreeCommands.test.ts
+++ b/webapp/src/shell/edge/main/workspace/worktree/gitWorktreeCommands.test.ts
@@ -13,7 +13,7 @@
 
 import {afterEach, describe, expect, it} from 'vitest';
 import {execFileSync} from 'node:child_process';
-import {mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync} from 'node:fs';
+import {chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {basename, delimiter, dirname, join} from 'node:path';
 
@@ -99,6 +99,38 @@ describe('createWorktree (discover-based)', () => {
         const repoRoot: string = makeRepo();
         await createWorktree(repoRoot, 'wt-dup');
         await expect(createWorktree(repoRoot, 'wt-dup')).rejects.toThrow(/Failed to create git worktree/);
+    });
+
+    // ROOT-CAUSE REGRESSION GUARD for "spawning in a new worktree takes 10+s":
+    // `git worktree add` fires post-checkout from the BRANCH TREE just checked
+    // out. A stale base whose post-checkout still runs `pnpm install` would
+    // re-stall the spawn even after PR #225 (which only fixed the hook in
+    // newer commits). createWorktree overrides `core.hooksPath` for THIS one
+    // invocation onto an app-owned no-op dir, so the branch-tree hook is
+    // bypassed regardless of how stale the base is.
+    it('overrides core.hooksPath so a post-checkout checked into the branch tree does not run', async () => {
+        const repoRoot: string = makeRepo();
+        // Plant a "branch tree" post-checkout that writes a marker on every
+        // checkout, and tell git to look there via core.hooksPath. This is the
+        // exact shape of the project's real hooks dir.
+        const markerDir: string = realpathSync(mkdtempSync(join(tmpdir(), 'vt-wt-stale-hook-')));
+        cleanups.push(() => rmSync(markerDir, {recursive: true, force: true}));
+        const markerPath: string = join(markerDir, 'stale-hook-ran.txt');
+        const branchHooks: string = join(repoRoot, 'scripts', 'hooks');
+        mkdirSync(branchHooks, {recursive: true});
+        const branchHook: string = join(branchHooks, 'post-checkout');
+        writeFileSync(branchHook, `#!/bin/sh\necho "ran" > "${markerPath}"\n`, 'utf-8');
+        chmodSync(branchHook, 0o755);
+        git(repoRoot, ['config', 'core.hooksPath', 'scripts/hooks']);
+        git(repoRoot, ['add', '.']);
+        git(repoRoot, ['commit', '-q', '-m', 'plant stale hook']);
+        setEnvUntilCleanup('HOME', gitGateFreeHome());
+
+        await createWorktree(repoRoot, 'wt-hardened');
+
+        // The branch-tree hook MUST NOT have fired — `-c core.hooksPath=<no-op>`
+        // diverted git to the app-owned dir for this invocation.
+        expect(existsSync(markerPath)).toBe(false);
     });
 });
 

--- a/webapp/src/shell/edge/main/workspace/worktree/gitWorktreeCommands.ts
+++ b/webapp/src/shell/edge/main/workspace/worktree/gitWorktreeCommands.ts
@@ -163,6 +163,40 @@ function isExecutableFile(candidate: string): boolean {
 }
 
 /**
+ * Materialize an app-controlled, no-op `post-checkout` git hook and return its
+ * directory, suitable for `-c core.hooksPath=<dir>` on `git worktree add`.
+ *
+ * WHY: `git worktree add` fires post-checkout AFTER checking out the branch's
+ * files, so the hook that runs is whatever `scripts/hooks/post-checkout` happens
+ * to live in that branch's tree. If the base branch is stale, the OLD hook runs
+ * — historically a blocking `pnpm install --frozen-lockfile` (~15-45 s) that
+ * stalled the spawn-in-worktree UI. We can't rely on the base branch's hook
+ * version, so we override `core.hooksPath` for THIS one invocation to point at
+ * a dir we control, containing a no-op hook.
+ *
+ * That is the right behaviour for the app-spawned path: the app already owns
+ * worktree setup via the configured blocking + async hooks (configure-cdp.sh
+ * + on-created-async.sh). git's post-checkout has nothing to add.
+ *
+ * The override applies only to the `git worktree add` invocation — it is NOT
+ * written to the new worktree's config, so subsequent git ops in the new
+ * worktree resolve hooks normally (e.g. real `git switch` still gets deps
+ * reconciliation via the branch's checked-in post-checkout).
+ *
+ * Idempotent and race-safe: identical content, mkdir-recursive, unconditional
+ * write. Lives under `os.tmpdir()` (per-user on macOS); fine to leave behind.
+ */
+function getAppOwnedHooksDir(): string {
+    const dir: string = path.join(os.tmpdir(), 'voicetree-worktree-hooks');
+    const hookPath: string = path.join(dir, 'post-checkout');
+    const body: string = '#!/bin/sh\n# No-op: VoiceTree owns worktree setup via configured hooks.\nexit 0\n';
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(hookPath, body);
+    fs.chmodSync(hookPath, 0o755);
+    return dir;
+}
+
+/**
  * Resolve the absolute path of the repository's MAIN checkout from any path
  * inside the repo — the watched dir, which may be a subdirectory of the
  * checkout or even a linked worktree. `--path-format=absolute` is required: a
@@ -258,6 +292,13 @@ async function discoverWorktreePathForBranch(repoRoot: string, branch: string): 
  * must NOT also run its own dependency bootstrap — that would double-install
  * and race on `node_modules`. The flag is a no-op for plain git.
  *
+ * `-c core.hooksPath=<app-owned no-op dir>`: belt-and-suspenders for the SKIP
+ * flag. The flag is honoured by the git-gate wrapper and by recent versions of
+ * the project's own `scripts/hooks/post-checkout`, but `git worktree add` runs
+ * the hook the branch tree contains — so a stale base re-introduces a blocking
+ * `pnpm install`. Pointing `core.hooksPath` at an app-owned no-op dir for THIS
+ * invocation makes the fast path immune to a stale base. See `getAppOwnedHooksDir`.
+ *
  * @param repoRoot - A directory inside the git repository (placement is
  *   resolved against the repo's main checkout)
  * @param worktreeName - The name for the worktree and branch
@@ -295,10 +336,13 @@ export async function createWorktree(
     // -b creates a new branch named after the worktree; `placement.destination`
     // is either the bare name (git-gate places it) or an absolute path (app
     // places it). Run from the main checkout so placement is anchored there.
+    // `-c core.hooksPath=...` overrides post-checkout for this one invocation
+    // so a stale base branch's hook can't reintroduce the blocking install.
+    const hooksDir: string = getAppOwnedHooksDir();
     try {
         await execFileAsync(
             'git',
-            ['worktree', 'add', '-b', worktreeName, placement.destination],
+            ['-c', `core.hooksPath=${hooksDir}`, 'worktree', 'add', '-b', worktreeName, placement.destination],
             { cwd: mainCheckout, env },
         );
     } catch (error) {


### PR DESCRIPTION
## Summary

- PR #225 fixed the spawn-in-worktree stall in `scripts/hooks/post-checkout` itself, but `git worktree add` runs post-checkout from the FRESH worktree's tree — i.e. whatever version of the hook the base branch contains. Until the base is rebased past the fix, every new worktree re-checks-out the OLD hook and re-runs the ~15-45 s `pnpm install --frozen-lockfile`. Measured 48 s here.
- Make the fast path immune to a stale base: invoke `git worktree add` with `-c core.hooksPath=<app-owned no-op dir>`, materialized once under `os.tmpdir()/voicetree-worktree-hooks/`. The app already owns worktree setup via configured blocking + async hooks (`configure-cdp.sh` + `on-created-async.sh`); git's post-checkout has nothing to add for the app-spawned path.
- Override is per-invocation (just `-c` on the command line) — does NOT mutate the new worktree's git config. A real `git switch` later inside the new worktree still runs the branch's deps-reconciliation hook normally.

## Why this is additive, not a replacement for PR #225

PR #225 still matters for the git-gate path and for anyone who runs `git worktree add` from the CLI. This change is specifically for the app-spawned flow that calls into `createWorktree`.

## Test plan

- [x] New black-box regression guard in `gitWorktreeCommands.test.ts`: plant a marker-writing post-checkout into the branch tree + set `core.hooksPath=scripts/hooks` on the seed repo, call `createWorktree`, assert the marker file was NOT written (proving git was diverted to the app-owned no-op dir).
- [x] Existing 21 tests still green (`gitWorktreeCommands.test.ts` + `createWorktreeWithHooks.test.ts`).
- [ ] Manual: open a new worktree from the app on a stale base — should return in ~1 s (just `configure-cdp.sh`) instead of 15-45 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)