### PR TITLE
dev lochlan

### DIFF
--- a/packages/measures/budgets/subgraph/tree-width-approx.json
+++ b/packages/measures/budgets/subgraph/tree-width-approx.json
@@ -66,7 +66,7 @@
     "vt-daemon-protocol/__root__": 3,
     "vt-daemon/__root__": 0,
     "vt-daemon/_shared": 0,
-    "vt-daemon/agent-runtime": 13,
+    "vt-daemon/agent-runtime": 14,
     "vt-daemon/config": 1,
     "vt-daemon/create-graph": 2,
     "vt-daemon/hooks": 1,

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/tests/tmux/tmux-session-manager.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/tests/tmux/tmux-session-manager.test.ts
@@ -112,6 +112,24 @@ describe('tmux-session-manager', () => {
         await waitFor(async () => (await readIfExists(envPath)) === 'BF310_TEST_VAL')
     })
 
+    it('strips $TMUX/$TMUX_PANE inside the pane so an in-pane tmux cannot kill the control server', async () => {
+        const name: string = sessionName()
+        const dir: string = await makeTempDir()
+        const outPath: string = join(dir, 'tmux-handle.out')
+        sessions.add(name)
+
+        await createSession(
+            name,
+            `sh -c 'printf "[%s][%s]" "$TMUX" "$TMUX_PANE" > ${outPath}; sleep 5'`,
+        )
+
+        // tmux sets both vars to the control-server handle in every pane; the
+        // guard must strip them so the pane sees them empty. Otherwise a bare
+        // `tmux kill-server` in the pane would nuke the whole fleet.
+        await waitFor(async () => (await readIfExists(outPath)).startsWith('['))
+        expect(await readIfExists(outPath)).toBe('[][]')
+    })
+
     it('lists tmux sessions and reads session-scoped environment variables', async () => {
         const name: string = sessionName()
         sessions.add(name)

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/tmux/tmux-session-manager.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/tmux/tmux-session-manager.ts
@@ -130,7 +130,15 @@ async function createSessionOnly(
         '-s',
         sessionName,
         ...envArgs,
-        command,
+        // Strip the control-server handle from the pane. Every vt agent runs in
+        // a pane on the SHARED vt tmux control server and tmux sets
+        // $TMUX/$TMUX_PANE pointing at it, so a bare `tmux kill-server` (or any
+        // un-scoped `tmux kill-*`) run INSIDE a pane tears down the whole fleet
+        // at once — the exact incident this guards against. Unsetting them makes
+        // an in-pane tmux fall back to its own default socket; the daemon
+        // addresses the control server via explicit `-S` from outside, so
+        // relay/attach is intact.
+        `unset TMUX TMUX_PANE; ${command}`,
     ])
     return {pid: parsePid(result.stdout, sessionName)}
 }

--- a/packages/systems/vt-daemon/src/config/vtdAgentRuntimeWiring.test.ts
+++ b/packages/systems/vt-daemon/src/config/vtdAgentRuntimeWiring.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, it} from 'vitest'
+import * as O from 'fp-ts/lib/Option.js'
+import type {FilePath} from '@vt/graph-model/graph'
+import {configureAgentRuntimeForVtd} from './vtdAgentRuntimeWiring.ts'
+import {getRuntimeEnv, type GraphStateBridge} from '../agent-runtime/runtime/runtime-config.ts'
+
+// Black-box contract test for `configureAgentRuntimeForVtd`.
+//
+// Regression guard: vtd used to register an `env` provider carrying ONLY
+// `getVtBinDir`, leaving `getProjectRoot`/`getWriteFolderPath` undefined. Every
+// project-root-dependent feature that reads `getRuntimeEnv().getProjectRoot`
+// (recovery discovery, the tmux namespace resolver, terminal-manager,
+// removePersistedAgentRecord) then resolved null — so the resume / Surviving
+// Agents UI was dark for every vtd project. We assert the env provider now
+// surfaces project resolution by delegating to the injected graph bridge.
+//
+// The graph bridge is an injected boundary dependency, not an internal: we
+// feed a fake one in and assert on the observable env-provider output.
+
+function fakeGraphBridge(overrides: Partial<GraphStateBridge>): GraphStateBridge {
+    const notImplemented = (name: string) => (): never => {
+        throw new Error(`fakeGraphBridge.${name} not implemented`)
+    }
+    return {
+        getGraph: notImplemented('getGraph'),
+        getProjectPaths: notImplemented('getProjectPaths'),
+        getWriteFolderPath: notImplemented('getWriteFolderPath'),
+        getProjectRoot: notImplemented('getProjectRoot'),
+        getWatchStatus: notImplemented('getWatchStatus'),
+        applyGraphDelta: notImplemented('applyGraphDelta'),
+        createContextNode: notImplemented('createContextNode'),
+        createContextNodeFromSelectedNodes: notImplemented('createContextNodeFromSelectedNodes'),
+        getUnseenNodesAroundContextNode: notImplemented('getUnseenNodesAroundContextNode'),
+        updateContextNodeContainedIds: notImplemented('updateContextNodeContainedIds'),
+        ...overrides,
+    }
+}
+
+describe('configureAgentRuntimeForVtd — env project resolution', () => {
+    const projectRoot = '/Users/test/voicetree/proj' as FilePath
+    const writeFolder = '/Users/test/voicetree/proj/voicetree-x' as FilePath
+
+    function configure(): void {
+        configureAgentRuntimeForVtd(
+            '/Users/test/voicetree/packages/systems/voicetree-cli',
+            () => undefined,
+            fakeGraphBridge({
+                getProjectRoot: async (): Promise<FilePath | null> => projectRoot,
+                getWriteFolderPath: async (): Promise<O.Option<FilePath>> => O.some(writeFolder),
+            }),
+        )
+    }
+
+    it('exposes getProjectRoot from the graph bridge (was undefined → recovery dark)', async () => {
+        configure()
+        const env = getRuntimeEnv()
+        await expect(env.getProjectRoot?.()).resolves.toBe(projectRoot)
+    })
+
+    it('exposes getWriteFolderPath as a nullable (Option unwrapped) for the namespace fallback', async () => {
+        configure()
+        const env = getRuntimeEnv()
+        await expect(env.getWriteFolderPath?.()).resolves.toBe(writeFolder)
+    })
+
+    it('maps a None write-folder to null rather than leaking the Option', async () => {
+        configureAgentRuntimeForVtd(
+            '/Users/test/voicetree/packages/systems/voicetree-cli',
+            () => undefined,
+            fakeGraphBridge({
+                getProjectRoot: async (): Promise<FilePath | null> => projectRoot,
+                getWriteFolderPath: async (): Promise<O.Option<FilePath>> => O.none,
+            }),
+        )
+        const env = getRuntimeEnv()
+        await expect(env.getWriteFolderPath?.()).resolves.toBeNull()
+    })
+})

