### PR TITLE
feat(create_graph): gate node fan-out (>4 children) + graph complexity

### DIFF
--- a/packages/libraries/graph-model/src/pure/settings/settingsSchema.ts
+++ b/packages/libraries/graph-model/src/pure/settings/settingsSchema.ts
@@ -1,5 +1,5 @@
 import type { VTSettings, HotkeySettings, AgentConfig, HookSettings, EnvVarValue } from './types';
-import { DEFAULT_SUBGRAPH_WARN_THRESHOLD, DEFAULT_SUBGRAPH_ERROR_THRESHOLD } from './types';
+import { DEFAULT_SUBGRAPH_WARN_THRESHOLD, DEFAULT_SUBGRAPH_ERROR_THRESHOLD, DEFAULT_MAX_CHILDREN_PER_NODE, DEFAULT_COMPLEXITY_WARN_SCORE, DEFAULT_COMPLEXITY_BLOCK_SCORE } from './types';
 
 // ============================================================================
 // Types
@@ -186,6 +186,9 @@ export function createSettingsSchema(runtime: SettingsRuntime = {}): SettingsSch
     nodeLineLimit:          { default: 80,  label: 'Node Line Limit',    number: { min: 20, max: 200, step: 10 } },
     subgraphWarnThreshold:  { default: DEFAULT_SUBGRAPH_WARN_THRESHOLD,  section: 'general', label: 'Subgraph Warn Threshold',  number: { min: 2, max: 20, step: 1 } },
     subgraphErrorThreshold: { default: DEFAULT_SUBGRAPH_ERROR_THRESHOLD, section: 'general', label: 'Subgraph Block Threshold', number: { min: 3, max: 30, step: 1 } },
+    maxChildrenPerNode:     { default: DEFAULT_MAX_CHILDREN_PER_NODE,     section: 'general', label: 'Max Children Per Node',    number: { min: 2, max: 20, step: 1 } },
+    complexityWarnScore:    { default: DEFAULT_COMPLEXITY_WARN_SCORE,     section: 'general', label: 'Graph Complexity Warn Score',  number: { min: 0.3, max: 2, step: 0.1 } },
+    complexityBlockScore:   { default: DEFAULT_COMPLEXITY_BLOCK_SCORE,    section: 'general', label: 'Graph Complexity Block Score', number: { min: 0.5, max: 3, step: 0.1 } },
 
     // ── Hidden (not shown in UI — rendered inside agent-list field) ──────
     defaultAgent:              { hidden: true },

