### PR TITLE
feat(agent-runtime): add vt agent resume

### DIFF
--- a/packages/systems/voicetree-cli/src/commands/runtime/agent.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agent.ts
@@ -1,10 +1,12 @@
 import {requireTerminalId} from '../graph/core/args'
 import {callDaemon} from '../daemon-client'
 import {error, output} from '../output'
+import {formatResumeResult, type ResumeOutcome} from './agentResumeFormat'
 import {
     AGENT_CLOSE_SPEC,
     AGENT_LIST_SPEC,
     AGENT_OUTPUT_SPEC,
+    AGENT_RESUME_SPEC,
     AGENT_SEND_SPEC,
     AGENT_SPAWN_SPEC,
     AGENT_WAIT_SPEC,
@@ -377,6 +379,36 @@ export async function agentClose(
     )
 
     output(payload, formatStandardResponse)
+}
+
+export async function agentResume(
+    _terminalId: string | undefined,
+    args: string[]
+): Promise<void> {
+    if (isHelpRequest(args)) {
+        printHelp(AGENT_RESUME_SPEC)
+        return
+    }
+
+    const parsedArgs: ParsedArgs = parseArgs(args, AGENT_RESUME_SPEC)
+
+    if (parsedArgs.positionals.length !== 1) {
+        error('`agent resume` requires exactly one target terminal ID')
+    }
+
+    const targetTerminalId: string = parsedArgs.positionals[0]
+    const payload: unknown = await callDaemon('resumePersistedAgentSession', {terminalId: targetTerminalId})
+    const record: JsonRecord | undefined = asRecord(payload)
+    if (!record) {
+        error('Voicetree daemon returned an unexpected payload')
+    }
+
+    const outcome: ResumeOutcome = formatResumeResult(targetTerminalId, record)
+    if (!outcome.ok) {
+        error(outcome.message)
+    }
+
+    output(record, (): string => outcome.message)
 }
 
 export async function agentSend(

--- a/packages/systems/voicetree-cli/src/commands/runtime/agentResume.test.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agentResume.test.ts
@@ -1,0 +1,116 @@
+import {afterEach, describe, expect, it, vi, type MockInstance} from 'vitest'
+import {formatResumeResult, type ResumeOutcome} from './agentResumeFormat.ts'
+import {agentResume} from './agent.ts'
+import {CliError} from '../output.ts'
+
+// `formatResumeResult` is the pure heart of `vt agent resume`: it maps a
+// `ResumePersistedResult` payload (discriminated on `kind`) to the single line
+// the user sees and whether the resume succeeded. We test it as a black box —
+// record in, `{ok, message}` out — rather than mocking `callDaemon`, per the
+// repo's functional-design / no-internal-mock rule.
+describe('formatResumeResult — result-kind formatting', () => {
+    it('maps `spawned` to an ok line naming the pid and command', () => {
+        const outcome: ResumeOutcome = formatResumeResult('Amit', {
+            kind: 'spawned',
+            pid: 4242,
+            command: 'claude --resume abc123',
+        })
+        expect(outcome.ok).toBe(true)
+        expect(outcome.message).toContain('Amit')
+        expect(outcome.message).toContain('4242')
+        expect(outcome.message).toContain('claude --resume abc123')
+    })
+
+    it.each([
+        ['already-claimed', /already holds this terminal/],
+        ['no-resume-handle', /no resume handle/],
+        ['not-in-discovery', /no recoverable session is in discovery/],
+    ])('maps `stale` reason %s to a non-ok line', (reason, matcher) => {
+        const outcome: ResumeOutcome = formatResumeResult('Amit', {kind: 'stale', reason})
+        expect(outcome.ok).toBe(false)
+        expect(outcome.message).toMatch(matcher)
+        expect(outcome.message).toContain('Amit')
+    })
+
+    it('maps `no-native-session` to a non-ok line naming the CLI and reason', () => {
+        const outcome: ResumeOutcome = formatResumeResult('Amit', {
+            kind: 'no-native-session',
+            cliType: 'claude',
+            reason: 'no-transcript-found',
+        })
+        expect(outcome.ok).toBe(false)
+        expect(outcome.message).toContain('claude')
+        expect(outcome.message).toContain('no-transcript-found')
+    })
+
+    it('includes the diagnostic session id when present', () => {
+        const outcome: ResumeOutcome = formatResumeResult('Amit', {
+            kind: 'no-native-session',
+            cliType: 'codex',
+            reason: 'ambiguous-match',
+            diagnosticSessionId: 'sess-99',
+        })
+        expect(outcome.message).toContain('sess-99')
+    })
+
+    it('maps `unsupported` to a non-ok line naming the reason', () => {
+        const outcome: ResumeOutcome = formatResumeResult('Amit', {
+            kind: 'unsupported',
+            reason: 'gemini-not-supported',
+        })
+        expect(outcome.ok).toBe(false)
+        expect(outcome.message).toContain('gemini-not-supported')
+    })
+
+    it('maps `spawn-failed` to a non-ok line carrying the error detail', () => {
+        const outcome: ResumeOutcome = formatResumeResult('Amit', {
+            kind: 'spawn-failed',
+            error: 'tmux session create failed',
+        })
+        expect(outcome.ok).toBe(false)
+        expect(outcome.message).toContain('tmux session create failed')
+    })
+
+    it('degrades an unrecognised kind to a non-ok line instead of throwing', () => {
+        const outcome: ResumeOutcome = formatResumeResult('Amit', {kind: 'who-knows'})
+        expect(outcome.ok).toBe(false)
+        expect(outcome.message).toContain('who-knows')
+    })
+})
+
+// Arg parsing runs entirely before any daemon call, so these paths need no
+// network: a wrong positional count rejects, and `--help` prints usage and
+// returns. Both observable via thrown CliError / captured stdout.
+describe('agentResume — argument parsing', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('rejects when no terminal id is given', async () => {
+        await expect(agentResume(undefined, [])).rejects.toBeInstanceOf(CliError)
+    })
+
+    it('rejects when more than one positional is given', async () => {
+        await expect(agentResume(undefined, ['a', 'b'])).rejects.toBeInstanceOf(CliError)
+    })
+
+    it('rejects an unknown flag before reaching the daemon', async () => {
+        await expect(agentResume(undefined, ['Amit', '--bogus'])).rejects.toBeInstanceOf(CliError)
+    })
+
+    it('prints usage for --help and returns without contacting the daemon', async () => {
+        const logged: string[] = []
+        const logSpy: MockInstance = vi
+            .spyOn(console, 'log')
+            .mockImplementation((...values: unknown[]): void => {
+                logged.push(values.map((value: unknown): string => String(value)).join(' '))
+            })
+
+        await agentResume(undefined, ['--help'])
+
+        logSpy.mockRestore()
+        const output: string = logged.join('\n')
+        expect(output).toContain('vt agent resume')
+        expect(output).toContain('<terminalId>')
+    })
+})

