### PR TITLE
fix(daemon): record execArgv in command fingerprint so tsx-launched daemons reuse

### DIFF
--- a/packages/systems/graph-db-server/src/daemon/startDaemon.ts
+++ b/packages/systems/graph-db-server/src/daemon/startDaemon.ts
@@ -266,7 +266,14 @@ async function startOwnedDaemon(
 function commandFingerprintForProcess() {
   return {
     executable: process.execPath,
-    args: process.argv.slice(1),
+    // Splice execArgv back in front of argv: Node strips its own loader flags
+    // (`--import tsx`, `--experimental-*`) out of process.argv into
+    // process.execArgv before user code runs. The owner-record fingerprint is
+    // compared against the live exec line read from `ps -p <pid> -o command=`,
+    // which DOES include those flags; recording only argv.slice(1) loses them,
+    // so a tsx-launched daemon (`node --import tsx vt-graphd …`) mismatches and
+    // the stale-owner check flips to `unsafe-owner`, timing out the launcher.
+    args: [...process.execArgv, ...process.argv.slice(1)],
   }
 }
 

--- a/packages/systems/vt-daemon/bin/vtd.ts
+++ b/packages/systems/vt-daemon/bin/vtd.ts
@@ -200,7 +200,8 @@ async function main(): Promise<void> {
             contractVersion: VTD_CONTRACT_VERSION,
             commandFingerprint: {
                 executable: process.execPath,
-                args: process.argv.slice(1),
+                // execArgv carries tsx loader flags `ps` shows but argv omits — see startDaemon.ts.
+                args: [...process.execArgv, ...process.argv.slice(1)],
             },
             clock: Date.now,
         })


### PR DESCRIPTION
## What

vtd and vt-graphd record a command fingerprint at owner-claim time so a future launcher can verify the recorded owner pid is still the daemon it expects, comparing against the live command from `ps -p <pid> -o command=`. That `ps` line includes every launch token, but the recorded form used `process.argv.slice(1)`, which Node strips its loader flags (`--import tsx`, `--experimental-*`) out of into `process.execArgv` before user code runs.

For any daemon launched via tsx (`node --import tsx …` — the workspace-dev path for both daemons) the on-disk fingerprint was missing those flags while the live `ps` fingerprint had them → the stale-owner safety check flipped to `unsafe-owner` → the launcher refused to reuse/reclaim → `DaemonLaunchTimeout`.

## Fix

Splice `process.execArgv` back in front of `process.argv.slice(1)` at both recording sites (`startDaemon.ts`, `vtd.ts`), restoring the full exec line. Kept inline at each site rather than extracting a shared helper into `@vt/daemon-lifecycle`, to stay within the `graph-db-server -> daemon-lifecycle` cross-package value-symbol budget.

## Verification

- Full pre-push tier-1 gate green on the Linux devbox, including `e2e-tier1` (electron smoke test) 1/1 pass and `systems-health` (coupling) within budget.

## Note

This is the diagnosed-and-real layer of the recent smoke-test failure. The smoke test additionally appears to fail only inside the sandboxed agent environment (per-process /tmp overlay isolation breaks the cross-process owner-record handshake); on the devbox and in CI it passes. That environmental issue is not a code bug and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)