--- a/packages/libraries/graph-model/src/pure/settings/types.ts
+++ b/packages/libraries/graph-model/src/pure/settings/types.ts
@@ -91,6 +91,23 @@ export interface HookSettings {
 export const DEFAULT_SUBGRAPH_WARN_THRESHOLD: number = 4;
 export const DEFAULT_SUBGRAPH_ERROR_THRESHOLD: number = 6;
 
+/**
+ * Default fan-out cap for the create_graph `child_count_limit` gate. A node with
+ * more than this many children reads as an unstructured star rather than a tree,
+ * so create_graph blocks (overridable) until the agent nests the children.
+ */
+export const DEFAULT_MAX_CHILDREN_PER_NODE: number = 4;
+
+/**
+ * Default thresholds for the create_graph `graph_complexity_limit` gate, applied
+ * to the L∞ complexity score (see graphComplexity.ts) of the destination-folder
+ * component after the batch lands. `warn` surfaces a non-blocking nudge; `block`
+ * (≈ the 'heavy' rating boundary of 1.0) blocks creation, overridable with a
+ * rationale.
+ */
+export const DEFAULT_COMPLEXITY_WARN_SCORE: number = 0.7;
+export const DEFAULT_COMPLEXITY_BLOCK_SCORE: number = 1.0;
+
 export interface VTSettings {
     readonly terminalSpawnPathRelativeToWatchedDirectory: string;
     readonly agents: readonly AgentConfig[];
@@ -143,6 +160,25 @@ export interface VTSettings {
      * agent splits the cluster into a sub-folder or justifies the exception (default: 6).
      */
     readonly subgraphErrorThreshold?: number;
+    /**
+     * Max children a single node may have before create_graph blocks (overridable
+     * with a rationale). Keeps the graph a navigable tree instead of a wide star
+     * (default: 4).
+     */
+    readonly maxChildrenPerNode?: number;
+    /**
+     * Graph-complexity warn score: when the destination-folder component's L∞
+     * complexity score reaches this, create_graph returns a non-blocking warning
+     * (default: 0.7).
+     */
+    readonly complexityWarnScore?: number;
+    /**
+     * Graph-complexity block score: when the destination-folder component's L∞
+     * complexity score reaches this, create_graph blocks (overridable with a
+     * rationale) so the agent restructures the cluster (default: 1.0, the 'heavy'
+     * rating boundary).
+     */
+    readonly complexityBlockScore?: number;
     /** Starred folder paths that appear as quick-load recommendations across all projects */
     readonly starredFolders?: readonly string[];
     /** Hook scripts triggered by app events (e.g., worktree creation) */

--- a/packages/libraries/graph-model/src/settings.ts
+++ b/packages/libraries/graph-model/src/settings.ts
@@ -1,6 +1,6 @@
 export type { VTSettings, AgentConfig, EnvVarValue, HotkeyModifier, HotkeyBinding, HotkeySettings, HookSettings, ProjectConfig, VoiceTreeConfig, TerminalScrollStrategy } from './pure/settings/types'
 export { getUniqueAgentName } from './pure/settings/types'
-export { DEFAULT_SUBGRAPH_WARN_THRESHOLD, DEFAULT_SUBGRAPH_ERROR_THRESHOLD } from './pure/settings/types'
+export { DEFAULT_SUBGRAPH_WARN_THRESHOLD, DEFAULT_SUBGRAPH_ERROR_THRESHOLD, DEFAULT_MAX_CHILDREN_PER_NODE, DEFAULT_COMPLEXITY_WARN_SCORE, DEFAULT_COMPLEXITY_BLOCK_SCORE } from './pure/settings/types'
 export { AGENT_NAMES, getNextAgentName, getDefaultAgent } from './pure/settings/types'
 export {
     type Persona,

--- a/packages/measures/budgets/complexity/runtime-fan-in.json
+++ b/packages/measures/budgets/complexity/runtime-fan-in.json
@@ -1,3 +1,4 @@
 {
-  "max": 117
+  "max": 120,
+  "note": "2026-06-03: 117 -> 120 (+3). graph-model is the top fan-in package; the create_graph child_count_limit + graph_complexity_limit gates added 3 tunable settings defaults (DEFAULT_MAX_CHILDREN_PER_NODE, DEFAULT_COMPLEXITY_WARN_SCORE, DEFAULT_COMPLEXITY_BLOCK_SCORE) imported by createGraphTool."
 }

--- a/packages/measures/budgets/coupling/cross-package-value-symbol-budgets.ts
+++ b/packages/measures/budgets/coupling/cross-package-value-symbol-budgets.ts
@@ -188,6 +188,12 @@
 // `src/`), not new coupling. Mirrors the existing sanctioned real-daemon-booting
 // leaves `voicetree-bootcamp -> graph-db-client: 1` and `vt-daemon ->
 // graph-db-client: 1`. Should not grow.
+//
+// 2026-06-03: the create_graph child_count_limit + graph_complexity_limit gates:
+//   vt-daemon -> graph-tools: 7 -> 8 (+1 computeGraphComplexity, the same
+//     measure `vt graph complexity` runs, applied to the destination cluster)
+//   vt-daemon -> graph-model: 24 -> 27 (+3 the gates' tunable settings defaults
+//     DEFAULT_MAX_CHILDREN_PER_NODE / _COMPLEXITY_WARN_SCORE / _COMPLEXITY_BLOCK_SCORE)
 export const CROSS_PACKAGE_VALUE_SYMBOL_BUDGETS: Readonly<Record<string, number>> = {
     'app-config -> graph-model': 4,
     'daemon-test-harness -> graph-db-client': 2,
@@ -321,13 +327,13 @@ export const CROSS_PACKAGE_VALUE_SYMBOL_BUDGETS: Readonly<Record<string, number>
     // buildTerminalEnvVars adds appendPersonaToAgentPrompt; the roster/lookup/
     // render internals stay inside graph-model so the daemon depends on one new
     // symbol, not three.
-    'vt-daemon -> graph-model': 24,
+    'vt-daemon -> graph-model': 27,
     // 2026-05-27 [Phase 3]: daemon owns live-command dispatch + state
     // hydration post-BF-379. Three value symbols: `applyCommandWithDelta`,
     // `hydrateCommand`, `serializeState` (all wire shapes formerly evaluated
     // in webapp's process).
     'vt-daemon -> graph-state': 3,
-    'vt-daemon -> graph-tools': 7,
+    'vt-daemon -> graph-tools': 8,
     'vt-daemon -> observability': 10,
     'vt-daemon -> paths': 4,
     'vt-daemon -> voicetree-graph-validation': 1,

--- a/packages/systems/voicetree-graph-validation/src/overridableRules.ts
+++ b/packages/systems/voicetree-graph-validation/src/overridableRules.ts
@@ -8,7 +8,7 @@
  * Pure types + a frozen const literal — no runtime dependencies.
  */
 
-export const OVERRIDABLE_RULE_IDS = ['grandparent_attachment', 'node_line_limit', 'node_must_have_edge', 'subgraph_size_limit'] as const
+export const OVERRIDABLE_RULE_IDS = ['grandparent_attachment', 'node_line_limit', 'node_must_have_edge', 'subgraph_size_limit', 'child_count_limit', 'graph_complexity_limit'] as const
 export type OverridableRuleId = typeof OVERRIDABLE_RULE_IDS[number]
 
 export interface OverrideEntry {

--- a/packages/systems/vt-daemon/integration-tests/addProgressNodeMcp.validation.test.ts
+++ b/packages/systems/vt-daemon/integration-tests/addProgressNodeMcp.validation.test.ts
@@ -226,6 +226,93 @@ describe('MCP create_graph tool — validation + line length', () => {
     })
 })
 
+// ============================================================================
+// child-count + graph-complexity gates (real create_graph RPC, override bypass)
+// ============================================================================
+
+describe('MCP create_graph tool — child-count gate', () => {
+    // Raise the subgraph gate out of the way so only child_count_limit fires.
+    const SETTINGS = {subgraphWarnThreshold: 49, subgraphErrorThreshold: 50}
+
+    function nChildren(count: number): {filename: string; title: string; summary: string}[] {
+        return Array.from({length: count}, (_, i) => ({filename: `child-${i}`, title: `Child ${i}`, summary: 'S'}))
+    }
+
+    it('blocks when a node would exceed 4 children', async () => {
+        ({voicetreeHome, state, bridge} = await setupRealDeps({settings: SETTINGS}))
+
+        const response: McpToolResponse = await createGraphTool({
+            callerTerminalId: CALLER_TERMINAL_ID,
+            parentNodeId: 'parent-task',
+            nodes: nChildren(5),
+        }, bridge)
+        const payload: ErrorPayload = parsePayload(response) as ErrorPayload
+
+        expect(response.isError).toBe(true)
+        expect(payload.success).toBe(false)
+        expect(payload.error).toContain('child_count_limit')
+        expect(payload.error).toContain('5 children')
+        expect(state.deltas).toHaveLength(0) // nothing written
+    })
+
+    it('allows the 5th child through with an override_with_rationale', async () => {
+        ({voicetreeHome, state, bridge} = await setupRealDeps({settings: SETTINGS}))
+
+        const response: McpToolResponse = await createGraphTool({
+            callerTerminalId: CALLER_TERMINAL_ID,
+            parentNodeId: 'parent-task',
+            nodes: nChildren(5),
+            override_with_rationale: [{ruleId: 'child_count_limit', rationale: 'flat index node — children are siblings by design'}],
+        }, bridge)
+        const payload: SuccessPayload = parsePayload(response) as SuccessPayload
+
+        expect(payload.success).toBe(true)
+        expect(payload.nodes).toHaveLength(5)
+        expect(state.deltas.length).toBeGreaterThan(0) // deltas applied
+    })
+
+    it('allows exactly 4 children without an override', async () => {
+        ({voicetreeHome, state, bridge} = await setupRealDeps({settings: SETTINGS}))
+
+        const response: McpToolResponse = await createGraphTool({
+            callerTerminalId: CALLER_TERMINAL_ID,
+            parentNodeId: 'parent-task',
+            nodes: Array.from({length: 4}, (_, i) => ({filename: `child-${i}`, title: `Child ${i}`, summary: 'S'})),
+        }, bridge)
+        const payload: SuccessPayload = parsePayload(response) as SuccessPayload
+
+        expect(payload.success).toBe(true)
+        expect(payload.nodes).toHaveLength(4)
+    })
+})
+
+describe('MCP create_graph tool — graph-complexity gate', () => {
+    it('blocks when the destination cluster crosses the block score, bypassable with rationale', async () => {
+        // Low block score so any non-trivial structure trips the gate deterministically.
+        const SETTINGS = {complexityWarnScore: 0.05, complexityBlockScore: 0.1}
+        ;({voicetreeHome, state, bridge} = await setupRealDeps({settings: SETTINGS}))
+
+        const blocked: McpToolResponse = await createGraphTool({
+            callerTerminalId: CALLER_TERMINAL_ID,
+            parentNodeId: 'parent-task',
+            nodes: [{filename: 'n', title: 'N', summary: 'S'}],
+        }, bridge)
+        const blockedPayload: ErrorPayload = parsePayload(blocked) as ErrorPayload
+        expect(blocked.isError).toBe(true)
+        expect(blockedPayload.error).toContain('graph_complexity_limit')
+
+        ;({voicetreeHome, state, bridge} = await setupRealDeps({settings: SETTINGS}))
+        const allowed: McpToolResponse = await createGraphTool({
+            callerTerminalId: CALLER_TERMINAL_ID,
+            parentNodeId: 'parent-task',
+            nodes: [{filename: 'n', title: 'N', summary: 'S'}],
+            override_with_rationale: [{ruleId: 'graph_complexity_limit', rationale: 'inherently dense domain cluster'}],
+        }, bridge)
+        const allowedPayload: SuccessPayload = parsePayload(allowed) as SuccessPayload
+        expect(allowedPayload.success).toBe(true)
+    })
+})
+
 // Silence "unused" lint for buildGraph + WRITE_FOLDER imports — kept here so the
 // test file is self-contained when future cases want to swap the graph.
 void buildGraph

--- a/packages/systems/vt-daemon/src/create-graph/createGraphTool.ts
+++ b/packages/systems/vt-daemon/src/create-graph/createGraphTool.ts
@@ -20,7 +20,13 @@ import {slugify} from '../tools/graph/addProgressNodeTool'
 import {type McpToolResponse, buildJsonResponse} from '@vt/vt-daemon/_shared/toolResponse.ts'
 import {loadSettings} from '@vt/app-config/settings'
 import type {VTSettings} from '@vt/graph-model/settings'
-import {DEFAULT_SUBGRAPH_WARN_THRESHOLD, DEFAULT_SUBGRAPH_ERROR_THRESHOLD} from '@vt/graph-model/settings'
+import {
+    DEFAULT_SUBGRAPH_WARN_THRESHOLD,
+    DEFAULT_SUBGRAPH_ERROR_THRESHOLD,
+    DEFAULT_MAX_CHILDREN_PER_NODE,
+    DEFAULT_COMPLEXITY_WARN_SCORE,
+    DEFAULT_COMPLEXITY_BLOCK_SCORE,
+} from '@vt/graph-model/settings'
 import {
     type ValidationResult,
     type RuleViolation,
@@ -262,6 +268,9 @@ async function validateOverridableRules(
         lineLimit: settings.nodeLineLimit ?? 70,
         subgraphWarnThreshold: settings.subgraphWarnThreshold ?? DEFAULT_SUBGRAPH_WARN_THRESHOLD,
         subgraphErrorThreshold: settings.subgraphErrorThreshold ?? DEFAULT_SUBGRAPH_ERROR_THRESHOLD,
+        maxChildrenPerNode: settings.maxChildrenPerNode ?? DEFAULT_MAX_CHILDREN_PER_NODE,
+        complexityWarnScore: settings.complexityWarnScore ?? DEFAULT_COMPLEXITY_WARN_SCORE,
+        complexityBlockScore: settings.complexityBlockScore ?? DEFAULT_COMPLEXITY_BLOCK_SCORE,
         destinationFolderPath,
     })
     if (validationResult.status !== 'violations') return {error: null, warnings: []}

--- a/packages/systems/vt-daemon/src/create-graph/createGraphValidation.test.ts
+++ b/packages/systems/vt-daemon/src/create-graph/createGraphValidation.test.ts
@@ -474,3 +474,150 @@ describe('nodeMustHaveEdgeRule (via ALL_RULES)', () => {
         }
     })
 })
+
+// ============================================================================
+// child_count_limit rule
+// ============================================================================
+
+function childCountViolations(result: ValidationResult): readonly RuleViolation[] {
+    return result.status === 'violations'
+        ? result.violations.filter((v: RuleViolation) => v.ruleId === 'child_count_limit' && v.severity === 'violation')
+        : []
+}
+
+describe('child_count_limit rule', () => {
+    it('blocks when one parent gains more than the limit of children in a single batch', () => {
+        const graph: Graph = mockGraph(['/project/hub.md'])
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: Array.from({length: 5}, (_: unknown, i: number) =>
+                mockNode({filename: `child-${i}`, title: 'T', summary: 'S'})),
+            resolvedParentNodeId: '/project/hub.md',
+            graph,
+        }))
+        const violations: readonly RuleViolation[] = childCountViolations(result)
+        expect(violations).toHaveLength(1)
+        expect(violations[0].details.childCount).toBe(5)
+        expect(violations[0].details.limit).toBe(4)
+    })
+
+    it('counts existing children plus the batch (cross-batch accumulation)', () => {
+        const incomingEdges: Map<NodeIdAndFilePath, readonly NodeIdAndFilePath[]> = new Map([
+            ['/project/hub.md', ['/project/c1.md', '/project/c2.md', '/project/c3.md']],
+        ])
+        const graph: Graph = mockGraph(
+            ['/project/hub.md', '/project/c1.md', '/project/c2.md', '/project/c3.md'],
+            incomingEdges,
+        )
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: [
+                mockNode({filename: 'c4', title: 'T', summary: 'S'}),
+                mockNode({filename: 'c5', title: 'T', summary: 'S'}),
+            ],
+            resolvedParentNodeId: '/project/hub.md',
+            graph,
+        }))
+        const violations: readonly RuleViolation[] = childCountViolations(result)
+        expect(violations).toHaveLength(1)
+        expect(violations[0].details.existingChildren).toBe(3)
+        expect(violations[0].details.addedChildren).toBe(2)
+        expect(violations[0].details.childCount).toBe(5)
+    })
+
+    it('passes at exactly the limit', () => {
+        const incomingEdges: Map<NodeIdAndFilePath, readonly NodeIdAndFilePath[]> = new Map([
+            ['/project/hub.md', ['/project/c1.md', '/project/c2.md']],
+        ])
+        const graph: Graph = mockGraph(['/project/hub.md', '/project/c1.md', '/project/c2.md'], incomingEdges)
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: [
+                mockNode({filename: 'c3', title: 'T', summary: 'S'}),
+                mockNode({filename: 'c4', title: 'T', summary: 'S'}),
+            ],
+            resolvedParentNodeId: '/project/hub.md',
+            graph,
+        }))
+        expect(childCountViolations(result)).toHaveLength(0)
+    })
+
+    it('counts an in-batch parent gaining many children', () => {
+        const graph: Graph = mockGraph(['/project/root.md'])
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: [
+                mockNode({filename: 'hub', title: 'T', summary: 'S'}),
+                ...Array.from({length: 5}, (_: unknown, i: number) =>
+                    mockNode({filename: `leaf-${i}`, title: 'T', summary: 'S', content: '- parent [[hub]]'})),
+            ],
+            resolvedParentNodeId: '/project/root.md',
+            graph,
+        }))
+        const violations: readonly RuleViolation[] = childCountViolations(result)
+        expect(violations).toHaveLength(1)
+        expect(violations[0].details.parent).toBe('hub')
+        expect(violations[0].details.childCount).toBe(5)
+    })
+
+    it('exempts folder identity notes (containers hold many children by design)', () => {
+        const folderNote: NodeIdAndFilePath = '/project/foo/foo.md'
+        const graph: Graph = mockGraph([folderNote])
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: Array.from({length: 8}, (_: unknown, i: number) =>
+                mockNode({filename: `child-${i}`, title: 'T', summary: 'S'})),
+            resolvedParentNodeId: folderNote,
+            graph,
+        }))
+        expect(childCountViolations(result)).toHaveLength(0)
+    })
+
+    it('is overridable with a rationale', () => {
+        const graph: Graph = mockGraph(['/project/hub.md'])
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: Array.from({length: 6}, (_: unknown, i: number) =>
+                mockNode({filename: `child-${i}`, title: 'T', summary: 'S'})),
+            resolvedParentNodeId: '/project/hub.md',
+            graph,
+        }))
+        const blocking: readonly RuleViolation[] = childCountViolations(result)
+        const overrides: readonly OverrideEntry[] = [{ruleId: 'child_count_limit', rationale: 'flat index node'}]
+        const {unresolved} = resolveOverrides(blocking, overrides)
+        expect(unresolved).toHaveLength(0)
+    })
+})
+
+// ============================================================================
+// graph_complexity_limit rule
+// ============================================================================
+
+describe('graph_complexity_limit rule', () => {
+    it('does not block a small clean batch under default thresholds', () => {
+        const graph: Graph = mockGraph(['/project/task.md'])
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: [mockNode({filename: 'n', title: 'T', summary: 'S'})],
+            resolvedParentNodeId: '/project/task.md',
+            graph,
+        }))
+        const blocking: readonly RuleViolation[] = result.status === 'violations'
+            ? result.violations.filter((v: RuleViolation) => v.ruleId === 'graph_complexity_limit' && v.severity === 'violation')
+            : []
+        expect(blocking).toHaveLength(0)
+    })
+
+    it('blocks (overridable) once the destination cluster crosses the block score', () => {
+        const graph: Graph = mockGraph(['/project/p.md'])
+        const result: ValidationResult = runValidations(ALL_RULES, buildCtx({
+            nodes: [mockNode({filename: 'n', title: 'T', summary: 'S'})],
+            resolvedParentNodeId: '/project/p.md',
+            graph,
+            complexityBlockScore: 0.1,
+            complexityWarnScore: 0.05,
+        }))
+        const blocking: readonly RuleViolation[] = result.status === 'violations'
+            ? result.violations.filter((v: RuleViolation) => v.ruleId === 'graph_complexity_limit' && v.severity === 'violation')
+            : []
+        expect(blocking).toHaveLength(1)
+        expect(typeof blocking[0].details.score).toBe('number')
+
+        const overrides: readonly OverrideEntry[] = [{ruleId: 'graph_complexity_limit', rationale: 'inherently dense domain'}]
+        const {unresolved} = resolveOverrides(blocking, overrides)
+        expect(unresolved).toHaveLength(0)
+    })
+})

