### PR TITLE
fix(graph): lock background dot-grid to linear zoom so dots track nodes

### DIFF
--- a/webapp/src/shell/edge/UI-edge/graph/view/dotGridBackground.test.ts
+++ b/webapp/src/shell/edge/UI-edge/graph/view/dotGridBackground.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    _resetLayoutStoreForTests,
+    dispatchSetPan,
+    dispatchSetZoom,
+    flushLayout,
+} from '@vt/graph-state/state/layoutStore';
+
+import { attachDotGridBackground } from './dotGridBackground';
+
+const BASE_SPACING = 24;
+
+/**
+ * Commit a zoom/pan into the singleton layout store synchronously, the way the
+ * renderer would once a frame's gestures settle.
+ */
+function setLayout(zoom: number, pan: { x: number; y: number } = { x: 0, y: 0 }): void {
+    dispatchSetZoom(zoom);
+    dispatchSetPan(pan);
+    flushLayout();
+}
+
+function px(el: HTMLElement, prop: string): number {
+    return parseFloat(el.style.getPropertyValue(prop));
+}
+
+describe('attachDotGridBackground', () => {
+    let el: HTMLElement;
+    let detach: () => void;
+
+    beforeEach(() => {
+        _resetLayoutStoreForTests();
+        el = document.createElement('div');
+    });
+
+    afterEach(() => {
+        detach?.();
+        _resetLayoutStoreForTests();
+    });
+
+    it('spaces dots linearly in zoom, locking them to the nodes', () => {
+        setLayout(1);
+        detach = attachDotGridBackground(el, BASE_SPACING);
+        expect(px(el, '--dot-size')).toBe(BASE_SPACING);
+    });
+
+    it('doubles spacing and radius when zoom doubles (same rate as nodes)', () => {
+        setLayout(1);
+        detach = attachDotGridBackground(el, BASE_SPACING);
+        const size1 = px(el, '--dot-size');
+        const radius1 = px(el, '--dot-radius');
+
+        setLayout(2);
+        flushLayout();
+
+        // The store schedules a rAF flush; force the next frame so apply() runs.
+        return new Promise<void>((resolve) => {
+            requestAnimationFrame(() => {
+                expect(px(el, '--dot-size')).toBeCloseTo(size1 * 2);
+                expect(px(el, '--dot-radius')).toBeCloseTo(radius1 * 2);
+                resolve();
+            });
+        });
+    });
+
+    it('fades out when zoomed far enough that spacing reads as noise', () => {
+        setLayout(0.1); // 24 * 0.1 = 2.4px < MIN_DOT_SPACING
+        detach = attachDotGridBackground(el, BASE_SPACING);
+        expect(px(el, '--dot-opacity')).toBe(0);
+    });
+
+    it('phases the pattern by pan modulo spacing so grid lines pin to nodes', () => {
+        setLayout(2, { x: 100, y: 100 }); // size = 48, 100 % 48 = 4
+        detach = attachDotGridBackground(el, BASE_SPACING);
+        expect(px(el, '--dot-x')).toBeCloseTo(100 % 48);
+        expect(px(el, '--dot-y')).toBeCloseTo(100 % 48);
+    });
+});

--- a/webapp/src/shell/edge/UI-edge/graph/view/dotGridBackground.ts
+++ b/webapp/src/shell/edge/UI-edge/graph/view/dotGridBackground.ts
@@ -10,15 +10,14 @@
 import { getLayout, subscribeLayout } from '@vt/graph-state/state/layoutStore';
 
 const DEFAULT_BASE_SPACING = 24;
+// Below this on-screen spacing the grid reads as noise rather than structure,
+// so we fade it out instead of drawing an indistinct smear.
 const MIN_DOT_SPACING = 6;
-
-const DOT_SIZE_MIN = 10;
-const DOT_SIZE_MAX = 48;
-const DOT_SIZE_MID = (DOT_SIZE_MIN + DOT_SIZE_MAX) / 2;
-const DOT_SIZE_HALF = (DOT_SIZE_MAX - DOT_SIZE_MIN) / 2;
-// k = 1/HALF_RANGE gives derivative = 1 at the center, so the sigmoid
-// matches the linear feel in the sweet spot and only curves at extremes.
-const SIGMOID_K = 1 / DOT_SIZE_HALF;
+// Dot radius in graph-space px at `baseSpacing`. Scaling it by zoom alongside
+// the spacing keeps the dot *marks* in lockstep too, so the whole pattern is a
+// faithful zoom of one graph-space grid. At zoom 1 this is the 1px the CSS
+// `--dot-radius` fallback already used, so the resting look is unchanged.
+const BASE_DOT_RADIUS = 1;
 
 export function attachDotGridBackground(
     el: HTMLElement,
@@ -30,8 +29,12 @@ export function attachDotGridBackground(
         const layout = getLayout();
         const zoom = layout.zoom ?? 1;
         const pan = layout.pan ?? { x: 0, y: 0 };
-        const linearSize = baseSpacing * zoom;
-        const size = DOT_SIZE_MID + DOT_SIZE_HALF * Math.tanh(SIGMOID_K * (linearSize - DOT_SIZE_MID));
+        // Cytoscape renders model points as `screen = model * zoom + pan`, so a
+        // graph-space grid of spacing `baseSpacing` lands at `baseSpacing * zoom`
+        // px and shares the nodes' zoom rate exactly. The spacing law MUST stay
+        // linear in zoom — any easing/sigmoid here makes the dots drift against
+        // the nodes as you zoom.
+        const size = baseSpacing * zoom;
 
         if (size < MIN_DOT_SPACING) {
             el.style.setProperty('--dot-opacity', '0');
@@ -40,6 +43,9 @@ export function attachDotGridBackground(
 
         el.style.setProperty('--dot-opacity', '1');
         el.style.setProperty('--dot-size', `${size}px`);
+        el.style.setProperty('--dot-radius', `${BASE_DOT_RADIUS * zoom}px`);
+        // Phase the pattern so model-space grid lines stay pinned to the nodes:
+        // a line at model k*baseSpacing sits at screen k*size + pan, i.e. pan % size.
         el.style.setProperty('--dot-x', `${pan.x % size}px`);
         el.style.setProperty('--dot-y', `${pan.y % size}px`);
     };


### PR DESCRIPTION
The dot-grid spacing used a tanh sigmoid that compressed at zoom extremes,
so dots scaled slower than Cytoscape's linear node transform and drifted
against the nodes. Make spacing = baseSpacing*zoom and scale the dot radius
by zoom too, making the underlay a faithful zoom of one graph-space grid.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
