### PR TITLE
style(terminals): shrink tmux status pill to 50% size

### DIFF
--- a/webapp/src/shell/UI/floating-windows/terminals/terminal-chrome.css
+++ b/webapp/src/shell/UI/floating-windows/terminals/terminal-chrome.css
@@ -250,6 +250,11 @@
   color: var(--muted-foreground);
   font: 10px/1.4 monospace;
   pointer-events: none;
+  /* Render the status pill at 50% size, scaled uniformly (font, padding,
+     border, radius) from its bottom-right corner so it stays pinned to the
+     same right/bottom anchor rather than drifting inward. */
+  transform: scale(0.5);
+  transform-origin: right bottom;
 }
 
 .terminal-relay-status.connected {


### PR DESCRIPTION
Scale .terminal-relay-status uniformly with transform: scale(0.5),
anchored to its bottom-right corner so the pill stays pinned to its
existing right/bottom position instead of drifting inward. Scaling
the whole element keeps font, padding, border and radius proportional
and avoids a sub-5px font that browsers render poorly.