--- a/packages/systems/voicetree-cli/src/commands/runtime/agentResumeFormat.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agentResumeFormat.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure interpretation of a `resumePersistedAgentSession` RPC result.
+ *
+ * The daemon route never throws — it always returns a `ResumePersistedResult`
+ * discriminated on `kind` (see vt-daemon `recovery/resumePersistedAgentSession.ts`
+ * and the `ResumePersistedAgentSession` protocol contract). So the CLI decides
+ * success vs. failure from the returned `kind`, not from a thrown error:
+ * `spawned` is the only success; every other kind is a clear, named reason the
+ * resume could not happen and must exit non-zero.
+ *
+ * Keeping this mapping pure (record in → `{ok, message}` out) makes it a
+ * black-box-testable unit and keeps `agent.ts` focused on I/O wiring.
+ */
+
+type JsonRecord = Record<string, unknown>
+
+export type ResumeOutcome = {
+    readonly ok: boolean
+    readonly message: string
+}
+
+function optionalString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+/**
+ * Map a `ResumePersistedResult` payload to a single user-facing line. Unknown
+ * `kind`s degrade to a non-ok line rather than throwing, so a future
+ * daemon-side variant surfaces legibly instead of crashing the CLI.
+ */
+export function formatResumeResult(terminalId: string, payload: JsonRecord): ResumeOutcome {
+    const kind: unknown = payload.kind
+    switch (kind) {
+        case 'spawned': {
+            const pid: unknown = payload.pid
+            const command: string = optionalString(payload.command) ?? '(unknown command)'
+            return {
+                ok: true,
+                message: `Resumed agent ${terminalId} (pid ${String(pid)}).\nCommand: ${command}`,
+            }
+        }
+        case 'stale': {
+            const reason: string | undefined = optionalString(payload.reason)
+            const detail: string = reason === 'already-claimed'
+                ? 'a live agent already holds this terminal'
+                : reason === 'no-resume-handle'
+                    ? 'the session carries no resume handle (not a resumable CLI session)'
+                    : 'no recoverable session is in discovery (its record may have been removed)'
+            return {ok: false, message: `Cannot resume ${terminalId}: ${detail}.`}
+        }
+        case 'no-native-session': {
+            const cliType: string = optionalString(payload.cliType) ?? 'CLI'
+            const reason: string = optionalString(payload.reason) ?? 'not-found'
+            const diagnostic: string | undefined = optionalString(payload.diagnosticSessionId)
+            const diagnosticSuffix: string = diagnostic ? ` (diagnostic session ${diagnostic})` : ''
+            return {
+                ok: false,
+                message: `Cannot resume ${terminalId}: no ${cliType} native session found — ${reason}${diagnosticSuffix}.`,
+            }
+        }
+        case 'unsupported': {
+            const reason: string = optionalString(payload.reason) ?? 'unsupported session'
+            return {ok: false, message: `Cannot resume ${terminalId}: unsupported — ${reason}.`}
+        }
+        case 'spawn-failed': {
+            const detail: string = optionalString(payload.error) ?? 'unknown spawn error'
+            return {ok: false, message: `Failed to resume ${terminalId}: ${detail}.`}
+        }
+        default:
+            return {
+                ok: false,
+                message: `Cannot resume ${terminalId}: daemon returned an unrecognised result kind \`${String(kind)}\`.`,
+            }
+    }
+}

