### PR TITLE
feat(cli): vt agent fork [terminalId] — branch a live/exited agent into a new terminal

### DIFF
--- a/packages/systems/voicetree-cli/src/commands/runtime/agent.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agent.ts
@@ -1,9 +1,11 @@
 import {requireTerminalId} from '../graph/core/args'
 import {callDaemon} from '../daemon-client'
 import {error, output} from '../output'
+import {formatForkResult, type ForkOutcome} from './agentForkFormat'
 import {formatResumeResult, type ResumeOutcome} from './agentResumeFormat'
 import {
     AGENT_CLOSE_SPEC,
+    AGENT_FORK_SPEC,
     AGENT_LIST_SPEC,
     AGENT_OUTPUT_SPEC,
     AGENT_RESUME_SPEC,
@@ -404,6 +406,36 @@ export async function agentResume(
     }
 
     const outcome: ResumeOutcome = formatResumeResult(targetTerminalId, record)
+    if (!outcome.ok) {
+        error(outcome.message)
+    }
+
+    output(record, (): string => outcome.message)
+}
+
+export async function agentFork(
+    terminalId: string | undefined,
+    args: string[]
+): Promise<void> {
+    if (isHelpRequest(args)) {
+        printHelp(AGENT_FORK_SPEC)
+        return
+    }
+
+    const parsedArgs: ParsedArgs = parseArgs(args, AGENT_FORK_SPEC)
+
+    if (parsedArgs.positionals.length > 1) {
+        error('`agent fork` accepts at most one source terminal ID')
+    }
+
+    const sourceTerminalId: string = parsedArgs.positionals[0] ?? requireTerminalId(terminalId)
+    const payload: unknown = await callDaemon('forkAgentSession', {sourceTerminalId})
+    const record: JsonRecord | undefined = asRecord(payload)
+    if (!record) {
+        error('Voicetree daemon returned an unexpected payload')
+    }
+
+    const outcome: ForkOutcome = formatForkResult(sourceTerminalId, record)
     if (!outcome.ok) {
         error(outcome.message)
     }

--- a/packages/systems/voicetree-cli/src/commands/runtime/agentFork.test.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agentFork.test.ts
@@ -1,0 +1,163 @@
+import {afterEach, describe, expect, it, vi, type Mock, type MockInstance} from 'vitest'
+import {formatForkResult, type ForkOutcome} from './agentForkFormat.ts'
+import {agentFork} from './agent.ts'
+import {callDaemon} from '../daemon-client.ts'
+import {CliError} from '../output.ts'
+
+vi.mock('../daemon-client.ts', () => ({
+    callDaemon: vi.fn(),
+}))
+
+const mockedCallDaemon: Mock = vi.mocked(callDaemon)
+
+describe('formatForkResult — result-kind formatting', () => {
+    it('maps `spawned` to an ok line naming source, forked terminal, pid, and command', () => {
+        const outcome: ForkOutcome = formatForkResult('Amit', {
+            kind: 'spawned',
+            forkedTerminalId: 'Amit_1',
+            pid: 4242,
+            command: 'claude --resume abc123',
+        })
+        expect(outcome.ok).toBe(true)
+        expect(outcome.message).toContain('Amit')
+        expect(outcome.message).toContain('Amit_1')
+        expect(outcome.message).toContain('4242')
+        expect(outcome.message).toContain('claude --resume abc123')
+    })
+
+    it.each([
+        ['no-resume-handle', /no resume handle/],
+        ['not-in-discovery', /no recoverable session is in discovery/],
+    ])('maps `stale` reason %s to a non-ok line', (reason, matcher) => {
+        const outcome: ForkOutcome = formatForkResult('Amit', {kind: 'stale', reason})
+        expect(outcome.ok).toBe(false)
+        expect(outcome.message).toMatch(matcher)
+        expect(outcome.message).toContain('Amit')
+    })
+
+    it('maps `no-native-session` to a non-ok line naming the CLI and reason', () => {
+        const outcome: ForkOutcome = formatForkResult('Amit', {
+            kind: 'no-native-session',
+            cliType: 'claude',
+            reason: 'no-transcript-found',
+        })
+        expect(outcome.ok).toBe(false)
+        expect(outcome.message).toContain('claude')
+        expect(outcome.message).toContain('no-transcript-found')
+    })
+
+    it('includes the diagnostic session id when present', () => {
+        const outcome: ForkOutcome = formatForkResult('Amit', {
+            kind: 'no-native-session',
+            cliType: 'codex',
+            reason: 'ambiguous-match',
+            diagnosticSessionId: 'sess-99',
+        })
+        expect(outcome.message).toContain('sess-99')
+    })
+
+    it('maps `unsupported` to a non-ok line naming the reason', () => {
+        const outcome: ForkOutcome = formatForkResult('Amit', {
+            kind: 'unsupported',
+            reason: 'gemini-not-supported',
+        })
+        expect(outcome.ok).toBe(false)
+        expect(outcome.message).toContain('gemini-not-supported')
+    })
+
+    it('maps `spawn-failed` to a non-ok line carrying the error detail', () => {
+        const outcome: ForkOutcome = formatForkResult('Amit', {
+            kind: 'spawn-failed',
+            error: 'tmux session create failed',
+        })
+        expect(outcome.ok).toBe(false)
+        expect(outcome.message).toContain('tmux session create failed')
+    })
+
+    it('degrades an unrecognised kind to a non-ok line instead of throwing', () => {
+        const outcome: ForkOutcome = formatForkResult('Amit', {kind: 'who-knows'})
+        expect(outcome.ok).toBe(false)
+        expect(outcome.message).toContain('who-knows')
+    })
+})
+
+describe('agentFork — argument parsing and RPC wiring', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+        mockedCallDaemon.mockReset()
+    })
+
+    it('defaults omitted source terminal id to the caller terminal id', async () => {
+        mockedCallDaemon.mockResolvedValue({
+            kind: 'spawned',
+            forkedTerminalId: 'Raj_1',
+            pid: 123,
+            command: 'codex resume sess-1',
+        })
+        vi.spyOn(console, 'log').mockImplementation((): void => {})
+
+        await agentFork('Raj', [])
+
+        expect(mockedCallDaemon).toHaveBeenCalledWith('forkAgentSession', {sourceTerminalId: 'Raj'})
+    })
+
+    it('uses an explicit positional source terminal id when given', async () => {
+        mockedCallDaemon.mockResolvedValue({
+            kind: 'spawned',
+            forkedTerminalId: 'Amit_1',
+            pid: 123,
+            command: 'claude --resume sess-1',
+        })
+        vi.spyOn(console, 'log').mockImplementation((): void => {})
+
+        await agentFork('Raj', ['Amit'])
+
+        expect(mockedCallDaemon).toHaveBeenCalledWith('forkAgentSession', {sourceTerminalId: 'Amit'})
+    })
+
+    it('does not require caller terminal id when an explicit source is given', async () => {
+        mockedCallDaemon.mockResolvedValue({
+            kind: 'spawned',
+            forkedTerminalId: 'Amit_1',
+            pid: 123,
+            command: 'claude --resume sess-1',
+        })
+        vi.spyOn(console, 'log').mockImplementation((): void => {})
+
+        await agentFork(undefined, ['Amit'])
+
+        expect(mockedCallDaemon).toHaveBeenCalledWith('forkAgentSession', {sourceTerminalId: 'Amit'})
+    })
+
+    it('rejects when no caller terminal id is available for self-fork default', async () => {
+        await expect(agentFork(undefined, [])).rejects.toBeInstanceOf(CliError)
+        expect(mockedCallDaemon).not.toHaveBeenCalled()
+    })
+
+    it('rejects when more than one positional is given', async () => {
+        await expect(agentFork('Raj', ['a', 'b'])).rejects.toBeInstanceOf(CliError)
+        expect(mockedCallDaemon).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unknown flag before reaching the daemon', async () => {
+        await expect(agentFork('Raj', ['Amit', '--bogus'])).rejects.toBeInstanceOf(CliError)
+        expect(mockedCallDaemon).not.toHaveBeenCalled()
+    })
+
+    it('prints usage for --help and returns without contacting the daemon', async () => {
+        const logged: string[] = []
+        const logSpy: MockInstance = vi
+            .spyOn(console, 'log')
+            .mockImplementation((...values: unknown[]): void => {
+                logged.push(values.map((value: unknown): string => String(value)).join(' '))
+            })
+
+        await agentFork(undefined, ['--help'])
+
+        logSpy.mockRestore()
+        const output: string = logged.join('\n')
+        expect(output).toContain('vt agent fork')
+        expect(output).toContain('[terminalId]')
+        expect(mockedCallDaemon).not.toHaveBeenCalled()
+    })
+})

