### PR TITLE
agent ids: append a 3-char hash for uniqueness, strip it in the sidebar

### DIFF
--- a/packages/libraries/graph-model/src/pure/agents/personaInjection.test.ts
+++ b/packages/libraries/graph-model/src/pure/agents/personaInjection.test.ts
@@ -17,8 +17,8 @@ describe('appendPersonaToAgentPrompt', () => {
         expect(out).toBe(BASE);
     });
 
-    it('resolves the persona through a collision-suffixed name', () => {
-        const out = appendPersonaToAgentPrompt(BASE, 'Richard_1', {siliconValleyMode: true});
+    it('resolves the persona through a hash-suffixed id', () => {
+        const out = appendPersonaToAgentPrompt(BASE, 'Richard-k3f', {siliconValleyMode: true});
         expect(out.AGENT_PROMPT).toContain('Richard Hendricks');
     });
 

--- a/packages/libraries/graph-model/src/pure/agents/siliconValleyRoster.test.ts
+++ b/packages/libraries/graph-model/src/pure/agents/siliconValleyRoster.test.ts
@@ -3,7 +3,6 @@ import {AGENT_NAMES, getNextAgentName, getUniqueAgentName} from '../settings/typ
 import {
     SILICON_VALLEY_ROSTER,
     SILICON_VALLEY_IDS,
-    baseIdFromAgentName,
     lookupPersona,
     renderPersonaSoul,
     getAgentNamePool,
@@ -35,27 +34,13 @@ describe('SILICON_VALLEY_ROSTER integrity', () => {
     });
 });
 
-describe('baseIdFromAgentName', () => {
-    it('returns the name unchanged when there is no collision suffix', () => {
-        expect(baseIdFromAgentName('Richard')).toBe('Richard');
-    });
-
-    it('strips a single _1 collision suffix', () => {
-        expect(baseIdFromAgentName('Richard_1')).toBe('Richard');
-    });
-
-    it('strips recursively appended suffixes (Richard_1_1)', () => {
-        expect(baseIdFromAgentName('Richard_1_1')).toBe('Richard');
-    });
-});
-
 describe('lookupPersona', () => {
     it('finds a persona by exact id', () => {
         expect(lookupPersona('Gilfoyle')?.fullName).toBe('Bertram Gilfoyle');
     });
 
-    it('finds a persona through a collision suffix', () => {
-        expect(lookupPersona('Richard_1_1')?.id).toBe('Richard');
+    it('finds a persona through the uniqueness hash suffix', () => {
+        expect(lookupPersona('Richard-k3f')?.id).toBe('Richard');
     });
 
     it('returns undefined for a neutral (non-character) name', () => {
@@ -87,23 +72,23 @@ describe('pool exhaustion and collision (the "richard_2?" question)', () => {
         // One full cycle yields every character exactly once, whatever the start offset.
         expect(new Set(seen).size).toBe(SILICON_VALLEY_IDS.length);
         expect([...seen].sort()).toEqual([...SILICON_VALLEY_IDS].sort());
-        // The next call necessarily repeats an already-used name — i.e. a collision
-        // the registry must resolve via getUniqueAgentName.
+        // The next call necessarily repeats an already-used name — i.e. a base-name
+        // wrap the hash (via getUniqueAgentName) must keep distinct.
         expect(SILICON_VALLEY_IDS).toContain(getNextAgentName(SILICON_VALLEY_IDS));
     });
 
-    it('resolves a wrap-collision with _1 (NOT _2) and the persona still maps back', () => {
-        const taken: ReadonlySet<string> = new Set(['Gilfoyle']);
-        const unique: string = getUniqueAgentName('Gilfoyle', taken);
-        expect(unique).toBe('Gilfoyle_1');
-        // The suffixed agent still channels Gilfoyle's soul.
+    it('hashes a wrapped base name into a unique id whose persona still maps back', () => {
+        const unique: string = getUniqueAgentName('Gilfoyle', new Set(), () => 'k3f');
+        expect(unique).toBe('Gilfoyle-k3f');
+        // The hashed agent still channels Gilfoyle's soul.
         expect(lookupPersona(unique)?.id).toBe('Gilfoyle');
     });
 
-    it('resolves a double collision to _1_1, still mapping to the base persona', () => {
-        const taken: ReadonlySet<string> = new Set(['Richard', 'Richard_1']);
-        const unique: string = getUniqueAgentName('Richard', taken);
-        expect(unique).toBe('Richard_1_1');
+    it('regenerates the hash when the first candidate collides with a live id', () => {
+        const taken: ReadonlySet<string> = new Set(['Richard-aaa']);
+        const hashes: string[] = ['aaa', 'bbb'];
+        const unique: string = getUniqueAgentName('Richard', taken, () => hashes.shift()!);
+        expect(unique).toBe('Richard-bbb');
         expect(lookupPersona(unique)?.id).toBe('Richard');
     });
 });

--- a/packages/libraries/graph-model/src/pure/agents/siliconValleyRoster.ts
+++ b/packages/libraries/graph-model/src/pure/agents/siliconValleyRoster.ts
@@ -12,7 +12,7 @@
  * shell over it.
  */
 
-import {AGENT_NAMES, getNextAgentName} from '../settings/types';
+import {AGENT_NAMES, agentBaseName, getNextAgentName} from '../settings/types';
 import type {VTSettings} from '../settings/types';
 
 /**
@@ -93,17 +93,9 @@ const PERSONA_BY_ID: ReadonlyMap<string, Persona> = new Map(
     SILICON_VALLEY_ROSTER.map(p => [p.id, p]),
 );
 
-/**
- * Strip the collision suffixes `getUniqueAgentName` appends (`_1`, `_1_1`, …)
- * to recover the base roster id. `Richard_1_1` → `Richard`.
- */
-export function baseIdFromAgentName(agentName: string): string {
-    return agentName.replace(/(_\d+)+$/, '');
-}
-
-/** The persona for an agent name (suffix-tolerant), or undefined if it is not a roster character. */
+/** The persona for an agent name (hash-suffix tolerant), or undefined if it is not a roster character. */
 export function lookupPersona(agentName: string): Persona | undefined {
-    return PERSONA_BY_ID.get(baseIdFromAgentName(agentName));
+    return PERSONA_BY_ID.get(agentBaseName(agentName));
 }
 
 /**

--- a/packages/libraries/graph-model/src/pure/settings/agentId.test.ts
+++ b/packages/libraries/graph-model/src/pure/settings/agentId.test.ts
@@ -1,0 +1,63 @@
+import {describe, it, expect} from 'vitest';
+import {
+    AGENT_ID_HASH_LENGTH,
+    AGENT_ID_SEPARATOR,
+    agentBaseName,
+    formatAgentId,
+    getUniqueAgentName,
+} from './types';
+import {uniqueAgentName} from '../../settings';
+
+describe('formatAgentId', () => {
+    it('joins base name and hash with the separator', () => {
+        expect(formatAgentId('Ayu', 'k3f')).toBe(`Ayu${AGENT_ID_SEPARATOR}k3f`);
+    });
+});
+
+describe('agentBaseName', () => {
+    it('strips the uniqueness hash', () => {
+        expect(agentBaseName('Ayu-k3f')).toBe('Ayu');
+    });
+
+    it('round-trips with formatAgentId', () => {
+        expect(agentBaseName(formatAgentId('Richard', 'z9q'))).toBe('Richard');
+    });
+
+    it('leaves a bare base name (no hash) unchanged', () => {
+        expect(agentBaseName('Ayu')).toBe('Ayu');
+    });
+
+    it('strips only the trailing hash, preserving multi-token base names', () => {
+        expect(agentBaseName('JianYang-7ab')).toBe('JianYang');
+    });
+});
+
+describe('getUniqueAgentName', () => {
+    it('appends the supplied hash to the base name', () => {
+        expect(getUniqueAgentName('Sam', new Set(), () => 'q4z')).toBe('Sam-q4z');
+    });
+
+    it('regenerates until the candidate is free', () => {
+        const hashes: string[] = ['aaa', 'aaa', 'ccc'];
+        const taken: ReadonlySet<string> = new Set(['Sam-aaa']);
+        expect(getUniqueAgentName('Sam', taken, () => hashes.shift()!)).toBe('Sam-ccc');
+    });
+});
+
+describe('uniqueAgentName (random source)', () => {
+    it('produces a hash of the configured length over [a-z0-9]', () => {
+        const id: string = uniqueAgentName('Sam', new Set());
+        const hash: string = id.slice(`Sam${AGENT_ID_SEPARATOR}`.length);
+        expect(id.startsWith(`Sam${AGENT_ID_SEPARATOR}`)).toBe(true);
+        expect(hash).toMatch(new RegExp(`^[a-z0-9]{${AGENT_ID_HASH_LENGTH}}$`));
+    });
+
+    it('repeated draws of one base name are distinct', () => {
+        // 46,656 ids per base name — a handful of draws colliding is astronomically
+        // unlikely, which is the whole point of the hash.
+        const ids: Set<string> = new Set(
+            Array.from({length: 50}, () => uniqueAgentName('Sam', new Set())),
+        );
+        expect(ids.size).toBe(50);
+    });
+});

--- a/packages/libraries/graph-model/src/pure/settings/types.ts
+++ b/packages/libraries/graph-model/src/pure/settings/types.ts
@@ -69,7 +69,7 @@ export function agentBaseName(agentId: string): string {
  * Build a unique agent id by appending a hash to the base name,
  * regenerating on the rare chance the candidate collides with a live id.
  * `generateHash` is injectable so callers and tests can supply any source.
- * For production use with a random source, use `uniqueAgentName` from `agentId.ts`.
+ * For production use with a random source, use `uniqueAgentName` from `../../settings`.
  */
 export function getUniqueAgentName(
     baseName: string,

--- a/packages/libraries/graph-model/src/pure/settings/types.ts
+++ b/packages/libraries/graph-model/src/pure/settings/types.ts
@@ -22,8 +22,9 @@ export const AGENT_NAMES: readonly string[] = [
 ] as const;
 
 // Round-robin agent name selection. The counter rotates over whichever pool is
-// passed (neutral AGENT_NAMES or the Silicon Valley roster); `getUniqueAgentName`
-// resolves any collision once a pool wraps.
+// passed (neutral AGENT_NAMES or the Silicon Valley roster); the base name it
+// yields is only the human-friendly half of an id — `getUniqueAgentName` adds the
+// hash that actually makes the id unique.
 // eslint-disable-next-line functional/prefer-readonly-type -- intentionally mutable counter
 const agentNameState: { index: number } = { index: -1 };
 
@@ -33,14 +34,52 @@ export function getNextAgentName(names: readonly string[] = AGENT_NAMES): string
 }
 
 /**
- * Get a unique agent name by appending _1 recursively until no collision.
- * Example: Sam → Sam_1 → Sam_1_1 → Sam_1_1_1
+ * Agent ids are `<BaseName><AGENT_ID_SEPARATOR><hash>` — a friendly round-robin
+ * base name plus a short random alphanumeric hash. The hash is what makes an id
+ * unique. Base names come from a tiny pool, drawn round-robin and freed when an
+ * agent exits, so without the hash a base name reused later would collide with a
+ * past agent that the graph still references by id. Three chars over a 36-symbol
+ * alphabet give 46,656 ids per base name; `getUniqueAgentName` still checks the
+ * candidate against live ids and regenerates on the rare clash, so collisions
+ * among concurrent agents are impossible and temporal ones astronomically
+ * unlikely. The hash is stripped for display — see `agentBaseName`.
  */
-export function getUniqueAgentName(baseName: string, existingNames: ReadonlySet<string>): string {
-    if (!existingNames.has(baseName)) {
-        return baseName;
-    }
-    return getUniqueAgentName(`${baseName}_1`, existingNames);
+export const AGENT_ID_SEPARATOR = '-';
+export const AGENT_ID_HASH_LENGTH = 3;
+export const AGENT_ID_HASH_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+/** Compose an agent id from its base name and uniqueness hash. */
+export function formatAgentId(baseName: string, hash: string): string {
+    return `${baseName}${AGENT_ID_SEPARATOR}${hash}`;
+}
+
+const AGENT_ID_HASH_SUFFIX_RE: RegExp =
+    new RegExp(`${AGENT_ID_SEPARATOR}[a-z0-9]{${AGENT_ID_HASH_LENGTH}}$`);
+
+/**
+ * Recover the human-friendly base name from an agent id by stripping the
+ * uniqueness hash: `Ayu-k3f` → `Ayu`. Base names never contain the separator, so
+ * the suffix is unambiguous; an id with no hash suffix is returned unchanged.
+ */
+export function agentBaseName(agentId: string): string {
+    return agentId.replace(AGENT_ID_HASH_SUFFIX_RE, '');
+}
+
+/**
+ * Build a unique agent id by appending a hash to the base name,
+ * regenerating on the rare chance the candidate collides with a live id.
+ * `generateHash` is injectable so callers and tests can supply any source.
+ * For production use with a random source, use `uniqueAgentName` from `agentId.ts`.
+ */
+export function getUniqueAgentName(
+    baseName: string,
+    existingNames: ReadonlySet<string>,
+    generateHash: () => string,
+): string {
+    const candidate: string = formatAgentId(baseName, generateHash());
+    return existingNames.has(candidate)
+        ? getUniqueAgentName(baseName, existingNames, generateHash)
+        : candidate;
 }
 
 export type EnvVarValue = string | readonly string[];

--- a/packages/libraries/graph-model/src/settings.ts
+++ b/packages/libraries/graph-model/src/settings.ts
@@ -1,12 +1,24 @@
+import { getUniqueAgentName, AGENT_ID_HASH_LENGTH, AGENT_ID_HASH_ALPHABET } from './pure/settings/types'
+
 export type { VTSettings, AgentConfig, EnvVarValue, HotkeyModifier, HotkeyBinding, HotkeySettings, HookSettings, ProjectConfig, VoiceTreeConfig, TerminalScrollStrategy } from './pure/settings/types'
-export { getUniqueAgentName } from './pure/settings/types'
+export { getUniqueAgentName, agentBaseName, formatAgentId, AGENT_ID_SEPARATOR, AGENT_ID_HASH_LENGTH, AGENT_ID_HASH_ALPHABET } from './pure/settings/types'
 export { DEFAULT_SUBGRAPH_WARN_THRESHOLD, DEFAULT_SUBGRAPH_ERROR_THRESHOLD, DEFAULT_MAX_CHILDREN_PER_NODE, DEFAULT_COMPLEXITY_WARN_SCORE, DEFAULT_COMPLEXITY_BLOCK_SCORE, DEFAULT_SUBGRAPH_LIMITS } from './pure/settings/types'
 export { AGENT_NAMES, getNextAgentName, getDefaultAgent } from './pure/settings/types'
+
+function randomAgentHash(): string {
+    return Array.from(
+        { length: AGENT_ID_HASH_LENGTH },
+        () => AGENT_ID_HASH_ALPHABET[Math.floor(Math.random() * AGENT_ID_HASH_ALPHABET.length)],
+    ).join('');
+}
+
+export function uniqueAgentName(baseName: string, existingNames: ReadonlySet<string>): string {
+    return getUniqueAgentName(baseName, existingNames, randomAgentHash);
+}
 export {
     type Persona,
     SILICON_VALLEY_ROSTER,
     SILICON_VALLEY_IDS,
-    baseIdFromAgentName,
     lookupPersona,
     renderPersonaSoul,
     getAgentNamePool,

--- a/packages/measures/budgets/coupling/cross-package-value-symbol-budgets.ts
+++ b/packages/measures/budgets/coupling/cross-package-value-symbol-budgets.ts
@@ -194,6 +194,10 @@
 //     measure `vt graph complexity` runs, applied to the destination cluster)
 //   vt-daemon -> graph-model: 24 -> 27 (+3 the gates' tunable settings defaults
 //     DEFAULT_MAX_CHILDREN_PER_NODE / _COMPLEXITY_WARN_SCORE / _COMPLEXITY_BLOCK_SCORE)
+// 2026-06-05 [agent-id-hash PR #235]: 27 -> 28 (+1 agentBaseName).
+//   Fork now strips the hash from the source agent name before generating a fresh
+//   one (forkAgentSession.ts). `getUniqueAgentName` renamed to the impure wrapper
+//   `uniqueAgentName` (net 0), but `agentBaseName` is genuinely new here (+1).
 export const CROSS_PACKAGE_VALUE_SYMBOL_BUDGETS: Readonly<Record<string, number>> = {
     'app-config -> graph-model': 4,
     'daemon-test-harness -> graph-db-client': 2,
@@ -345,7 +349,7 @@ export const CROSS_PACKAGE_VALUE_SYMBOL_BUDGETS: Readonly<Record<string, number>
     // buildTerminalEnvVars adds appendPersonaToAgentPrompt; the roster/lookup/
     // render internals stay inside graph-model so the daemon depends on one new
     // symbol, not three.
-    'vt-daemon -> graph-model': 27,
+    'vt-daemon -> graph-model': 28,
     // 2026-05-27 [Phase 3]: daemon owns live-command dispatch + state
     // hydration post-BF-379. Three value symbols: `applyCommandWithDelta`,
     // `hydrateCommand`, `serializeState` (all wire shapes formerly evaluated

--- a/packages/systems/vt-daemon/src/agent-runtime/recovery/forkAgentSession.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/recovery/forkAgentSession.ts
@@ -6,7 +6,7 @@ import {
 import {buildResumeCommand, type ResumeMode} from '@vt/vt-daemon/agent-runtime/spawn/cli/resumeCli.ts'
 import {spawnTmuxBackedTerminal} from '../headless/tmuxHeadlessRuntime'
 import {getExistingAgentNames} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/index.ts'
-import {getUniqueAgentName} from '@vt/graph-model/settings'
+import {agentBaseName, uniqueAgentName} from '@vt/graph-model/settings'
 import {
     defaultResolveNativeSession,
     type NativeSessionMissReason,
@@ -135,7 +135,9 @@ export function defaultForkAgentDeps(
         discover: () => discoverRecoverableAgentSessions(discoveryDeps),
         resolveNativeSession: defaultResolveNativeSession,
         allocateForkAgentName: (sourceAgentName: string): string => {
-            return getUniqueAgentName(sourceAgentName, getExistingAgentNames())
+            // Fork keeps the source's friendly base name but earns its own hash,
+            // so the forked id is distinct from the session it resumes.
+            return uniqueAgentName(agentBaseName(sourceAgentName), getExistingAgentNames())
         },
         spawn: (terminalId, terminalData, command, cwd, env) =>
             spawnTmuxBackedTerminal(terminalId, terminalData, command, cwd, env),

--- a/packages/systems/vt-daemon/src/agent-runtime/spawn/spawnPlainTerminal.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/spawn/spawnPlainTerminal.ts
@@ -8,7 +8,7 @@ import type {Position} from '@vt/graph-model/graph';
 import {createNewNodeNoParent} from '@vt/graph-model/graph';
 import {getNodeTitle} from '@vt/graph-model/markdown';
 import type {VTSettings} from '@vt/graph-model/settings';
-import {getUniqueAgentName, pickAgentName} from '@vt/graph-model/settings';
+import {uniqueAgentName, pickAgentName} from '@vt/graph-model/settings';
 import {createTerminalData, type TerminalId} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/types.ts';
 import {getExistingAgentNames} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/index.ts';
 import {getTerminalManager} from '@vt/vt-daemon/agent-runtime/terminals/manager/terminal-manager-instance.ts';
@@ -40,7 +40,7 @@ export async function spawnPlainTerminal(nodeId: NodeIdAndFilePath, terminalCoun
   // Plain terminals still need unique IDs for registry tracking
   const baseAgentName: string = pickAgentName(settings);
   const existingNames: Set<string> = getExistingAgentNames();
-  const agentName: string = getUniqueAgentName(baseAgentName, existingNames);
+  const agentName: string = uniqueAgentName(baseAgentName, existingNames);
   // terminalId = agentName (unified identification)
   const terminalId: TerminalId = agentName as TerminalId;
 

--- a/packages/systems/vt-daemon/src/agent-runtime/spawn/spawnTerminalWithContextNode.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/spawn/spawnTerminalWithContextNode.ts
@@ -20,7 +20,7 @@ import {type TerminalId } from '@vt/vt-daemon/agent-runtime/terminals/terminal-r
 import type { NodeIdAndFilePath, GraphNode, Graph } from '@vt/graph-model/graph';
 import { findFirstParentNode } from '@vt/graph-model/graph';
 import type { VTSettings } from '@vt/graph-model/settings';
-import { getUniqueAgentName, pickAgentName } from '@vt/graph-model/settings';
+import { uniqueAgentName, pickAgentName } from '@vt/graph-model/settings';
 import { getNextTerminalCountForNode, getExistingAgentNames, recordTerminalPending } from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/index.ts';
 import {
     getRuntimeGraph,
@@ -103,7 +103,7 @@ export async function spawnTerminalWithContextNode(
     const agentName: string = inheritTerminalId ?? (() => {
         const baseAgentName: string = pickAgentName(settings);
         const existingNames: Set<string> = getExistingAgentNames();
-        return getUniqueAgentName(baseAgentName, existingNames);
+        return uniqueAgentName(baseAgentName, existingNames);
     })();
     const terminalId: TerminalId = agentName as TerminalId;
 

--- a/packages/systems/vt-daemon/src/agent-runtime/spawn/terminalData.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/spawn/terminalData.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import type {Graph, GraphNode, NodeIdAndFilePath} from '@vt/graph-model/graph'
 import {getNodeTitle} from '@vt/graph-model/markdown'
 import type {VTSettings} from '@vt/graph-model/settings'
-import {getUniqueAgentName, pickAgentName} from '@vt/graph-model/settings'
+import {uniqueAgentName, pickAgentName} from '@vt/graph-model/settings'
 import {createTerminalData, type TerminalData, type TerminalId} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/types.ts'
 import {getExistingAgentNames} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/index.ts'
 import {buildTerminalEnvVars} from './buildTerminalEnvVars'
@@ -84,7 +84,7 @@ export async function prepareTerminalDataInMain(
     const agentName: string = precomputedAgentName ?? inheritTerminalId ?? (() => {
         const baseAgentName: string = pickAgentName(settings)
         const existingNames: Set<string> = getExistingAgentNames()
-        return getUniqueAgentName(baseAgentName, existingNames)
+        return uniqueAgentName(baseAgentName, existingNames)
     })()
 
     const watchStatus: {

--- a/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-context-node-agent.spec.ts
+++ b/webapp/e2e-tests/electron/critical_e2e_verification_tests/electron-context-node-agent.spec.ts
@@ -27,6 +27,7 @@
 import { expect } from '@playwright/test';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import { agentBaseName } from '@vt/graph-model/settings';
 import { test, type ExtendedWindow } from './electron-context-node-agent-fixtures';
 
 const TEST_AGENT_COMMAND = 'CLAUDE_CODE_NO_FLICKER=1 claude --dangerously-skip-permissions "$AGENT_PROMPT"';
@@ -206,10 +207,14 @@ test.describe('Context Node Agent Terminal E2E', () => {
 
     console.log('=== STEP 7: Verify spawned agent appears in the terminal tree sidebar ===');
     await expect(appWindow.getByTestId('terminal-tree-sidebar')).toBeVisible({ timeout: 15000 });
+    // Identity (with hash) is verified by the data-terminal-id locator above.
+    // The visible text shows the hash-stripped base name — the sidebar strips the
+    // uniqueness suffix for display, so assert on agentBaseName(), the same pure
+    // helper the sidebar renders with.
     const terminalTreeRow = appWindow.locator(`[data-testid="terminal-tree-sidebar"] [data-terminal-id="${terminalId}"]`);
     await expect(terminalTreeRow).toBeVisible({ timeout: 15000 });
-    await expect(terminalTreeRow).toContainText(terminalId);
-    console.log(`✓ Terminal tree sidebar shows spawned agent: ${terminalId}`);
+    await expect(terminalTreeRow).toContainText(agentBaseName(terminalId));
+    console.log(`✓ Terminal tree sidebar shows spawned agent: ${terminalId} (displayed as "${agentBaseName(terminalId)}")`);
 
     console.log('');
     console.log('=== TEST SUMMARY ===');

--- a/webapp/src/shell/UI/views/treeStyleTerminalTabs/TerminalTreeSidebar.tsx
+++ b/webapp/src/shell/UI/views/treeStyleTerminalTabs/TerminalTreeSidebar.tsx
@@ -17,6 +17,7 @@ import { getTerminalId } from '@/shell/edge/UI-edge/floating-windows/anchoring/t
 import type { TerminalData } from '@/shell/edge/UI-edge/floating-windows/terminals/terminalDataType';
 import { buildTerminalTree, type ChildStatusSummary, type TerminalTreeNode } from '@vt/graph-model/agent-tabs';
 import { getShortcutHintForTab } from '@vt/graph-model/agent-tabs';
+import { agentBaseName } from '@vt/graph-model/settings';
 import { getShortcutPlatform } from '@/shell/UI/platform/shortcutPlatform';
 
 import { useCollapseState } from './terminalTreeCollapseState';
@@ -202,7 +203,7 @@ function TreeNode({ treeNode, isActive, shortcutHint, onSelect, isCollapsed, onT
     const handleClose: (e: React.MouseEvent) => void = useCallback((e: React.MouseEvent): void => {
         e.stopPropagation();
         if (terminal.isHeadless) {
-            void window.hostAPI?.main.closeHeadlessAgent(terminalId);
+            void window.hostAPI?.main.closeHeadlessAgent({ terminalId });
             return;
         }
         const terminalElement: Element | null = document.querySelector(`[data-floating-window-id="${terminalId}"]`);
@@ -265,7 +266,7 @@ function TreeNode({ treeNode, isActive, shortcutHint, onSelect, isCollapsed, onT
                     </span>
                 )}
                 <span className="terminal-tree-agent-id" title={terminalId}>
-                    {terminalId}{terminal.agentTypeName ? ` - ${terminal.agentTypeName}` : ''}{terminal.isHeadless ? ' (Headless)' : ''}
+                    {agentBaseName(terminalId)}{terminal.agentTypeName ? ` - ${terminal.agentTypeName}` : ''}{terminal.isHeadless ? ' (Headless)' : ''}
                     {terminal.statusPhrase ? (
                         <span className="terminal-tree-status-phrase" title={terminal.statusPhrase}>
                             {' '}— {terminal.statusPhrase}

--- a/webapp/src/shell/edge/main/agent/ask-mode/askModeCreateAndSpawn.ts
+++ b/webapp/src/shell/edge/main/agent/ask-mode/askModeCreateAndSpawn.ts
@@ -7,7 +7,7 @@ import * as O from 'fp-ts/lib/Option.js';
 import type {Graph, NodeIdAndFilePath} from '@vt/graph-model/graph';
 import {resolveEnvVarsWithSelection, expandEnvVarsInValues} from '@vt/graph-model/settings';
 import type {VTSettings} from '@vt/graph-model/settings';
-import {getUniqueAgentName, getDefaultAgent, pickAgentName} from '@vt/graph-model/settings';
+import {uniqueAgentName, getDefaultAgent, pickAgentName} from '@vt/graph-model/settings';
 import {createTerminalData, type TerminalId} from '@/shell/edge/UI-edge/floating-windows/anchoring/types';
 import {getExistingAgentNames} from '@vt/vt-daemon-client';
 import {getActiveProject, getVtDaemonClient} from '@/shell/edge/main/runtime/electron/daemon/daemon-url-binding';
@@ -68,7 +68,7 @@ export async function askModeCreateAndSpawn(relevantNodeIds: readonly string[], 
   // Generate unique agent name with collision handling
   const baseAgentName: string = pickAgentName(settings);
   const existingNames: ReadonlySet<string> = new Set(await getExistingAgentNames(getVtDaemonClient()));
-  const agentName: string = getUniqueAgentName(baseAgentName, existingNames);
+  const agentName: string = uniqueAgentName(baseAgentName, existingNames);
   const title: string = `${agentName}: ${strippedTitle}`;
   // terminalId = agentName (unified identification)
   const terminalId: TerminalId = agentName as TerminalId;


### PR DESCRIPTION
Agent ids were a tiny round-robin base-name pool (~60 names) freed on exit,
so a base name reused over time collided with a past agent the graph still
referenced by id, plus a fragile _1/_1_1 concurrent-collision suffix. Replace
both with <BaseName>-<hash>, hash = 3 chars over [a-z0-9] (46,656 per base),
regenerated on the rare clash with a live id. The terminal tree sidebar strips
the hash for display (full id stays on hover).

- graph-model/pure/settings/types: formatAgentId, agentBaseName, injectable
  getUniqueAgentName (random hash by default)
- roster: drop duplicate baseIdFromAgentName, reuse agentBaseName
- forkAgentSession: base-strip the source before allocating a fresh hash
- TerminalTreeSidebar: render agentBaseName(terminalId)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
