### PR TITLE
chore: ignore brain submodule in ripgrep searches

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,4 @@
+# brain/ is a git submodule (~66MB markdown). .gitignore can't exclude it across
+# the submodule boundary, so ripgrep descends into brain's own (permissive) ignores
+# and searches all ~3000 markdown files — generating ~57% of all grep noise.
+/brain/


### PR DESCRIPTION
brain/ is a git submodule that .gitignore can't exclude across the submodule
boundary. Adding /brain/ to a root .ignore (ripgrep-native) drops brain/ hits
from 670 → 0 for `status`, reducing total noise by ~27–52% per keyword.