--- a/packages/systems/voicetree-cli/src/commands/runtime/agentSpecs.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agentSpecs.ts
@@ -89,6 +89,14 @@ export const AGENT_CLOSE_SPEC: SubcommandSpec = {
     ],
 }
 
+export const AGENT_RESUME_SPEC: SubcommandSpec = {
+    verb: 'vt agent resume',
+    rpcTool: 'resumePersistedAgentSession',
+    usageTail: '<terminalId>',
+    summary: 'Resume a closed/exited agent under its original terminalId.',
+    flags: [],
+}
+
 export const AGENT_SEND_SPEC: SubcommandSpec = {
     verb: 'vt agent send',
     rpcTool: 'send_message',

--- a/packages/systems/voicetree-cli/src/voicetree-cli.ts
+++ b/packages/systems/voicetree-cli/src/voicetree-cli.ts
@@ -5,6 +5,7 @@ import {
     agentClose,
     agentList,
     agentOutput,
+    agentResume,
     agentSend,
     agentSpawn,
     agentWait,
@@ -58,6 +59,7 @@ Subcommands:
   list      List running agents
   wait      Start background monitoring for one or more agents
   close     Close an agent terminal
+  resume    Resume a closed/exited agent under its original terminalId
   send      Send a message to an agent terminal
   output    Read buffered agent output`
 
@@ -132,6 +134,9 @@ async function dispatchAgentCommand(
             return
         case 'close':
             await agentClose(terminalId, args)
+            return
+        case 'resume':
+            await agentResume(terminalId, args)
             return
         case 'send':
             await agentSend(terminalId, args)
@@ -249,7 +254,7 @@ function readVtVersion(): string {
 }
 
 const KNOWN_AGENT_SUBS: ReadonlySet<string> = new Set([
-    'spawn', 'list', 'wait', 'close', 'send', 'output',
+    'spawn', 'list', 'wait', 'close', 'resume', 'send', 'output',
 ])
 const KNOWN_GRAPH_SUBS: ReadonlySet<string> = new Set([
     'create', 'index', 'search', 'unseen', 'live', 'structure', 'lint', 'complexity', 'rename', 'mv', 'group',

--- a/packages/systems/vt-daemon/src/agent-runtime/headless/tests/persistExitedMetadata.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/headless/tests/persistExitedMetadata.test.ts
@@ -1,0 +1,109 @@
+import {mkdtemp, readFile, rm} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {afterEach, describe, expect, it} from 'vitest'
+import {persistExitedMetadata} from '../tmuxHeadlessRuntime'
+import {writeMetadata, type TmuxTerminalMetadata} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/terminal-metadata.ts'
+import type {NativeSessionRequest, NativeSessionResult} from '../../recovery/resolvers/resolveNativeSession'
+import {makeTerminalData} from '../../recovery/tests/classifier.test-fixtures'
+import type {TerminalId} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/types.ts'
+
+const TERMINAL_ID = 'A' as TerminalId
+const WRITER_PID = 4321
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, {recursive: true, force: true})))
+})
+
+async function seedRunningMetadata(overrides: Partial<TmuxTerminalMetadata> = {}): Promise<string> {
+    const dir: string = await mkdtemp(join(tmpdir(), 'persist-exited-'))
+    tempDirs.push(dir)
+    const path: string = join(dir, `${TERMINAL_ID}.json`)
+    writeMetadata(path, {
+        name: TERMINAL_ID,
+        status: 'running',
+        pid: 100,
+        terminalData: makeTerminalData({initialCommand: 'claude'}),
+        ...overrides,
+    }, WRITER_PID)
+    return path
+}
+
+async function read(path: string): Promise<TmuxTerminalMetadata> {
+    return JSON.parse(await readFile(path, 'utf8')) as TmuxTerminalMetadata
+}
+
+const found = (sessionId: string) =>
+    async (_req: NativeSessionRequest): Promise<NativeSessionResult> => ({kind: 'found', sessionId})
+
+describe('persistExitedMetadata — close/exit captures recovery.native (D3)', () => {
+    it('flips the record to exited AND backfills recovery.native from the resolver', async () => {
+        const path: string = await seedRunningMetadata()
+
+        await persistExitedMetadata(TERMINAL_ID, path, WRITER_PID, 0, found('sess-on-exit'))
+
+        const after = await read(path)
+        expect(after.status).toBe('exited')
+        expect(after.exitCode).toBe(0)
+        expect(after.endedAt).toEqual(expect.any(String))
+        expect(after.recovery?.native).toEqual({
+            cli: 'claude',
+            mode: 'interactive',
+            sessionId: 'sess-on-exit',
+            capturedAt: expect.any(String),
+            source: 'claude-project-transcript',
+        })
+    })
+
+    it('marks exited but leaves recovery absent when the resolver misses (best-effort)', async () => {
+        const path: string = await seedRunningMetadata()
+
+        await persistExitedMetadata(
+            TERMINAL_ID,
+            path,
+            WRITER_PID,
+            1,
+            async (): Promise<NativeSessionResult> => ({kind: 'not-found', reason: 'no-jsonl-matches'}),
+        )
+
+        const after = await read(path)
+        expect(after.status).toBe('exited')
+        expect(after.exitCode).toBe(1)
+        expect(after.recovery).toBeUndefined()
+    })
+
+    it('preserves a pre-existing recovery.native and does not re-resolve', async () => {
+        let resolverCalls = 0
+        const path: string = await seedRunningMetadata({
+            recovery: {native: {cli: 'claude', mode: 'interactive', sessionId: 'captured-earlier', capturedAt: '2026-01-01T00:00:00.000Z', source: 'claude-project-transcript'}},
+        })
+
+        await persistExitedMetadata(TERMINAL_ID, path, WRITER_PID, 0, async () => {
+            resolverCalls += 1
+            return {kind: 'found', sessionId: 'should-not-overwrite'}
+        })
+
+        const after = await read(path)
+        expect(after.status).toBe('exited')
+        expect(after.recovery?.native.sessionId).toBe('captured-earlier')
+        expect(resolverCalls).toBe(0)
+    })
+
+    it('is idempotent: an already-exited record is left untouched', async () => {
+        const path: string = await seedRunningMetadata({status: 'exited', endedAt: '2026-05-01T00:00:00.000Z', exitCode: 0})
+        let resolverCalls = 0
+
+        await persistExitedMetadata(TERMINAL_ID, path, WRITER_PID, 7, async () => {
+            resolverCalls += 1
+            return {kind: 'found', sessionId: 'x'}
+        })
+
+        const after = await read(path)
+        expect(after.endedAt).toBe('2026-05-01T00:00:00.000Z')
+        expect(after.exitCode).toBe(0)
+        expect(after.recovery).toBeUndefined()
+        expect(resolverCalls).toBe(0)
+    })
+})

--- a/packages/systems/vt-daemon/src/agent-runtime/headless/tmuxHeadlessRuntime.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/headless/tmuxHeadlessRuntime.ts
@@ -3,7 +3,9 @@ import {join} from 'node:path'
 import {getProjectDotVoicetreePath} from '@vt/paths'
 import type {TerminalData, TerminalId} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/types.ts'
 import type {TmuxReconciliationResult} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/index.ts'
-import {readMetadata, writeMetadata, type TmuxTerminalMetadata} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/terminal-metadata.ts'
+import {readMetadata, writeMetadata, type NativeRecoveryHandle, type TmuxTerminalMetadata} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/terminal-metadata.ts'
+import {captureNativeRecoveryHandle} from '@vt/vt-daemon/agent-runtime/recovery/captureNativeRecovery.ts'
+import type {ResolveNativeSession} from '@vt/vt-daemon/agent-runtime/recovery/resolvers/resolveNativeSession.ts'
 import {
     captureOutput,
     getOutput,
@@ -92,21 +94,46 @@ function clearTmuxPoll(terminalId: TerminalId): void {
     }
 }
 
-function markTmuxMetadataExited(
+/**
+ * Read-modify-write a terminal's metadata to the `exited` lifecycle state,
+ * capturing a durable `recovery.native` handle on the way out if the record is
+ * a resumable Claude/Codex agent that doesn't already have one (D3).
+ *
+ * Idempotent: a record already marked `exited` is left untouched, so the first
+ * exit transition wins and its captured handle never churns. The capture is
+ * best-effort — a resolver miss leaves `recovery` exactly as it was (preserved
+ * through the `...existing` spread). Exported for black-box testing against a
+ * real metadata file; production callers reach it via `markTmuxMetadataExited`.
+ */
+export async function persistExitedMetadata(
     terminalId: TerminalId,
+    metadataPath: string,
     writerPid: number,
     exitCode: number | null = null,
-): void {
-    const session: TmuxHeadlessSession | undefined = tmuxHeadlessState.sessions.get(terminalId)
-    if (!session) return
-    const existing: TmuxTerminalMetadata | null = readMetadata(session.metadataPath)
+    resolveNativeSession: ResolveNativeSession | undefined = undefined,
+): Promise<void> {
+    const existing: TmuxTerminalMetadata | null = readMetadata(metadataPath)
     if (!existing || existing.status === 'exited') return
-    writeMetadata(session.metadataPath, {
+    const native: NativeRecoveryHandle | null = resolveNativeSession
+        ? await captureNativeRecoveryHandle(terminalId, existing, resolveNativeSession)
+        : await captureNativeRecoveryHandle(terminalId, existing)
+    writeMetadata(metadataPath, {
         ...existing,
         status: 'exited',
         exitCode,
         endedAt: new Date().toISOString(),
+        ...(native ? {recovery: {...existing.recovery, native}} : {}),
     }, writerPid)
+}
+
+async function markTmuxMetadataExited(
+    terminalId: TerminalId,
+    writerPid: number,
+    exitCode: number | null = null,
+): Promise<void> {
+    const session: TmuxHeadlessSession | undefined = tmuxHeadlessState.sessions.get(terminalId)
+    if (!session) return
+    await persistExitedMetadata(terminalId, session.metadataPath, writerPid, exitCode)
 }
 
 function startTmuxExitPoll(terminalId: TerminalId, sessionName: string, deps: HeadlessAgentDeps): ReturnType<typeof setInterval> {
@@ -117,7 +144,7 @@ function startTmuxExitPoll(terminalId: TerminalId, sessionName: string, deps: He
                 clearTmuxPoll(terminalId)
                 const session: TmuxHeadlessSession | undefined = tmuxHeadlessState.sessions.get(terminalId)
                 const exitCode: number | null = session ? readExitCode(session.exitCodePath) : null
-                markTmuxMetadataExited(terminalId, deps.processPid, exitCode)
+                await markTmuxMetadataExited(terminalId, deps.processPid, exitCode)
                 deps.markTerminalExited(terminalId, exitCode)
             } catch (error) {
                 deps.writeLog({level: 'error', message: `[headlessAgentManager] tmux exit poll failed for ${terminalId}:`, error})
@@ -243,7 +270,7 @@ export async function killTmuxHeadlessAgent(
     // callers (RPC closeHeadlessAgent, closeAgentTool) could hand control back
     // to the client while the session was still alive.
     await killSession(tmuxSession.sessionName).catch(() => undefined)
-    markTmuxMetadataExited(terminalId, deps.processPid, null)
+    await markTmuxMetadataExited(terminalId, deps.processPid, null)
     deletePromptFileByPath(tmuxSession.promptFilePath)
     deps.markTerminalExited(terminalId, null)
     return true

--- a/packages/systems/vt-daemon/src/agent-runtime/recovery/captureNativeRecovery.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/recovery/captureNativeRecovery.ts
@@ -1,0 +1,57 @@
+import {detectSupportedCliFromMetadata} from './classifier'
+import {
+    defaultResolveNativeSession,
+    type ResolveNativeSession,
+} from './resolvers/resolveNativeSession'
+import type {
+    NativeRecoveryHandle,
+    TmuxTerminalMetadata,
+} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/terminal-metadata.ts'
+
+function nativeSourceFor(cli: 'claude' | 'codex'): NativeRecoveryHandle['source'] {
+    return cli === 'claude' ? 'claude-project-transcript' : 'codex-state-index'
+}
+
+/**
+ * Best-effort resolution of a durable native resume handle for a
+ * Claude/Codex terminal, intended to be called at the close/exit lifecycle
+ * transition (when the provider transcript reliably exists on disk).
+ *
+ * Returns `null` — never throws — when the handle should not be (re)written:
+ *
+ * - the record already carries `recovery.native` (preserve the existing one;
+ *   the first capture wins and the durable id never churns),
+ * - the metadata does not target a supported CLI (`claude`/`codex`),
+ * - the metadata lacks `VOICETREE_PROJECT_PATH` (resolver cannot scope a scan),
+ * - the resolver could not deterministically locate the provider session.
+ *
+ * A non-null return is a complete `NativeRecoveryHandle` ready to merge into
+ * `metadata.recovery.native`. This is the D3 capture primitive: persisting the
+ * handle eagerly at exit means resume reads it straight from the terminal JSON
+ * instead of re-running the ambiguous `~/.claude/projects` recency scan.
+ */
+export async function captureNativeRecoveryHandle(
+    terminalId: string,
+    metadata: TmuxTerminalMetadata,
+    resolveNativeSession: ResolveNativeSession = defaultResolveNativeSession,
+): Promise<NativeRecoveryHandle | null> {
+    if (metadata.recovery?.native) return null
+    const cliType: 'claude' | 'codex' | null = detectSupportedCliFromMetadata(metadata)
+    if (!cliType) return null
+    const env: Record<string, string> | undefined = metadata.terminalData?.initialEnvVars
+    const projectRoot: string | undefined = env?.VOICETREE_PROJECT_PATH
+    if (!projectRoot) return null
+    const taskNodePath: string = env?.TASK_NODE_PATH ?? ''
+
+    const result = await resolveNativeSession({cliType, terminalId, projectRoot, taskNodePath})
+    if (result.kind !== 'found') return null
+
+    return {
+        cli: cliType,
+        mode: metadata.terminalData?.isHeadless ? 'headless' : 'interactive',
+        sessionId: result.sessionId,
+        capturedAt: new Date().toISOString(),
+        source: nativeSourceFor(cliType),
+        ...(result.providerStorePath ? {providerStorePath: result.providerStorePath} : {}),
+    }
+}

--- a/packages/systems/vt-daemon/src/agent-runtime/recovery/tests/captureNativeRecovery.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/recovery/tests/captureNativeRecovery.test.ts
@@ -1,0 +1,176 @@
+import {describe, expect, it} from 'vitest'
+import {captureNativeRecoveryHandle} from '../captureNativeRecovery'
+import {resumePersistedAgentSession, type ResumePersistedDeps} from '../resumePersistedAgentSession'
+import type {NativeSessionRequest, NativeSessionResult} from '../resolvers/resolveNativeSession'
+import type {RecoverableAgentSession} from '../types'
+import type {TmuxTerminalMetadata} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/terminal-metadata.ts'
+import type {TerminalData, TerminalId} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/types.ts'
+import {makeTerminalData, TERMINAL_A, SESSION_A, PROJECT_PATH} from './classifier.test-fixtures'
+
+const TERMINAL_ID_A: TerminalId = TERMINAL_A as TerminalId
+
+function makeMetadata(overrides: Partial<TmuxTerminalMetadata> = {}): TmuxTerminalMetadata {
+    return {
+        name: TERMINAL_A,
+        status: 'running',
+        session: SESSION_A,
+        terminalData: makeTerminalData({initialCommand: 'claude'}),
+        ...overrides,
+    }
+}
+
+function recordingResolver(
+    impl: (req: NativeSessionRequest) => NativeSessionResult,
+): {resolve: (req: NativeSessionRequest) => Promise<NativeSessionResult>; calls: NativeSessionRequest[]} {
+    const calls: NativeSessionRequest[] = []
+    return {
+        calls,
+        resolve: async (req: NativeSessionRequest): Promise<NativeSessionResult> => {
+            calls.push(req)
+            return impl(req)
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// captureNativeRecoveryHandle — the D3 capture primitive
+// ---------------------------------------------------------------------------
+
+describe('captureNativeRecoveryHandle', () => {
+    it('resolves and returns a complete native handle for a Claude record with no prior recovery', async () => {
+        const {resolve, calls} = recordingResolver(() => ({
+            kind: 'found',
+            sessionId: 'sess-claude-1',
+            providerStorePath: '/Users/bob/.claude/projects/p/t.jsonl',
+        }))
+
+        const handle = await captureNativeRecoveryHandle(TERMINAL_ID_A, makeMetadata(), resolve)
+
+        expect(handle).toEqual({
+            cli: 'claude',
+            mode: 'interactive',
+            sessionId: 'sess-claude-1',
+            capturedAt: expect.any(String),
+            source: 'claude-project-transcript',
+            providerStorePath: '/Users/bob/.claude/projects/p/t.jsonl',
+        })
+        expect(calls).toEqual([{cliType: 'claude', terminalId: TERMINAL_ID_A, projectRoot: PROJECT_PATH, taskNodePath: ''}])
+    })
+
+    it('captures a headless Codex handle with the codex-state-index source and headless mode', async () => {
+        const {resolve} = recordingResolver(() => ({kind: 'found', sessionId: 'thread-codex-1'}))
+        const metadata = makeMetadata({
+            terminalData: makeTerminalData({initialCommand: 'codex exec --full-auto "$AGENT_PROMPT"', isHeadless: true}),
+        })
+
+        const handle = await captureNativeRecoveryHandle(TERMINAL_ID_A, metadata, resolve)
+
+        expect(handle).toEqual({
+            cli: 'codex',
+            mode: 'headless',
+            sessionId: 'thread-codex-1',
+            capturedAt: expect.any(String),
+            source: 'codex-state-index',
+        })
+    })
+
+    it('forwards TASK_NODE_PATH into the resolver request when present', async () => {
+        const {resolve, calls} = recordingResolver(() => ({kind: 'found', sessionId: 's'}))
+        const metadata = makeMetadata({
+            terminalData: makeTerminalData({
+                initialCommand: 'claude',
+                initialEnvVars: {VOICETREE_PROJECT_PATH: PROJECT_PATH, TASK_NODE_PATH: '/project/.voicetree/tasks/T.md'},
+            }),
+        })
+
+        await captureNativeRecoveryHandle(TERMINAL_ID_A, metadata, resolve)
+
+        expect(calls[0].taskNodePath).toBe('/project/.voicetree/tasks/T.md')
+    })
+
+    it('returns null and never calls the resolver when recovery.native is already present (preserve)', async () => {
+        const {resolve, calls} = recordingResolver(() => ({kind: 'found', sessionId: 'should-not-happen'}))
+        const metadata = makeMetadata({
+            recovery: {native: {cli: 'claude', mode: 'interactive', sessionId: 'already-here', capturedAt: '2026-01-01T00:00:00.000Z', source: 'claude-project-transcript'}},
+        })
+
+        const handle = await captureNativeRecoveryHandle(TERMINAL_ID_A, metadata, resolve)
+
+        expect(handle).toBeNull()
+        expect(calls).toHaveLength(0)
+    })
+
+    it('returns null without resolving for an unsupported CLI', async () => {
+        const {resolve, calls} = recordingResolver(() => ({kind: 'found', sessionId: 'x'}))
+        const metadata = makeMetadata({terminalData: makeTerminalData({initialCommand: 'gemini'})})
+
+        expect(await captureNativeRecoveryHandle(TERMINAL_ID_A, metadata, resolve)).toBeNull()
+        expect(calls).toHaveLength(0)
+    })
+
+    it('returns null without resolving when VOICETREE_PROJECT_PATH is missing', async () => {
+        const {resolve, calls} = recordingResolver(() => ({kind: 'found', sessionId: 'x'}))
+        const metadata = makeMetadata({
+            terminalData: makeTerminalData({initialCommand: 'claude', initialEnvVars: {VOICETREE_TERMINAL_ID: TERMINAL_A}}),
+        })
+
+        expect(await captureNativeRecoveryHandle(TERMINAL_ID_A, metadata, resolve)).toBeNull()
+        expect(calls).toHaveLength(0)
+    })
+
+    it('returns null when the resolver cannot deterministically locate a provider session', async () => {
+        const {resolve, calls} = recordingResolver(() => ({kind: 'not-found', reason: 'no-jsonl-matches'}))
+
+        expect(await captureNativeRecoveryHandle(TERMINAL_ID_A, makeMetadata(), resolve)).toBeNull()
+        expect(calls).toHaveLength(1)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: a captured handle makes resume JSON-driven — no resolver scan.
+// This is the end-to-end shape of BF-455 + BF-457: exit captures the handle,
+// resume consumes it straight from the persisted record.
+// ---------------------------------------------------------------------------
+
+describe('captured handle → resume reads it without the resolver scan', () => {
+    it('resumes from the persisted nativeSessionId and never invokes the resolver', async () => {
+        const captured = await captureNativeRecoveryHandle(
+            TERMINAL_ID_A,
+            makeMetadata(),
+            async () => ({kind: 'found', sessionId: 'sess-captured-at-exit'}),
+        )
+        expect(captured?.sessionId).toBe('sess-captured-at-exit')
+
+        const row: RecoverableAgentSession = {
+            terminalId: TERMINAL_ID_A,
+            agentName: 'Ari',
+            metadataPath: '/project/.voicetree/terminals/A.json',
+            terminalData: makeTerminalData({initialCommand: 'claude'}),
+            isClaimed: false,
+            status: 'exited',
+            // discovery surfaces recovery.native.sessionId into resume.nativeSessionId
+            resume: {cliType: 'claude', nativeSessionId: captured!.sessionId},
+        }
+
+        const resolveCalls: NativeSessionRequest[] = []
+        const spawnCalls: {command: string}[] = []
+        const deps: ResumePersistedDeps = {
+            discover: async () => [row],
+            resolveNativeSession: async (req: NativeSessionRequest): Promise<NativeSessionResult> => {
+                resolveCalls.push(req)
+                return {kind: 'found', sessionId: 'resolver-should-not-run'}
+            },
+            spawn: async (_id: TerminalId, _data: TerminalData, command: string) => {
+                spawnCalls.push({command})
+                return {pid: 4242}
+            },
+        }
+
+        const result = await resumePersistedAgentSession(TERMINAL_ID_A, deps)
+
+        expect(result.kind).toBe('spawned')
+        expect(spawnCalls).toHaveLength(1)
+        expect(spawnCalls[0].command).toContain('claude --resume sess-captured-at-exit')
+        expect(resolveCalls).toHaveLength(0)
+    })
+})


### PR DESCRIPTION
## Summary
- Adds `vt agent resume <terminalId>` to resume a persisted exited agent session from the CLI.
- Captures and persists Claude/Codex native recovery handles at tmux exit/close time, so resume can use the durable session id instead of rescanning provider state later.
- Adds pure CLI result formatting plus daemon recovery/headless regression coverage.

## Verification
- `pnpm --filter @voicetree/cli exec vitest run src/commands/runtime/agentResume.test.ts` — passed (13 tests)
- `pnpm --filter @vt/vt-daemon test -- src/agent-runtime/recovery/tests/captureNativeRecovery.test.ts src/agent-runtime/headless/tests/persistExitedMetadata.test.ts` — passed (vt-daemon package suite: 106 files, 958 tests)
- pre-push hook: `pnpm run test:t1` — passed, 0 failing checks

## Review Notes
- Branch is a single commit on top of `origin/dev-manu`.
- Runtime change is limited to the resume CLI command and best-effort native recovery capture during tmux-backed agent exit handling.
