### PR TITLE
fix(recovery): accurate marker-mismatch copy + honest 'spawned' wire type

### DIFF
--- a/openspec/changes/fix-resume-recovery-and-surviving-agents-ux/specs/surviving-agent-session-resume/spec.md
+++ b/openspec/changes/fix-resume-recovery-and-surviving-agents-ux/specs/surviving-agent-session-resume/spec.md
@@ -96,7 +96,7 @@ Claude resolver `reason` values:
 #### Scenario: Marker mismatch reports actionable detail
 - **WHEN** the resolver finds candidate rows but none contain `VOICETREE_TERMINAL_ID = <id>` matched against this project
 - **THEN** `not-found` reason is `marker-mismatch`
-- **AND** the UI says: "No matching session — likely the project was moved or the task node renamed since spawn"
+- **AND** the UI says: "No saved transcript matched this session — its conversation log may have been deleted or never recorded"
 
 ### Requirement: Codex Resume produces a manually-runnable `codex resume` command
 

--- a/packages/libraries/vt-daemon-protocol/src/rpc/rpc-contracts.ts
+++ b/packages/libraries/vt-daemon-protocol/src/rpc/rpc-contracts.ts
@@ -112,14 +112,14 @@ export interface RecoverableAgentSession {
 }
 
 export type ResumePersistedResult =
-    | {readonly kind: 'spawned'; readonly pid: number; readonly command: string}
+    | {readonly kind: 'spawned'; readonly pid: number; readonly command: string; readonly terminalData: TerminalData}
     | {readonly kind: 'stale'; readonly reason: 'not-in-discovery' | 'already-claimed' | 'no-resume-handle'}
     | {readonly kind: 'no-native-session'; readonly cliType: 'claude' | 'codex'}
     | {readonly kind: 'unsupported'; readonly reason: 'gemini-not-supported' | 'custom-cli-not-supported' | 'empty-session-id' | 'missing-initial-command' | 'no-cli-detected' | 'missing-project-root'}
     | {readonly kind: 'spawn-failed'; readonly error: string}
 
 export type ForkAgentSessionResult =
-    | {readonly kind: 'spawned'; readonly forkedTerminalId: TerminalId; readonly pid: number; readonly command: string}
+    | {readonly kind: 'spawned'; readonly forkedTerminalId: TerminalId; readonly pid: number; readonly command: string; readonly terminalData: TerminalData}
     | {readonly kind: 'stale'; readonly reason: 'not-in-discovery' | 'no-resume-handle'}
     | {readonly kind: 'no-native-session'; readonly cliType: 'claude' | 'codex'}
     | {readonly kind: 'unsupported'; readonly reason: 'gemini-not-supported' | 'custom-cli-not-supported' | 'empty-session-id' | 'missing-initial-command' | 'no-cli-detected' | 'missing-project-root'}

--- a/packages/systems/vt-daemon-client/src/__tests__/wrappers.recovery.test.ts
+++ b/packages/systems/vt-daemon-client/src/__tests__/wrappers.recovery.test.ts
@@ -74,12 +74,13 @@ describe('vt-daemon-client wrappers — recovery facade', (): void => {
             resume: {cliType: 'claude'},
         },
     ]