--- a/packages/systems/vt-daemon/src/create-graph/createGraphValidation.testHelpers.ts
+++ b/packages/systems/vt-daemon/src/create-graph/createGraphValidation.testHelpers.ts
@@ -4,7 +4,13 @@
  */
 
 import type {Graph, GraphNode, NodeIdAndFilePath, Position} from '@vt/graph-model/graph'
-import {DEFAULT_SUBGRAPH_WARN_THRESHOLD, DEFAULT_SUBGRAPH_ERROR_THRESHOLD} from '@vt/graph-model/settings'
+import {
+    DEFAULT_SUBGRAPH_WARN_THRESHOLD,
+    DEFAULT_SUBGRAPH_ERROR_THRESHOLD,
+    DEFAULT_MAX_CHILDREN_PER_NODE,
+    DEFAULT_COMPLEXITY_WARN_SCORE,
+    DEFAULT_COMPLEXITY_BLOCK_SCORE,
+} from '@vt/graph-model/settings'
 import type {CreateGraphNodeInput} from './createGraphTypes'
 import type {ValidationContext} from './createGraphValidation'
 
@@ -59,6 +65,9 @@ export function buildCtx(
         lineLimit: overrides.lineLimit ?? 70,
         subgraphWarnThreshold: overrides.subgraphWarnThreshold ?? DEFAULT_SUBGRAPH_WARN_THRESHOLD,
         subgraphErrorThreshold: overrides.subgraphErrorThreshold ?? DEFAULT_SUBGRAPH_ERROR_THRESHOLD,
+        maxChildrenPerNode: overrides.maxChildrenPerNode ?? DEFAULT_MAX_CHILDREN_PER_NODE,
+        complexityWarnScore: overrides.complexityWarnScore ?? DEFAULT_COMPLEXITY_WARN_SCORE,
+        complexityBlockScore: overrides.complexityBlockScore ?? DEFAULT_COMPLEXITY_BLOCK_SCORE,
         destinationFolderPath: overrides.destinationFolderPath ?? '',
     }
 }

