### PR TITLE
fix(wait-for-agents): make agent-declared lifecycle the authoritative done signal

### DIFF
--- a/packages/systems/vt-daemon/integration-tests/isAgentCompleteCycleDetection.test.ts
+++ b/packages/systems/vt-daemon/integration-tests/isAgentCompleteCycleDetection.test.ts
@@ -19,8 +19,10 @@ import {
 import type {TerminalRecord} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry'
 import {
     isAgentComplete,
+    getReportedStatus,
     type IsAgentCompleteDeps,
 } from '../src/agent-runtime/agent-control/completion/isAgentComplete.ts'
+import type {TerminalLifecycle} from '@vt/vt-daemon/agent-runtime/lifecycle'
 
 function buildGraphNode(nodeId: string, title: string, agentName: string, isContextNode: boolean = false): GraphNode {
     return {
@@ -256,5 +258,77 @@ describe('isAgentComplete progress-node gate', () => {
 
         const result: boolean = isAgentComplete(record, graph, NOW, [record], undefined, depsWith({}))
         expect(result).toBe(true)
+    })
+})
+
+describe('isAgentComplete authoritative lifecycle signal', () => {
+    const NOW: number = 100_000
+
+    // No idle, no nodes, alive < 30 min — the heuristic alone would NOT say "done".
+    // Only a settled lifecycle should flip these to complete.
+    function strictDeps(): IsAgentCompleteDeps {
+        return {
+            getIdleSince: (_id: string) => null,
+            getAgentNodes: (_id: string) => [],
+            getNewNodesForAgent: (_g: Graph, _n: string | undefined, _s: number) => [],
+        }
+    }
+
+    function withLifecycle(data: TerminalData, lifecycle: TerminalLifecycle, isHeadless: boolean = false): TerminalData {
+        return {...data, lifecycle, isHeadless}
+    }
+
+    it('treats a self-reported headless agent (lifecycle=completed) as complete before its process exits', () => {
+        // The reported bug: a headless agent that declared done via create_graph but whose
+        // process is still alive (status running) was polled forever by the heuristic.
+        const data: TerminalData = withLifecycle(makeTerminalData('agent-x', 'alpha'), 'completed', true)
+        const record: TerminalRecord = makeRecord('agent-x', data, 'running')
+        record.spawnedAt = NOW - 60_000 // 1 min — well within the 30-min gate
+
+        const result: boolean = isAgentComplete(record, buildGraph(), NOW, [record], undefined, strictDeps())
+        expect(result).toBe(true)
+    })
+
+    it('treats lifecycle=errored as complete', () => {
+        const data: TerminalData = withLifecycle(makeTerminalData('agent-x', 'alpha'), 'errored', true)
+        const record: TerminalRecord = makeRecord('agent-x', data, 'running')
+        record.spawnedAt = NOW - 60_000
+
+        const result: boolean = isAgentComplete(record, buildGraph(), NOW, [record], undefined, strictDeps())
+        expect(result).toBe(true)
+    })
+
+    it('does NOT complete a self-reported-done parent while a child is still running', () => {
+        // Robustness: a settled lifecycle is authoritative for the agent ITSELF, but the
+        // subtree is only done when descendants are too.
+        const parent: TerminalData = withLifecycle(makeTerminalData('agent-a', 'alpha'), 'completed', true)
+        const child: TerminalData = makeTerminalData('agent-b', 'beta', 'agent-a') // running, not settled
+        const recordA: TerminalRecord = makeRecord('agent-a', parent, 'running')
+        const recordB: TerminalRecord = makeRecord('agent-b', child, 'running')
+        recordA.spawnedAt = NOW - 60_000
+        recordB.spawnedAt = NOW - 60_000
+
+        const result: boolean = isAgentComplete(recordA, buildGraph(), NOW, [recordA, recordB], undefined, strictDeps())
+        expect(result).toBe(false)
+    })
+})
+
+describe('getReportedStatus', () => {
+    function withLifecycle(data: TerminalData, lifecycle: TerminalLifecycle, isHeadless: boolean = false): TerminalData {
+        return {...data, lifecycle, isHeadless}
+    }
+
+    it('reports the settled lifecycle over the runtime heuristic', () => {
+        const completed: TerminalRecord = makeRecord('a', withLifecycle(makeTerminalData('a', 'alpha'), 'completed', true), 'running')
+        const errored: TerminalRecord = makeRecord('b', withLifecycle(makeTerminalData('b', 'beta'), 'errored', true), 'running')
+        expect(getReportedStatus(completed)).toBe('completed')
+        expect(getReportedStatus(errored)).toBe('errored')
+    })
+
+    it('falls back to the runtime heuristic when the lifecycle has not settled', () => {
+        const running: TerminalRecord = makeRecord('c', withLifecycle(makeTerminalData('c', 'gamma'), 'active', true), 'running')
+        const exited: TerminalRecord = makeRecord('d', withLifecycle(makeTerminalData('d', 'delta'), 'spawning'), 'exited')
+        expect(getReportedStatus(running)).toBe('running')
+        expect(getReportedStatus(exited)).toBe('exited')
     })
 })

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/agent-completion-monitor.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/agent-completion-monitor.ts
@@ -17,6 +17,7 @@ import {
 import {
     isAgentComplete,
     getAgentStatus,
+    getReportedStatus,
 } from './completion/isAgentComplete.ts'
 import {
     buildCompletionMessage,
@@ -137,7 +138,7 @@ export function startMonitor(
                 return {
                     terminalId: r.terminalId,
                     agentName: r.terminalData.agentName,
-                    status: getAgentStatus(r),
+                    status: getReportedStatus(r),
                     exitCode: r.exitCode,
                     nodes: mergedNodes,
                     lastOutput

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/completion/buildCompletionMessage.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/completion/buildCompletionMessage.ts
@@ -3,10 +3,12 @@
  * Used by the async agent monitor to notify parent agents when all children complete.
  */
 
+import type {ReportedAgentStatus} from './isAgentComplete'
+
 export interface AgentResult {
     terminalId: string
     agentName: string | undefined
-    status: 'running' | 'idle' | 'exited'
+    status: ReportedAgentStatus
     exitCode: number | null
     nodes: Array<{nodeId: string; title: string}>
     /** Truncated last output from headless agent — included when exitCode !== 0 for diagnostics. */
@@ -22,8 +24,8 @@ export function buildCompletionMessage(agentResults: AgentResult[], stillWaiting
             agent.nodes.length > 0
                 ? agent.nodes.map((n: {nodeId: string; title: string}) => `${n.title} (${n.nodeId})`).join(', ')
                 : '(no nodes created)'
-        const statusLabel: string = agent.status === 'exited' && agent.exitCode !== null
-            ? `exited:${agent.exitCode}`
+        const statusLabel: string = (agent.status === 'exited' || agent.status === 'errored') && agent.exitCode !== null
+            ? `${agent.status}:${agent.exitCode}`
             : agent.status
         parts.push(`- ${name} [${statusLabel}]: ${nodeList}`)
         if (agent.lastOutput) {

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/completion/isAgentComplete.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/completion/isAgentComplete.ts
@@ -1,7 +1,13 @@
 /**
  * Pure completion-check for a single agent terminal.
- * Combines: getAgentStatus, getIdleSince.
- * Returns true when: (exited) OR (idle + idle ≥ SUSTAINED_IDLE_MS + all children complete)
+ *
+ * Completeness is decided in two layers, authoritative first:
+ *   1. The agent's settled lifecycle (`completed`/`errored`) — set deterministically
+ *      when the agent self-reports done via `create_graph`'s `agentStatus`, or by
+ *      exit classification. This is sticky and trustworthy, so it wins outright.
+ *   2. Fallback heuristic for agents that have NOT settled a lifecycle: exited, or
+ *      sustained-idle past SUSTAINED_IDLE_MS with the progress-node gate satisfied.
+ * Either way, an agent is only complete once all its descendant children are too.
  *
  * Deep function — internal leaf lookups (idle-since, agent-nodes,
  * new-nodes-for-agent) are injected as deps so tests can supply
@@ -14,12 +20,16 @@ import type {Graph} from '@vt/graph-model/graph'
 import {getAgentNodes as defaultGetAgentNodes} from './agentNodeIndex'
 import {getNewNodesForAgent as defaultGetNewNodesForAgent} from './getNewNodesForAgent'
 import {getIdleSince as defaultGetIdleSince} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/queries.ts'
+import {isFinishedLifecycle} from '@vt/vt-daemon/agent-runtime/lifecycle'
 import type {TerminalRecord} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry-state.ts'
 
 const SUSTAINED_IDLE_MS: number = 7_000 // 7 seconds — agent must be idle this long before considered done
 export const NO_PROGRESS_TIMEOUT_MS: number = 30 * 60 * 1000 // 30 minutes — max time to wait for agent without progress nodes
 
 export type AgentStatus = 'running' | 'idle' | 'exited'
+
+/** Status union used for completion reporting — widens {@link AgentStatus} with the settled lifecycle outcomes. */
+export type ReportedAgentStatus = AgentStatus | 'completed' | 'errored'
 
 export interface IsAgentCompleteDeps {
     readonly getIdleSince: (terminalId: string) => number | null
@@ -33,10 +43,27 @@ export const defaultIsAgentCompleteDeps: IsAgentCompleteDeps = {
     getNewNodesForAgent: defaultGetNewNodesForAgent,
 }
 
+/**
+ * Runtime status heuristic — what the PTY/process is doing right now. Used by
+ * `close_agent` (don't kill an actively-running pane without force) and the
+ * idle-nudge. NOT authoritative for completion: see {@link getReportedStatus}.
+ */
 export function getAgentStatus(record: TerminalRecord): AgentStatus {
     if (record.status === 'exited') return 'exited'
     if (record.terminalData.isHeadless) return 'running' // No PTY — isDone is meaningless
     return record.terminalData.isDone ? 'idle' : 'running'
+}
+
+/**
+ * Authoritative status for completion reporting. Prefers the agent's settled
+ * lifecycle (`completed`/`errored` — self-reported via `create_graph` or set by
+ * exit classification) over the runtime heuristic, so a headless agent that has
+ * declared itself done is never reported as still `running`.
+ */
+export function getReportedStatus(record: TerminalRecord): ReportedAgentStatus {
+    const lifecycle = record.terminalData.lifecycle
+    if (lifecycle === 'completed' || lifecycle === 'errored') return lifecycle
+    return getAgentStatus(record)
 }
 
 /**
@@ -49,9 +76,49 @@ function getChildRecords(parentId: string, allRecords: readonly TerminalRecord[]
 }
 
 /**
+ * Whether a single agent terminal is itself done, ignoring its children.
+ *
+ * Authoritative signal first: a settled lifecycle (`completed`/`errored`) is the
+ * agent's own deterministic declaration (or an exit classification) and wins
+ * outright — this is what lets a self-reported headless agent be detected as done
+ * before its process exits, and dissolves the no-progress-node gate (declaring
+ * done IS a `create_graph` call). Otherwise fall back to the runtime heuristic:
+ * exited, or sustained-idle past the threshold with the progress-node gate met.
+ */
+function isSelfComplete(
+    record: TerminalRecord,
+    graph: Graph,
+    now: number,
+    deps: IsAgentCompleteDeps,
+): boolean {
+    if (isFinishedLifecycle(record.terminalData.lifecycle)) return true
+
+    const status: AgentStatus = getAgentStatus(record)
+    if (status === 'running') return false
+    if (status === 'exited') return true // process gone, can't come back
+
+    // Agent is idle — only done if sustained idle for ≥ 7s
+    const idleSince: number | null = deps.getIdleSince(record.terminalId)
+    if (idleSince === null || (now - idleSince) < SUSTAINED_IDLE_MS) return false
+
+    // If agent hasn't created any progress nodes, don't consider complete —
+    // it's likely still working (between tool calls or waiting on sub-agents).
+    // Safety valve: after 30 minutes from spawn, consider complete anyway so orchestration doesn't hang.
+    const indexNodes: readonly {readonly nodeId: string; readonly title: string}[] = deps.getAgentNodes(record.terminalId)
+    const graphNodes: Array<{nodeId: string; title: string}> = deps.getNewNodesForAgent(graph, record.terminalData.agentName, record.spawnedAt)
+    if (indexNodes.length === 0 && graphNodes.length === 0) {
+        const aliveMs: number = now - record.spawnedAt
+        if (!Number.isFinite(aliveMs) || aliveMs < NO_PROGRESS_TIMEOUT_MS) {
+            return false
+        }
+    }
+    return true
+}
+
+/**
  * Check if an agent and all its descendant children are complete.
  * An agent with active (non-complete) children is NOT considered complete,
- * even if the agent itself is idle — it's waiting for its children to finish.
+ * even if the agent itself is done — it's waiting for its children to finish.
  *
  * Uses a visited set to prevent infinite recursion from cycles in the
  * parent-child graph (e.g., replaceSelf creating terminalId === parentTerminalId).
@@ -68,28 +135,7 @@ export function isAgentComplete(
     if (seen.has(record.terminalId)) return true // cycle — treat as complete to break recursion
     seen.add(record.terminalId)
 
-    const status: AgentStatus = getAgentStatus(record)
-    if (status === 'running') return false
-
-    // Exited agents are immediately done (can't come back)
-    if (status === 'exited') return true
-
-    // Agent is idle — only done if sustained idle for ≥ 7s
-    const idleSince: number | null = deps.getIdleSince(record.terminalId)
-    const selfComplete: boolean = idleSince !== null && (now - idleSince) >= SUSTAINED_IDLE_MS
-    if (!selfComplete) return false
-
-    // If agent hasn't created any progress nodes, don't consider complete —
-    // it's likely still working (between tool calls or waiting on sub-agents).
-    // Safety valve: after 30 minutes from spawn, consider complete anyway so orchestration doesn't hang.
-    const indexNodes: readonly {readonly nodeId: string; readonly title: string}[] = deps.getAgentNodes(record.terminalId)
-    const graphNodes: Array<{nodeId: string; title: string}> = deps.getNewNodesForAgent(graph, record.terminalData.agentName, record.spawnedAt)
-    if (indexNodes.length === 0 && graphNodes.length === 0) {
-        const aliveMs: number = now - record.spawnedAt
-        if (!Number.isFinite(aliveMs) || aliveMs < NO_PROGRESS_TIMEOUT_MS) {
-            return false
-        }
-    }
+    if (!isSelfComplete(record, graph, now, deps)) return false
 
     // Check all child terminals are also complete (recursive, with cycle detection)
     const children: TerminalRecord[] = getChildRecords(record.terminalId, allRecords)


### PR DESCRIPTION
wait_for_agents could poll forever (or stall ~30 min) without ever notifying
the orchestrator. isAgentComplete derived completion purely from heuristics —
process exit + an output-idle signal that getAgentStatus deliberately ignores
for headless agents (returns 'running' until the process exits). The accurate,
deterministic signal an agent already emits — lifecycle 'completed'/'errored',
set by create_graph's agentStatus self-report (or by exit classification) — was
never consulted by the completion check, only by the UI.

isAgentComplete now treats a settled lifecycle as authoritative (layer 1), with
the exit/idle+progress-node heuristic as fallback (layer 2); the subtree-complete
recursion is preserved so a self-reported parent still waits on running children.
Because declaring done IS a create_graph call, this also dissolves the 30-min
no-progress gate for self-reporting agents.

Completion reporting is made lifecycle-aware via getReportedStatus so the monitor
no longer prints a contradictory 'completed ... [running]' for a headless agent
that finished before its process exited. getAgentStatus stays the runtime
heuristic used by close_agent and the idle-nudge.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