--- a/packages/systems/voicetree-cli/src/commands/runtime/agentForkFormat.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agentForkFormat.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure interpretation of a `forkAgentSession` RPC result.
+ *
+ * Forking mirrors resume's recovery-result handling but creates a branched
+ * terminal under a fresh terminalId. The daemon reports all outcomes as a
+ * discriminated `kind`; `spawned` is the only successful kind.
+ */
+
+type JsonRecord = Record<string, unknown>
+
+export type ForkOutcome = {
+    readonly ok: boolean
+    readonly message: string
+}
+
+function optionalString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+export function formatForkResult(sourceTerminalId: string, payload: JsonRecord): ForkOutcome {
+    const kind: unknown = payload.kind
+    switch (kind) {
+        case 'spawned': {
+            const forkedTerminalId: string = optionalString(payload.forkedTerminalId) ?? '(unknown terminal)'
+            const pid: unknown = payload.pid
+            const command: string = optionalString(payload.command) ?? '(unknown command)'
+            return {
+                ok: true,
+                message: `Forked ${sourceTerminalId} → ${forkedTerminalId} (pid ${String(pid)}).\nCommand: ${command}`,
+            }
+        }
+        case 'stale': {
+            const reason: string | undefined = optionalString(payload.reason)
+            const detail: string = reason === 'no-resume-handle'
+                ? 'the session carries no resume handle (not a forkable CLI session)'
+                : 'no recoverable session is in discovery (its record may have been removed)'
+            return {ok: false, message: `Cannot fork ${sourceTerminalId}: ${detail}.`}
+        }
+        case 'no-native-session': {
+            const cliType: string = optionalString(payload.cliType) ?? 'CLI'
+            const reason: string = optionalString(payload.reason) ?? 'not-found'
+            const diagnostic: string | undefined = optionalString(payload.diagnosticSessionId)
+            const diagnosticSuffix: string = diagnostic ? ` (diagnostic session ${diagnostic})` : ''
+            return {
+                ok: false,
+                message: `Cannot fork ${sourceTerminalId}: no ${cliType} native session found — ${reason}${diagnosticSuffix}.`,
+            }
+        }
+        case 'unsupported': {
+            const reason: string = optionalString(payload.reason) ?? 'unsupported session'
+            return {ok: false, message: `Cannot fork ${sourceTerminalId}: unsupported — ${reason}.`}
+        }
+        case 'spawn-failed': {
+            const detail: string = optionalString(payload.error) ?? 'unknown spawn error'
+            return {ok: false, message: `Failed to fork ${sourceTerminalId}: ${detail}.`}
+        }
+        default:
+            return {
+                ok: false,
+                message: `Cannot fork ${sourceTerminalId}: daemon returned an unrecognised result kind \`${String(kind)}\`.`,
+            }
+    }
+}