--- a/packages/systems/vt-daemon/src/create-graph/createGraphValidation.ts
+++ b/packages/systems/vt-daemon/src/create-graph/createGraphValidation.ts
@@ -9,9 +9,11 @@
 
 import type {CreateGraphNodeInput} from './createGraphTypes'
 import type {Graph, NodeIdAndFilePath} from '@vt/graph-model/graph'
-import {extractParentRefs} from '@vt/graph-model/markdown'
+import {isFolderIdentityNote} from '@vt/graph-model/graph'
+import {extractParentRefs, normalizeBatchFilenameKey, findBestMatchingNode, type ParentLineRef} from '@vt/graph-model/markdown'
+import {computeGraphComplexity, type EdgePair, type GraphComplexityResult} from '@vt/graph-tools/node'
 import {countBodyLines} from '../tools/graph/addProgressNodeTool'
-import {countFolderBoundedComponent} from './subgraphComponent'
+import {countFolderBoundedComponent, collectFolderBoundedComponent} from './subgraphComponent'
 import * as daemonProtocol from '@vt/vt-daemon-protocol'
 import {
     type OverridableRuleId,
@@ -54,6 +56,12 @@ export interface ValidationContext {
     readonly lineLimit: number
     readonly subgraphWarnThreshold: number
     readonly subgraphErrorThreshold: number
+    /** Max children a single node may have before child_count_limit blocks. */
+    readonly maxChildrenPerNode: number
+    /** Destination-component complexity score that triggers a non-blocking warning. */
+    readonly complexityWarnScore: number
+    /** Destination-component complexity score that blocks (overridable). */
+    readonly complexityBlockScore: number
     /**
      * The folder (id with trailing slash) the batch's nodes will land in — the
      * component the subgraph_size_limit rule gardens. See design.md Decision 1a.
@@ -357,12 +365,235 @@ const subgraphSizeLimitRule: ValidationRule = {
     },
 }
 
+// ----------------------------------------------------------------------------
+// Shared parent-resolution helpers (child_count_limit + graph_complexity_limit)
+// ----------------------------------------------------------------------------
+
+function baseNameOf(nodeId: string): string {
+    return nodeId.split('/').pop()?.replace(/\.md$/, '') ?? nodeId
+}
+
+/** Distinct in-batch parent refs of a node (deduped by normalized filename). */
+function parentRefsOf(node: CreateGraphNodeInput): readonly ParentLineRef[] {
+    const refs: readonly ParentLineRef[] = extractParentRefs(node.content ?? '')
+    const seen: Set<string> = new Set()
+    const unique: ParentLineRef[] = []
+    for (const ref of refs) {
+        const key: string = normalizeBatchFilenameKey(ref.filename)
+        if (seen.has(key)) continue
+        seen.add(key)
+        unique.push(ref)
+    }
+    return unique
+}
+
+interface ResolvedParent {
+    /** Stable identity used to tally children across the batch + graph. */
+    readonly key: string
+    /** The matching graph node id, if this parent already exists in the graph. */
+    readonly graphNodeId: NodeIdAndFilePath | undefined
+    /** Human-readable name for messages. */
+    readonly displayName: string
+}
+
+/**
+ * Resolve a parent-line ref to a stable tally key: an in-batch sibling
+ * (`batch:<key>`), an existing graph node (its id), or an unresolved target
+ * (`unresolved:<key>`). Mirrors createGraphBatch's resolveParentLinks lookup so
+ * the gate counts the same edges the batch will author.
+ */
+function resolveParentRef(
+    ref: ParentLineRef,
+    ctx: ValidationContext,
+    batchKeys: ReadonlySet<string>,
+): ResolvedParent {
+    const refKey: string = normalizeBatchFilenameKey(ref.filename)
+    if (batchKeys.has(refKey)) {
+        return {key: `batch:${refKey}`, graphNodeId: undefined, displayName: baseNameOf(ref.filename)}
+    }
+    const resolved: NodeIdAndFilePath | undefined =
+        findBestMatchingNode(ref.filename, ctx.graph.nodes, ctx.graph.nodeByBaseName)
+    if (resolved && ctx.graph.nodes[resolved]) {
+        return {key: resolved, graphNodeId: resolved, displayName: baseNameOf(resolved)}
+    }
+    return {key: `unresolved:${refKey}`, graphNodeId: undefined, displayName: baseNameOf(ref.filename)}
+}
+
+/** Resolve every parent a batch node attaches to (fallback graph-parent when none authored). */
+function resolvedParentsOf(
+    node: CreateGraphNodeInput,
+    ctx: ValidationContext,
+    batchKeys: ReadonlySet<string>,
+): readonly ResolvedParent[] {
+    const refs: readonly ParentLineRef[] = parentRefsOf(node)
+    if (refs.length === 0) {
+        return [{
+            key: ctx.resolvedParentNodeId,
+            graphNodeId: ctx.resolvedParentNodeId,
+            displayName: baseNameOf(ctx.resolvedParentNodeId),
+        }]
+    }
+    return refs.map((ref: ParentLineRef) => resolveParentRef(ref, ctx, batchKeys))
+}
+
+/** Existing children of a node = nodes whose edges point to it (its incoming edges). */
+function existingChildCount(graph: Graph, nodeId: NodeIdAndFilePath): number {
+    return (graph.incomingEdgesIndex.get(nodeId) ?? []).length
+}
+
+/** Folders and context nodes legitimately hold many children — never limited. */
+function isExemptParent(graph: Graph, nodeId: NodeIdAndFilePath): boolean {
+    if (isFolderIdentityNote(nodeId)) return true
+    return graph.nodes[nodeId]?.nodeUIMetadata.isContextNode === true
+}
+
+/**
+ * Child-count limit rule: no single parent should gain so many children that the
+ * graph becomes an unstructured star instead of a navigable tree. Counts each
+ * parent's post-insertion children (existing incoming edges + children authored
+ * in this batch) and blocks (overridable) any parent over the limit. Folder
+ * notes and context nodes are exempt — they are containers by design.
+ */
+const childCountLimitRule: ValidationRule = {
+    id: 'child_count_limit',
+    description: 'No node may exceed the configured number of children (overridable) — build trees, not wide stars.',
+    check(ctx: ValidationContext): readonly RuleViolation[] {
+        const batchKeys: ReadonlySet<string> =
+            new Set(ctx.nodes.map((n: CreateGraphNodeInput) => normalizeBatchFilenameKey(n.filename)))
+
+        interface Tally {added: number; existing: number; exempt: boolean; name: string}
+        const tallies: Map<string, Tally> = new Map()
+
+        for (const node of ctx.nodes) {
+            for (const parent of resolvedParentsOf(node, ctx, batchKeys)) {
+                let tally: Tally | undefined = tallies.get(parent.key)
+                if (!tally) {
+                    tally = {
+                        added: 0,
+                        existing: parent.graphNodeId ? existingChildCount(ctx.graph, parent.graphNodeId) : 0,
+                        exempt: parent.graphNodeId ? isExemptParent(ctx.graph, parent.graphNodeId) : false,
+                        name: parent.displayName,
+                    }
+                    tallies.set(parent.key, tally)
+                }
+                tally.added++
+            }
+        }
+
+        const violations: RuleViolation[] = []
+        for (const [, tally] of tallies) {
+            if (tally.exempt) continue
+            const total: number = tally.existing + tally.added
+            if (total > ctx.maxChildrenPerNode) {
+                violations.push({
+                    ruleId: 'child_count_limit',
+                    message: `Node "${tally.name}" would have ${total} children (limit ${ctx.maxChildrenPerNode}). Build a TREE: group these under intermediate nodes (declare \`- parent [[intermediate-node]]\`) instead of attaching them all to one parent.`,
+                    nodeFilename: '__graph_root__',
+                    severity: 'violation',
+                    details: {
+                        parent: tally.name,
+                        childCount: total,
+                        existingChildren: tally.existing,
+                        addedChildren: tally.added,
+                        limit: ctx.maxChildrenPerNode,
+                    },
+                })
+            }
+        }
+        return violations
+    },
+}
+
+/**
+ * Build the post-insertion edge list (directed child→parent, matching
+ * `vt graph complexity`'s loadProjectGraph) over the destination-folder
+ * component plus the batch's new nodes. Edges to nodes outside the considered
+ * set are dropped so the measure reflects the local cluster only.
+ */
+function buildComponentComplexity(ctx: ValidationContext): GraphComplexityResult {
+    const componentIds: ReadonlySet<NodeIdAndFilePath> =
+        collectFolderBoundedComponent(ctx.graph, ctx.resolvedParentNodeId, ctx.destinationFolderPath)
+    const batchKeys: ReadonlySet<string> =
+        new Set(ctx.nodes.map((n: CreateGraphNodeInput) => normalizeBatchFilenameKey(n.filename)))
+    const newNodeKey = (filename: string): string => `batch:${normalizeBatchFilenameKey(filename)}`
+
+    const nodeIdSet: Set<string> = new Set<string>([...componentIds, ctx.resolvedParentNodeId])
+    for (const node of ctx.nodes) nodeIdSet.add(newNodeKey(node.filename))
+
+    const edges: EdgePair[] = []
+    // Existing edges among the component (and the seed parent) that stay in-set.
+    const existingSources: Set<string> = new Set<string>([...componentIds, ctx.resolvedParentNodeId])
+    for (const id of existingSources) {
+        for (const edge of ctx.graph.nodes[id]?.outgoingEdges ?? []) {
+            if (edge.targetId !== id && nodeIdSet.has(edge.targetId)) {
+                edges.push({src: id, tgt: edge.targetId})
+            }
+        }
+    }
+    // New edges this batch authors (child→parent), keyed to match nodeIdSet.
+    for (const node of ctx.nodes) {
+        const src: string = newNodeKey(node.filename)
+        for (const parent of resolvedParentsOf(node, ctx, batchKeys)) {
+            const tgt: string = parent.graphNodeId ?? parent.key
+            if (tgt !== src && nodeIdSet.has(tgt)) edges.push({src, tgt})
+        }
+    }
+
+    return computeGraphComplexity([...nodeIdSet], edges)
+}
+
+/**
+ * Graph-complexity limit rule: runs the same complexity measure as
+ * `vt graph complexity` over the destination-folder component (after this batch
+ * lands) and pushes back as the cluster gets harder to comprehend — a
+ * non-blocking warning at `complexityWarnScore`, an overridable block at
+ * `complexityBlockScore` (≈ the 'heavy' boundary). Catches tangled/mesh growth
+ * that the per-parent child_count_limit (a single hub) does not.
+ */
+const graphComplexityLimitRule: ValidationRule = {
+    id: 'graph_complexity_limit',
+    description: 'The destination cluster\'s graph-complexity score must stay below the configured block threshold (overridable).',
+    check(ctx: ValidationContext): readonly RuleViolation[] {
+        const result: GraphComplexityResult = buildComponentComplexity(ctx)
+        const folderName: string = folderNameOf(ctx.destinationFolderPath)
+        const details: Record<string, unknown> = {
+            folder: ctx.destinationFolderPath,
+            folderName,
+            score: result.score,
+            rating: result.rating,
+            cyclic: result.cyclic,
+            warnScore: ctx.complexityWarnScore,
+            blockScore: ctx.complexityBlockScore,
+        }
+
+        if (result.score >= ctx.complexityBlockScore) {
+            return [{
+                ruleId: 'graph_complexity_limit',
+                message: `Cluster "${folderName}" would reach complexity score ${result.score} (${result.rating.toUpperCase()}), at or above the block threshold ${ctx.complexityBlockScore}. Restructure the cluster — split it into sub-folders, reduce cross-links, or flatten redundant branching — so it stays comprehensible.`,
+                nodeFilename: '__graph_root__',
+                severity: 'violation',
+                details,
+            }]
+        }
+        if (result.score >= ctx.complexityWarnScore) {
+            return [{
+                ruleId: 'graph_complexity_limit',
+                message: `Cluster "${folderName}" complexity is ${result.score} (${result.rating}, warn ${ctx.complexityWarnScore}, block ${ctx.complexityBlockScore}). Consider simplifying its structure before it grows harder to navigate.`,
+                nodeFilename: '__graph_root__',
+                severity: 'warning',
+                details,
+            }]
+        }
+        return []
+    },
+}
+
 // ============================================================================
 // Export
 // ============================================================================
 
 function createValidationRules(): readonly ValidationRule[] {
-    return [grandparentAttachmentRule, nodeLineLimitRule, nodeMustHaveEdgeRule, subgraphSizeLimitRule]
+    return [grandparentAttachmentRule, nodeLineLimitRule, nodeMustHaveEdgeRule, subgraphSizeLimitRule, childCountLimitRule, graphComplexityLimitRule]
 }
 
 export const ALL_RULES: readonly ValidationRule[] = createValidationRules()

--- a/packages/systems/vt-daemon/src/create-graph/subgraphComponent.ts
+++ b/packages/systems/vt-daemon/src/create-graph/subgraphComponent.ts
@@ -43,19 +43,22 @@ function isCountedMember(
 }
 
 /**
- * Size of the folder-bounded, undirected, hard-edge component reachable from
- * `startNodeId`, bounded to `folderPath` (a folder id with a trailing slash).
+ * The folder-bounded, undirected, hard-edge component reachable from
+ * `startNodeId`, bounded to `folderPath` (a folder id with a trailing slash),
+ * returned as the set of *counted members* (the destination folder's own
+ * identity note excluded; neighbouring folder notes included as collapsed
+ * single units).
  *
  * The seed may itself sit outside `folderPath` (e.g. a task node parenting a
- * worktree folder); it bridges into the folder but is only counted if it belongs
- * to the folder. This makes the result the size of the destination cluster that
- * is actually growing, independent of where the parent lives.
+ * worktree folder); it bridges into the folder but is only included if it
+ * belongs to the folder. This makes the result the destination cluster that is
+ * actually growing, independent of where the parent lives.
  */
-export function countFolderBoundedComponent(
+export function collectFolderBoundedComponent(
     graph: Graph,
     startNodeId: NodeIdAndFilePath,
     folderPath: string,
-): number {
+): ReadonlySet<NodeIdAndFilePath> {
     const destinationIdentityNote: NodeIdAndFilePath = getFolderIdentityNoteId(folderPath)
 
     const seen: Set<NodeIdAndFilePath> = new Set([startNodeId])
@@ -77,9 +80,22 @@ export function countFolderBoundedComponent(
         }
     }
 
-    let count: number = 0
+    const members: Set<NodeIdAndFilePath> = new Set()
     for (const nodeId of seen) {
-        if (isCountedMember(nodeId, folderPath, destinationIdentityNote)) count++
+        if (isCountedMember(nodeId, folderPath, destinationIdentityNote)) members.add(nodeId)
     }
-    return count
+    return members
+}
+
+/**
+ * Size of the folder-bounded component reachable from `startNodeId` (see
+ * {@link collectFolderBoundedComponent}). No IO, no settings — post-insertion
+ * arithmetic (adding the batch size) is the caller's job (BF-446).
+ */
+export function countFolderBoundedComponent(
+    graph: Graph,
+    startNodeId: NodeIdAndFilePath,
+    folderPath: string,
+): number {
+    return collectFolderBoundedComponent(graph, startNodeId, folderPath).size
 }


### PR DESCRIPTION
Add two overridable soft-rules to the daemon create_graph ALL_RULES, both
bypassable via override_with_rationale exactly like subgraph_size_limit:

- child_count_limit: blocks when a parent would exceed maxChildrenPerNode
  (default 4) post-insertion (existing incoming edges + children authored in
  the batch). Folder identity notes and context nodes are exempt (containers
  by design). Nudges the agent to build a tree via intermediate nodes.
- graph_complexity_limit: runs the same computeGraphComplexity measure as
  `vt graph complexity` over the destination-folder component after the batch
  lands. Warn at complexityWarnScore (0.7), overridable block at
  complexityBlockScore (1.0, the 'heavy' boundary). Scoped to the local
  cluster so pre-existing heaviness elsewhere never blocks an unrelated create.

The two are complementary: the complexity measure hub-discounts a single
fan-out (a star), so child_count_limit catches the star while complexity
catches tangled mesh/treewidth growth.

All thresholds are tunable in settings. Verified end-to-end through the real
create_graph RPC (integration tests): 5th child blocked + rationale bypass,
exactly-4 passes, complexity block + bypass. 39 validation unit tests + 16
integration tests; typecheck + coupling-budget gates green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