-    const resumeResult: ResumePersistedResult = {kind: 'spawned', pid: 4242, command: 'claude --resume'}
+    const resumeResult: ResumePersistedResult = {kind: 'spawned', pid: 4242, command: 'claude --resume', terminalData: makeTerminalData('resume-1')}
     const forkResult: ForkAgentSessionResult = {
         kind: 'spawned',
         forkedTerminalId: 'forked-1' as TerminalId,
         pid: 4243,
         command: 'claude --resume --fork',
+        terminalData: makeTerminalData('forked-1'),
     }
 
     beforeEach(async (): Promise<void> => {

--- a/webapp/src/shell/UI/views/treeStyleTerminalTabs/SurvivingAgentsSection.resumeFailure.test.tsx
+++ b/webapp/src/shell/UI/views/treeStyleTerminalTabs/SurvivingAgentsSection.resumeFailure.test.tsx
@@ -107,7 +107,7 @@ const REASON_CASES: readonly ReasonCase[] = [
     {
         reason: 'marker-mismatch',
         cliType: 'codex',
-        expectedMessage: 'No matching session — likely the project was moved or the task node renamed since spawn',
+        expectedMessage: 'No saved transcript matched this session — its conversation log may have been deleted or never recorded',
     },
     {
         reason: 'no-rows',
@@ -160,7 +160,7 @@ describe('SurvivingAgentsSection — structured resume-failure reason rendering 
         });
         fireEvent.click(screen.getByRole('button', {name: /resume claude session/i}));
         const failureBlock: HTMLElement = await findByTestId('surviving-agents-resume-failure');
-        expect(failureBlock.textContent).toContain('No matching session');
+        expect(failureBlock.textContent).toContain('No saved transcript matched this session');
         expect(screen.queryByText('this generic string must not be shown')).toBeNull();
     });
 });

--- a/webapp/src/shell/UI/views/treeStyleTerminalTabs/SurvivingAgentsSection.tsx
+++ b/webapp/src/shell/UI/views/treeStyleTerminalTabs/SurvivingAgentsSection.tsx
@@ -49,7 +49,7 @@ const RESUME_FAILURE_MESSAGES: Record<NoNativeSessionResult['reason'], string> =
     'db-missing': 'Codex state database not found at ~/.codex/state_5.sqlite',
     'db-schema-mismatch': "Codex state DB schema is unexpected — voicetree can't read it",
     'outside-recency-window': "Session exists but is older than the resolver's recency window",
-    'marker-mismatch': 'No matching session — likely the project was moved or the task node renamed since spawn',
+    'marker-mismatch': 'No saved transcript matched this session — its conversation log may have been deleted or never recorded',
     'no-rows': 'No Codex threads recorded for this project',
     'projects-dir-missing': 'Claude projects directory not found at ~/.claude/projects',
     'no-jsonl-matches': 'No Claude transcripts matched this project/cwd',


### PR DESCRIPTION
## Context

The core resume bug (every resume failing with `marker-mismatch` after `b78cd40c7` dropped the `VOICETREE_PROJECT_PATH` prompt line) was **independently fixed on `dev` by 3e503f1db** — which restored the marker, hoisted the marker set into `recovery-markers.ts`, and added a contract test to prevent future template/matcher drift. That's the stronger guardrail, so this PR was rebased to **defer to that fix** and keep only the two pieces it didn't cover.

## What's left in this PR (both additive, non-overlapping with the dev fix)

**1. Honest `'spawned'` wire type** (`dc0a9676c`)
`resumePersistedAgentSession` / `forkAgentSession` return `terminalData` on their `'spawned'` result, and `recoveryRoutes.uiLaunchEventForRecoveryResult` reads it to emit the `terminal-ui-launch` event (`recoveryRoutes.test.ts` already asserts `event?.terminalData`). But the protocol contracts omitted it — 2 latent tsc errors in `recoveryRoutes.ts`. Added `terminalData: TerminalData` to both protocol `'spawned'` arms so the wire type matches what's actually sent and consumed. **`vt-daemon` now typechecks clean.**

**2. Accurate `marker-mismatch` copy** (`e16f9f255`)
The message claimed *"the project was moved or the task node renamed since spawn"* — rarely the real cause. It now reads *"No saved transcript matched this session — its conversation log may have been deleted or never recorded."* Updated UI message + spec scenario.

## Verification
- `vt-daemon`, `vt-daemon-protocol`, `vt-daemon-client`, `webapp` all typecheck clean.
- Affected suites pass, including dev's `prompt-template-recovery-markers.contract.test.ts` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)