--- a/packages/systems/voicetree-cli/src/commands/runtime/agentSpecs.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agentSpecs.ts
@@ -97,6 +97,14 @@ export const AGENT_RESUME_SPEC: SubcommandSpec = {
     flags: [],
 }
 
+export const AGENT_FORK_SPEC: SubcommandSpec = {
+    verb: 'vt agent fork',
+    rpcTool: 'forkAgentSession',
+    usageTail: '[terminalId]',
+    summary: 'Fork a live (or exited) agent into a new branched terminal. Defaults to the caller.',
+    flags: [],
+}
+
 export const AGENT_SEND_SPEC: SubcommandSpec = {
     verb: 'vt agent send',
     rpcTool: 'send_message',

--- a/packages/systems/voicetree-cli/src/voicetree-cli.ts
+++ b/packages/systems/voicetree-cli/src/voicetree-cli.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path'
 import {fileURLToPath} from 'node:url'
 import {
     agentClose,
+    agentFork,
     agentList,
     agentOutput,
     agentResume,
@@ -60,6 +61,7 @@ Subcommands:
   wait      Start background monitoring for one or more agents
   close     Close an agent terminal
   resume    Resume a closed/exited agent under its original terminalId
+  fork      Fork a live or exited agent into a new branched terminal
   send      Send a message to an agent terminal
   output    Read buffered agent output`
 
@@ -137,6 +139,9 @@ async function dispatchAgentCommand(
             return
         case 'resume':
             await agentResume(terminalId, args)
+            return
+        case 'fork':
+            await agentFork(terminalId, args)
             return
         case 'send':
             await agentSend(terminalId, args)
@@ -254,7 +259,7 @@ function readVtVersion(): string {
 }
 
 const KNOWN_AGENT_SUBS: ReadonlySet<string> = new Set([
-    'spawn', 'list', 'wait', 'close', 'resume', 'send', 'output',
+    'spawn', 'list', 'wait', 'close', 'resume', 'fork', 'send', 'output',
 ])
 const KNOWN_GRAPH_SUBS: ReadonlySet<string> = new Set([
     'create', 'index', 'search', 'unseen', 'live', 'structure', 'lint', 'complexity', 'rename', 'mv', 'group',


### PR DESCRIPTION
Adds the CLI entry point for forking. Fork = resume a (typically LIVE) agent's
native session into a NEW terminalId, parented to the source, so both run — the
distinguishing case from `vt agent resume` (which reclaims the same id of a dead
agent). Wraps the existing `forkAgentSession` RPC; no daemon or protocol changes.

- `vt agent fork [terminalId]` — defaults to the caller's own terminal id, so an
  agent can fork itself (`$VOICETREE_TERMINAL_ID`).
- agentForkFormat.ts: pure formatter mapping every ForkAgentSessionResult kind
  (spawned/stale/no-native-session/unsupported/spawn-failed) to a clear line;
  only `spawned` is success.
- No -m divergence prompt by design (redirect a fork afterward with `vt agent send`).

Tests: +15 (arg parsing incl. self-default + every result-kind). CLI typecheck clean.
Verified on real data: current-code engine resolved a live Codex agent's real
session and built `codex resume <id>` with parent=source.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