--- a/packages/systems/vt-daemon/src/config/vtdAgentRuntimeWiring.ts
+++ b/packages/systems/vt-daemon/src/config/vtdAgentRuntimeWiring.ts
@@ -11,6 +11,7 @@
 // location, so the caller passes the already-resolved dir in here.
 
 import {existsSync} from 'node:fs'
+import * as O from 'fp-ts/lib/Option.js'
 import type {TerminalRegistryEvent} from '@vt/vt-daemon-protocol'
 import {registerChildIfMonitored} from '../agent-runtime/agent-control/agent-completion-monitor.ts'
 import {configureAgentRuntime, type GraphStateBridge} from '../agent-runtime/runtime/runtime-config.ts'
@@ -31,9 +32,20 @@ export function configureAgentRuntimeForVtd(
 ): void {
     const vtBinDir: string | null = resolveVtBinDir(voicetreeCliPackageDir, existsSync)
 
+    // Project-root resolution must be exposed on the agent-runtime `env`
+    // provider, NOT only on the graph bridge: recovery discovery, the tmux
+    // namespace resolver, terminal-manager, and removePersistedAgentRecord all
+    // read `getRuntimeEnv().getProjectRoot` (and the namespace resolver falls
+    // back to `getWriteFolderPath`). Registering only `getVtBinDir` left those
+    // returning null, so `discoverRecoverableAgentSessions` enumerated zero
+    // records and the resume/Surviving-Agents UI was dark for every vtd
+    // project. Delegate to the graph bridge so there is a single source of truth.
     configureAgentRuntime({
         env: {
             getVtBinDir: (): string | null => vtBinDir,
+            getProjectRoot: (): Promise<string | null> => graph.getProjectRoot(),
+            getWriteFolderPath: async (): Promise<string | null> =>
+                O.toNullable(await graph.getWriteFolderPath()),
         },
         publishTerminalRegistryEvent,
         graph,

--- a/packages/systems/vt-daemon/src/rpc/recoveryRoutes.test.ts
+++ b/packages/systems/vt-daemon/src/rpc/recoveryRoutes.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from 'vitest'
+import type {NodeIdAndFilePath} from '@vt/graph-model/graph'
+import type {TerminalData, TerminalId} from '@vt/vt-daemon-protocol'
+import {uiLaunchEventForRecoveryResult} from './recoveryRoutes.ts'
+
+// Black-box test for the pure result→event mapping that closes the
+// resume/fork "invisible in browser-mode" gap: the normal spawn path emits
+// `terminal-ui-launch`, the recovery functions did not. The route fires this
+// event; here we pin the mapping (in/out, no side effects).
+
+const ctxNode = '/proj/voicetree-x/ctx-nodes/node_abc_context.md' as NodeIdAndFilePath
+const terminalData = {terminalId: 'Kai' as TerminalId, attachedToContextNodeId: ctxNode} as TerminalData
+
+describe('uiLaunchEventForRecoveryResult', () => {
+    it('maps a spawned resume result to a terminal-ui-launch event anchored at the context node', () => {
+        const event = uiLaunchEventForRecoveryResult({kind: 'spawned', pid: 4242, command: 'claude --resume x', terminalData})
+        expect(event).toEqual({
+            type: 'terminal-ui-launch',
+            nodeId: ctxNode,
+            terminalData,
+            skipFitAnimation: true,
+        })
+    })
+
+    it('maps a spawned fork result the same way (forkedTerminalId does not affect the launch)', () => {
+        const event = uiLaunchEventForRecoveryResult({
+            kind: 'spawned',
+            forkedTerminalId: 'Kai-fork' as TerminalId,
+            pid: 7,
+            command: 'claude --resume y',
+            terminalData,
+        })
+        expect(event?.type).toBe('terminal-ui-launch')
+        expect(event?.nodeId).toBe(ctxNode)
+        expect(event?.terminalData).toBe(terminalData)
+    })
+
+    it('returns null for a stale (not-in-discovery) result — nothing to launch', () => {
+        expect(uiLaunchEventForRecoveryResult({kind: 'stale', reason: 'not-in-discovery'})).toBeNull()
+    })
+
+    it('returns null for a spawn-failed result', () => {
+        expect(uiLaunchEventForRecoveryResult({kind: 'spawn-failed', error: 'boom'})).toBeNull()
+    })
+
+    it('returns null for a no-native-session result', () => {
+        expect(
+            uiLaunchEventForRecoveryResult({kind: 'no-native-session', cliType: 'claude', reason: 'not-found'}),
+        ).toBeNull()
+    })
+})

--- a/packages/systems/vt-daemon/src/rpc/recoveryRoutes.ts
+++ b/packages/systems/vt-daemon/src/rpc/recoveryRoutes.ts
@@ -20,10 +20,34 @@ import type {
     ForkAgentSession,
     RemovePersistedAgentRecord,
     RecoverableAgentSession as WireRecoverableAgentSession,
+    TerminalRegistryEvent,
 } from '@vt/vt-daemon-protocol'
+import {publishTerminalRegistryEvent} from '../agent-runtime/terminals/terminal-registry/terminal-registry-publisher.ts'
 
 import {type RpcRoute} from './RpcRoute.ts'
 import {buildJsonResponse, type McpToolResponse} from '@vt/vt-daemon/_shared/toolResponse.ts'
+
+/**
+ * The normal spawn path (launchTerminalSpawn) emits `terminal-ui-launch` after
+ * creating the tmux session so the renderer mounts the terminal window. The
+ * recovery functions create the session (via spawnTmuxBackedTerminal) but never
+ * emitted it, so a resumed/forked agent stayed invisible in browser-mode even
+ * once discovery surfaced it. Map a successful recovery result to the event the
+ * renderer needs; the route fires it at the edge (the session already exists,
+ * so the renderer's WS attach lands on a live pane). Non-`spawned` results
+ * (stale row, no native session, spawn failure) launch nothing.
+ */
+export function uiLaunchEventForRecoveryResult(
+    result: ResumePersistedAgentSession.Response | ForkAgentSession.Response,
+): Extract<TerminalRegistryEvent, {type: 'terminal-ui-launch'}> | null {
+    if (result.kind !== 'spawned') return null
+    return {
+        type: 'terminal-ui-launch',
+        nodeId: result.terminalData.attachedToContextNodeId,
+        terminalData: result.terminalData,
+        skipFitAnimation: true,
+    }
+}
 
 const discoverRecoverableAgentSessionsRoute: RpcRoute = {
     name: 'discoverRecoverableAgentSessions',
@@ -64,6 +88,8 @@ const resumePersistedAgentSessionRoute: RpcRoute = {
     handler: async (args: Record<string, unknown>): Promise<McpToolResponse> => {
         const req: ResumePersistedAgentSession.Request = args as unknown as ResumePersistedAgentSession.Request
         const result: ResumePersistedAgentSession.Response = await resumePersistedAgentSession(req.terminalId as TerminalId)
+        const launch = uiLaunchEventForRecoveryResult(result)
+        if (launch) publishTerminalRegistryEvent(launch)
         return buildJsonResponse(result)
     },
 }
@@ -76,6 +102,8 @@ const forkAgentSessionRoute: RpcRoute = {
     handler: async (args: Record<string, unknown>): Promise<McpToolResponse> => {
         const req: ForkAgentSession.Request = args as unknown as ForkAgentSession.Request
         const result: ForkAgentSession.Response = await forkAgentSession(req.sourceTerminalId as TerminalId)
+        const launch = uiLaunchEventForRecoveryResult(result)
+        if (launch) publishTerminalRegistryEvent(launch)
         return buildJsonResponse(result)
     },
 }


### PR DESCRIPTION
- fix(vtd): wire getProjectRoot/getWriteFolderPath onto agent-runtime env
- chore(budgets): bump agent-runtime tree-width-approx baseline 13->14
- fix(tmux): strip $TMUX/$TMUX_PANE from agent panes (defense in depth)
- fix(recovery): publish terminal-ui-launch on resume/fork so the agent renders
- fix(vtd): un-dark agent recovery + guard the tmux fleet-kill
