### PR TITLE
fix(recovery): filter foreign-project panes from Resumable Agents

### DIFF
--- a/packages/systems/vt-daemon/src/agent-runtime/recovery/discovery.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/recovery/discovery.ts
@@ -148,6 +148,13 @@ export async function discoverRecoverableAgentSessions(
     // what the session itself provides.
     for (const session of liveUnclaimed) {
         if (surfacedTerminalIds.has(session.terminalId)) continue
+        // Non-goal: cross-project recovery (see fix-resume design). A foreign-
+        // project pane is not attachable here and has no resume capability, so it
+        // would surface as a dead row in "Resumable agents" — only a Kill button,
+        // no Attach/Resume. The classifier already drops foreign-project metadata
+        // records; mirror that for metadata-less foreign panes so the recovery
+        // surface stays consistent.
+        if (session.classification === 'foreign-project') continue
         recoverable.push(metadataLessAttachableRow(session))
     }
     const horizonMs: number | null = opts.horizonMs === undefined ? getRecoveryHorizonMs() : opts.horizonMs

--- a/packages/systems/vt-daemon/src/agent-runtime/recovery/tests/discovery.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/recovery/tests/discovery.test.ts
@@ -154,6 +154,27 @@ describe('discoverRecoverableAgentSessions — attach capability', () => {
         expect(rows[0].resume).toBeUndefined()
     })
 
+    it('does NOT surface a foreign-project live tmux session with no metadata (non-goal: cross-project recovery)', async () => {
+        // A tmux pane from another project: not attachable here and carries no
+        // resume capability, so surfacing it produces a dead row in "Resumable
+        // agents" (only a Kill button, no Attach/Resume). The classifier already
+        // drops foreign-project *metadata* records; the metadata-less attachable
+        // path must mirror that for foreign *panes* too.
+        const foreign: UnclaimedTmuxSession = makeUnclaimed({
+            sessionName: `vt-${FOREIGN_HASH}-Omar`,
+            terminalId: 'Omar',
+            hash: FOREIGN_HASH,
+            classification: 'foreign-project',
+            attachable: false,
+            agentName: 'Omar',
+        })
+        const rows = await discoverRecoverableAgentSessions(makeDeps({
+            readProjectMetadataDir: async () => [],
+            listLiveUnclaimedTmuxSessions: async () => [foreign],
+        }))
+        expect(rows).toHaveLength(0)
+    })
+
     it('does not duplicate a terminal that appears in both metadata classification and live unclaimed list', async () => {
         const unclaimed: UnclaimedTmuxSession = makeUnclaimed()
         const rows = await discoverRecoverableAgentSessions(makeDeps({

--- a/webapp/src/shell/UI/views/treeStyleTerminalTabs/SurvivingAgentsSection.test.tsx
+++ b/webapp/src/shell/UI/views/treeStyleTerminalTabs/SurvivingAgentsSection.test.tsx
@@ -169,27 +169,10 @@ describe('SurvivingAgentsSection — attach capability rows', () => {
         consoleError.mockRestore();
     });
 
-    it('renders foreign-project attach rows as kill-only', () => {
-        const foreign: RecoverableAgentSession = makeAttachable({
-            sessionName: 'vt-bbbbbbbbbb-Beth',
-            terminalId: 'Beth',
-            hash: 'bbbbbbbbbb',
-            classification: 'foreign-project',
-            attachable: false,
-            agentName: 'Beth',
-            projectRoot: '/project/other',
-        });
-        const {container, onKill} = renderSection([foreign]);
-
-        const row: Element | null = container.querySelector('[data-terminal-id="Beth"]');
-        expect(row).not.toBeNull();
-        expect(within(row as HTMLElement).getByText('Foreign project')).toBeTruthy();
-        expect(within(row as HTMLElement).queryByRole('button', {name: /attach/i})).toBeNull();
-
-        fireEvent.click(within(row as HTMLElement).getByRole('button', {name: /kill beth/i}));
-
-        expect(onKill).toHaveBeenCalledWith('vt-bbbbbbbbbb-Beth');
-    });
+    // Foreign-project panes are filtered upstream in discovery (non-goal:
+    // cross-project recovery — see discoverRecoverableAgentSessions and the
+    // fix-resume design). The section therefore never receives a foreign row,
+    // so there is no UI behavior to assert for them here.
 });
 
 describe('SurvivingAgentsSection — resume capability rows', () => {


### PR DESCRIPTION
The metadata-less attachable loop in discoverRecoverableAgentSessions
surfaced every live unclaimed tmux session regardless of namespace,
including foreign-project panes. Those rows are not attachable here and
carry no resume capability, so they rendered in 'Resumable agents' with
only a Kill button — no Resume, no Attach — directly contradicting the
fix-resume design non-goal ('cross-project recovery: foreign-project
rows still filtered') and the classifier, which already drops foreign
metadata records.

Mirror the classifier's foreign drop in the metadata-less path so the
recovery surface is consistent. The prior tests passed because the
'drops foreign-project records' discovery test only exercised the
metadata path (never a foreign live tmux session), and the UI test fed
the component a foreign row directly — a shape discovery no longer
produces. Add the missing discovery coverage and remove the now-
contradictory UI test.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
