### PR TITLE
perf(worktree): stamp deps-guard marker after worktree install (+ test dev's prewarm-skip)

### DIFF
--- a/scripts/dev-setup/common/ensure-deps-fresh.mjs
+++ b/scripts/dev-setup/common/ensure-deps-fresh.mjs
@@ -77,6 +77,18 @@ function depsAreFresh(root) {
   return readMarker(root) === computeFingerprint(root)
 }
 
+// Stamp the marker with the current lockfile fingerprint, declaring "this env's
+// node_modules is in sync with the committed lockfile". Called after any install
+// path completes — both this guard's own install (below) and the worktree
+// initial installer (install-worktree-deps.sh, via `--stamp`) — so the marker
+// contract has a single source of truth and no installer can leave it unstamped.
+function stampMarker(root) {
+  const marker = markerPath(root)
+  mkdirSync(dirname(marker), {recursive: true})
+  writeFileSync(marker, computeFingerprint(root) + '\n')
+  return marker
+}
+
 // The side effect: reconcile node_modules to the committed lockfile if (and
 // only if) stale, then stamp the marker. Returns a small result object so
 // callers/tests can observe what happened without scraping logs.
@@ -100,11 +112,21 @@ function ensureDepsFresh({startDir = process.cwd(), log = msg => process.stderr.
     throw new Error(`pnpm install --frozen-lockfile failed (exit ${result.status}) in ${root}`)
   }
 
-  const marker = markerPath(root)
-  mkdirSync(dirname(marker), {recursive: true})
-  writeFileSync(marker, fingerprint + '\n')
+  stampMarker(root)
   log(`[deps-guard] deps installed; marker written (${root})\n`)
   return {root, fresh: false, installed: true}
+}
+
+// Stamp-only entrypoint: record the marker for an install another tool just
+// performed, WITHOUT installing here. Used by install-worktree-deps.sh after its
+// own `pnpm install --frozen-lockfile`, so the first later branch-switch/pull in
+// a fresh worktree finds the marker fresh instead of triggering a redundant
+// blocking reinstall. Returns the same result shape as ensureDepsFresh.
+function stampDepsFresh({startDir = process.cwd(), log = msg => process.stderr.write(msg)} = {}) {
+  const root = findWorkspaceRoot(startDir)
+  stampMarker(root)
+  log(`[deps-guard] marker stamped for existing install (${root})\n`)
+  return {root, fresh: false, installed: false}
 }
 
 const isDirectRun =
@@ -112,7 +134,11 @@ const isDirectRun =
 
 if (isDirectRun) {
   try {
-    ensureDepsFresh()
+    if (process.argv.includes('--stamp')) {
+      stampDepsFresh()
+    } else {
+      ensureDepsFresh()
+    }
   } catch (err) {
     process.stderr.write(`[deps-guard] ${err.message}\n`)
     process.exit(1)
@@ -126,4 +152,6 @@ export {
   readMarker,
   depsAreFresh,
   ensureDepsFresh,
+  stampMarker,
+  stampDepsFresh,
 }

--- a/scripts/dev-setup/common/ensure-deps-fresh.test.mjs
+++ b/scripts/dev-setup/common/ensure-deps-fresh.test.mjs
@@ -15,6 +15,7 @@ import {
   depsAreFresh,
   markerPath,
   findWorkspaceRoot,
+  stampDepsFresh,
 } from './ensure-deps-fresh.mjs'
 
 // Build a throwaway workspace: pnpm-workspace.yaml + pnpm-lock.yaml, and
@@ -83,6 +84,37 @@ test('stale when the marker holds an unrelated value', () => {
   const root = makeWorkspace({marker: 'not-a-real-fingerprint\n'})
   try {
     assert.equal(depsAreFresh(root), false)
+  } finally {
+    rmSync(root, {recursive: true, force: true})
+  }
+})
+
+test('stampDepsFresh makes a previously-stale workspace report fresh (no install)', () => {
+  // Mirrors install-worktree-deps.sh: pnpm already installed the deps, then we
+  // stamp the marker so the guard does not redundantly reinstall on the first
+  // later branch-switch/pull.
+  const root = makeWorkspace()
+  try {
+    assert.equal(depsAreFresh(root), false) // fresh worktree: no marker yet
+    const result = stampDepsFresh({startDir: root, log: () => {}})
+    assert.deepEqual(result, {root, fresh: false, installed: false})
+    assert.equal(depsAreFresh(root), true) // marker now matches lockfile
+  } finally {
+    rmSync(root, {recursive: true, force: true})
+  }
+})
+
+test('stampDepsFresh re-stamps after a lockfile change so the guard tracks it', () => {
+  const root = makeWorkspace({lock: 'lockfile: 1\n'})
+  try {
+    stampDepsFresh({startDir: root, log: () => {}})
+    assert.equal(depsAreFresh(root), true)
+
+    // Lockfile changes and a new install runs elsewhere; re-stamping realigns.
+    writeFileSync(join(root, 'pnpm-lock.yaml'), 'lockfile: 1\n  newdep: 2.0.0\n')
+    assert.equal(depsAreFresh(root), false)
+    stampDepsFresh({startDir: root, log: () => {}})
+    assert.equal(depsAreFresh(root), true)
   } finally {
     rmSync(root, {recursive: true, force: true})
   }

--- a/scripts/dev-setup/common/install-worktree-deps.sh
+++ b/scripts/dev-setup/common/install-worktree-deps.sh
@@ -57,6 +57,14 @@ else
   corepack pnpm install --frozen-lockfile
 fi
 
+# Stamp the deps-freshness marker so the guard (post-checkout / post-merge)
+# recognises this freshly-installed worktree as in-sync. Without this, the first
+# later branch-switch or pull in the worktree would trigger a redundant blocking
+# `pnpm install`. Best-effort: a missing/failed stamp only costs that one extra
+# reconcile later — it must never fail worktree setup.
+node "$SCRIPT_DIR/ensure-deps-fresh.mjs" --stamp \
+  || step "WARNING deps-fingerprint stamp failed; guard will reconcile on next checkout"
+
 seed_ck_index "$CHECKOUT_ROOT"
 
 step "complete"

--- a/scripts/hooks/post-checkout.test.mjs
+++ b/scripts/hooks/post-checkout.test.mjs
@@ -1,0 +1,64 @@
+// Black-box regression test for the post-checkout deps-guard gate.
+//
+// The perf bug this guards against: `git worktree add` fires post-checkout
+// synchronously *inside* the add. If the deps-guard runs a blocking
+// `pnpm install` there, it stalls the caller — most visibly the VoiceTree app's
+// spawn-in-worktree (~15s). Worktree creators that own the dependency lifecycle
+// (the app, git-gate) set VT_GIT_GATE_SKIP_WORKTREE_PREWARM=1 and install deps
+// off the critical path, so the hook must skip when that flag is set. A real
+// `git switch` does NOT set the flag, so lockfile reconciliation on a branch
+// switch is unaffected.
+//
+// We invoke the real hook with fake `git` + `node` on PATH and assert whether it
+// reached the `node ensure-deps-fresh.mjs` step. Run: `node --test post-checkout.test.mjs`.
+
+import {test} from 'node:test'
+import assert from 'node:assert/strict'
+import {mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, chmodSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join, dirname} from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {spawnSync} from 'node:child_process'
+
+const HOOK = join(dirname(fileURLToPath(import.meta.url)), 'post-checkout')
+const SHA_A = '1234567890abcdef1234567890abcdef12345678'
+const SHA_B = 'abcdef1234567890abcdef1234567890abcdef12'
+
+// Run the hook with $1/$2/$3 set and an optional extra env, behind fake `git`
+// (reports a repo root) and a fake `node` that touches a sentinel when invoked.
+// Returns true iff the hook reached the `node ensure-deps-fresh.mjs` step.
+function guardWouldRun(prevHead, newHead, flag, extraEnv = {}) {
+  const sandbox = mkdtempSync(join(tmpdir(), 'post-checkout-'))
+  try {
+    const bin = join(sandbox, 'bin')
+    mkdirSync(bin, {recursive: true})
+    const sentinel = join(sandbox, 'guard-ran')
+    writeFileSync(join(bin, 'git'), `#!/bin/sh\necho '${sandbox}'\n`)
+    writeFileSync(join(bin, 'node'), `#!/bin/sh\necho ran > '${sentinel}'\n`)
+    chmodSync(join(bin, 'git'), 0o755)
+    chmodSync(join(bin, 'node'), 0o755)
+    const result = spawnSync('bash', [HOOK, prevHead, newHead, flag], {
+      env: {...process.env, PATH: `${bin}:${process.env.PATH}`, ...extraEnv},
+    })
+    assert.equal(result.status, 0, `hook exited non-zero: ${result.stderr}`)
+    return existsSync(sentinel)
+  } finally {
+    rmSync(sandbox, {recursive: true, force: true})
+  }
+}
+
+test('SKIPS when VT_GIT_GATE_SKIP_WORKTREE_PREWARM=1 (caller owns deps lifecycle)', () => {
+  assert.equal(guardWouldRun(SHA_A, SHA_B, '1', {VT_GIT_GATE_SKIP_WORKTREE_PREWARM: '1'}), false)
+})
+
+test('RUNS on a normal branch switch (flag set, no prewarm-skip flag)', () => {
+  assert.equal(guardWouldRun(SHA_A, SHA_B, '1'), true)
+})
+
+test('SKIPS a file checkout (flag 0 cannot change the lockfile)', () => {
+  assert.equal(guardWouldRun(SHA_A, SHA_B, '0'), false)
+})
+
+test('a non-"1" value of the prewarm flag does NOT skip (only exact "1" opts out)', () => {
+  assert.equal(guardWouldRun(SHA_A, SHA_B, '1', {VT_GIT_GATE_SKIP_WORKTREE_PREWARM: '0'}), true)
+})


### PR DESCRIPTION
## Context

The blocking-`pnpm install`-inside-`git worktree add` regression (app spawn-in-worktree ~5–15s) is **already fixed on `dev`** by `dac0b75cd` — *post-checkout honors `VT_GIT_GATE_SKIP_WORKTREE_PREWARM`*. My original PR fixed the same bug a different way (skip on initial/all-zero prev-HEAD); that's redundant and conflicting, so I **dropped it** and rebased to keep only what dev's fix is missing.

## What this adds (purely additive — dev touched neither modified file)

**1. Stamp the deps-guard marker after the worktree install.** `install-worktree-deps.sh` syncs `node_modules` to the lockfile but never wrote the `.vt-deps-fingerprint` marker. After the async worktree install, the **first** later real `git switch`/pull found no marker → judged deps stale → ran a **redundant blocking `pnpm install`** (same at `run-remote`'s command boundary). New `ensure-deps-fresh.mjs --stamp` records the fingerprint right after install. Best-effort: a failed stamp only costs one extra reconcile, never fails setup.

**2. Regression test for dev's prewarm-skip** (`dac0b75cd` shipped untested): skips when the flag is `1`, still reconciles on a real branch switch, skips file checkouts.

## Files
- `scripts/dev-setup/common/ensure-deps-fresh.mjs` — `stampMarker` + `stampDepsFresh` + `--stamp`
- `scripts/dev-setup/common/ensure-deps-fresh.test.mjs` — 2 new stamp tests
- `scripts/dev-setup/common/install-worktree-deps.sh` — stamp after install
- `scripts/hooks/post-checkout.test.mjs` — NEW regression test for the prewarm-skip

## Verification
- `node --test`: 9 deps-guard + 4 post-checkout, all green.
- Pre-commit tier-0 green on devbox. No change to `post-checkout` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)