### PR TITLE
fix(measures): tier wall-clock budget = max per-job span (kills budget-gate flake)

### DIFF
--- a/.github/workflows/measures-budget-gate.generated.yml
+++ b/.github/workflows/measures-budget-gate.generated.yml
@@ -98,6 +98,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-0-pre-commit-lint checks"
         env:
+          MEASURES_CI_JOB: tier-0-pre-commit-lint
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -131,6 +132,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-0-pre-commit-policy checks"
         env:
+          MEASURES_CI_JOB: tier-0-pre-commit-policy
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -164,6 +166,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-0-pre-commit-static checks"
         env:
+          MEASURES_CI_JOB: tier-0-pre-commit-static
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -197,6 +200,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-1-coverage checks"
         env:
+          MEASURES_CI_JOB: tier-1-coverage
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -239,6 +243,7 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
       - name: "Run tier-1-e2e check"
         env:
+          MEASURES_CI_JOB: "tier-1-e2e-${{ matrix.check_id }}"
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -285,6 +290,7 @@ jobs:
         run: pnpm --filter @vt/measures run measures:build-native:local
       - name: "Run tier-1-health checks"
         env:
+          MEASURES_CI_JOB: tier-1-health
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -318,6 +324,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-1-structure checks"
         env:
+          MEASURES_CI_JOB: tier-1-structure
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -351,6 +358,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-1-typecheck checks"
         env:
+          MEASURES_CI_JOB: tier-1-typecheck
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -385,6 +393,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-2-contract checks"
         env:
+          MEASURES_CI_JOB: tier-2-contract
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -423,6 +432,7 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
       - name: "Run tier-2-e2e checks"
         env:
+          MEASURES_CI_JOB: tier-2-e2e
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -467,6 +477,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-2-fuzz check"
         env:
+          MEASURES_CI_JOB: "tier-2-fuzz-${{ matrix.check_id }}"
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -502,6 +513,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-2-lint checks"
         env:
+          MEASURES_CI_JOB: tier-2-lint
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -536,6 +548,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-2-unit checks"
         env:
+          MEASURES_CI_JOB: tier-2-unit
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -570,6 +583,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-3-analyzers checks"
         env:
+          MEASURES_CI_JOB: tier-3-analyzers
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \
@@ -608,6 +622,7 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
       - name: "Run tier-3-e2e checks"
         env:
+          MEASURES_CI_JOB: tier-3-e2e
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           xvfb-run -a -s "-screen 0 1280x1024x24" \
@@ -645,6 +660,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "Run tier-4-analyzers checks"
         env:
+          MEASURES_CI_JOB: tier-4-analyzers
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           node --no-warnings=ExperimentalWarning --experimental-strip-types \

--- a/packages/measures/scripts/check-tier-budgets.ts
+++ b/packages/measures/scripts/check-tier-budgets.ts
@@ -110,7 +110,7 @@ type ReportLike = {
     readonly startedAt: string
     readonly endedAt: string
     readonly status: 'pass' | 'fail' | 'skip' | string
-    readonly details?: {readonly measurePath?: string}
+    readonly details?: {readonly measurePath?: string; readonly jobId?: string}
 }
 
 type TierTiming = EvaluationResult['tierTimings'][number]
@@ -144,26 +144,47 @@ function aggregateTierTimings(reports: readonly ReportLike[]): Map<number, TierT
     }
     const out = new Map<number, TierTiming>()
     for (const [tier, group] of byTier) {
-        let minStart = Number.POSITIVE_INFINITY
-        let maxEnd = Number.NEGATIVE_INFINITY
-        let sum = 0
-        let slowest: TierTiming['slowest'] = null
-        for (const r of group) {
-            const s = Date.parse(r.startedAt)
-            const e = Date.parse(r.endedAt)
-            if (Number.isNaN(s) || Number.isNaN(e)) continue
-            if (s < minStart) minStart = s
-            if (e > maxEnd) maxEnd = e
-            sum += r.durationMs
-            if (slowest === null || r.durationMs > slowest.durationMs) {
-                slowest = {checkId: r.checkId, durationMs: r.durationMs}
-            }
-        }
-        const wallClockMs = (minStart === Number.POSITIVE_INFINITY || maxEnd === Number.NEGATIVE_INFINITY)
-            ? 0 : maxEnd - minStart
-        out.set(tier, {tier, wallClockMs, sumMs: sum, checkCount: group.length, slowest})
+        out.set(tier, summarizeTier(tier, group))
     }
     return out
+}
+
+// CI splits a tier's checks across several parallel jobs — one independently
+// provisioned runner each. The real wall-clock the tier costs is the slowest
+// single job's span, never the gap between separately scheduled runners (which
+// is pure provisioning skew nobody spent on work). So wall-clock is the max
+// per-job span, keyed by the runner's jobId. Reports without a jobId (local
+// single-process runs) collapse into one group, which reduces to the whole-tier
+// span — the same number the old global aggregation produced.
+//
+// sum and slowest stay tier-global: sum gates total machine-time (a cost, not a
+// latency), and the slowest single check is meaningful regardless of its job.
+function summarizeTier(tier: number, group: readonly ReportLike[]): TierTiming {
+    const spanByJob = new Map<string, {minStart: number; maxEnd: number}>()
+    let sum = 0
+    let slowest: TierTiming['slowest'] = null
+    for (const r of group) {
+        const s = Date.parse(r.startedAt)
+        const e = Date.parse(r.endedAt)
+        if (Number.isNaN(s) || Number.isNaN(e)) continue
+        sum += r.durationMs
+        if (slowest === null || r.durationMs > slowest.durationMs) {
+            slowest = {checkId: r.checkId, durationMs: r.durationMs}
+        }
+        const jobId = r.details?.jobId ?? ''
+        const span = spanByJob.get(jobId)
+        if (span) {
+            if (s < span.minStart) span.minStart = s
+            if (e > span.maxEnd) span.maxEnd = e
+        } else {
+            spanByJob.set(jobId, {minStart: s, maxEnd: e})
+        }
+    }
+    let wallClockMs = 0
+    for (const {minStart, maxEnd} of spanByJob.values()) {
+        if (maxEnd - minStart > wallClockMs) wallClockMs = maxEnd - minStart
+    }
+    return {tier, wallClockMs, sumMs: sum, checkCount: group.length, slowest}
 }
 
 function evaluateBudgets(

--- a/packages/measures/scripts/gen-workflows.ts
+++ b/packages/measures/scripts/gen-workflows.ts
@@ -295,7 +295,7 @@ function captureCiStep(conc: ConcernSpec): Step {
         kind: 'run',
         name: `Run ${jobIdFor(conc.tier, conc.concern)} checks`,
         run: wrapped,
-        env: {NODE_OPTIONS: CAPTURE_CI_NODE_OPTIONS},
+        env: {MEASURES_CI_JOB: jobIdFor(conc.tier, conc.concern), NODE_OPTIONS: CAPTURE_CI_NODE_OPTIONS},
     }
 }
 
@@ -319,7 +319,9 @@ function captureCiMatrixStep(conc: ConcernSpec): Step {
         kind: 'run',
         name: `Run ${jobIdFor(conc.tier, conc.concern)} check`,
         run: wrapped,
-        env: {NODE_OPTIONS: CAPTURE_CI_NODE_OPTIONS},
+        // Per matrix leg → its own runner, so the budget gate sees each leg as a
+        // distinct job and never folds cross-leg provisioning skew into wall-clock.
+        env: {MEASURES_CI_JOB: `${jobIdFor(conc.tier, conc.concern)}-\${{ matrix.check_id }}`, NODE_OPTIONS: CAPTURE_CI_NODE_OPTIONS},
     }
 }
 

--- a/packages/measures/src/_runners/capture-ci-checks.ts
+++ b/packages/measures/src/_runners/capture-ci-checks.ts
@@ -12,7 +12,7 @@ import {pathToFileURL, fileURLToPath} from 'node:url'
 
 import {recordCheckReport} from '../_shared/writers/check-report-writer.ts'
 import {spawnCheck} from './capture-check-runner.ts'
-import {errorSummaryForFailedOutcome, formatFailureBody} from './failure-summary.ts'
+import {errorSummaryForFailedOutcome, formatFailuresSection, formatGithubFailureSummary} from './failure-summary.ts'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(SCRIPT_DIR, '..', '..', '..', '..')
@@ -221,6 +221,11 @@ async function recordOutcome(check, outcome) {
         : undefined
     /** @type {Record<string, unknown>} */
     const details = {exitCode: outcome.exitCode, measurePath: check.measurePath, measureFolder: check.measureFolder}
+    // Identifies the parallel CI runner this check ran on, so the budget gate can
+    // compute per-job wall-clock instead of folding in cross-runner scheduling
+    // skew. Set per job by the generated workflow; absent on local runs.
+    const jobId = process.env.MEASURES_CI_JOB?.trim()
+    if (jobId) details.jobId = jobId
     if (outcome.timedOut) details.timedOut = true
     if (outcome.signal) details.signal = outcome.signal
     if (outcome.spawnError) details.spawnError = outcome.spawnError
@@ -440,42 +445,6 @@ function formatRunHeader(opts, checks) {
 async function runAllChecks(checks, opts) {
     if (opts.failFast || opts.sequential) return runChecksSequentially(checks, opts)
     return runChecksInParallel(checks, opts)
-}
-
-function formatFailuresSection(failures) {
-    if (failures.length === 0) return ''
-    const blocks = failures.map(({check, outcome}) => {
-        const body = formatFailureBody(outcome)
-        const bodyLine = body ? `${body}\n` : ''
-        return `  ✗ ${check.id}\n${bodyLine}      report: health-dashboard/reports/checks/${check.id}.json\n`
-    })
-    return `\n  failures:\n\n${blocks.join('\n')}`
-}
-
-function formatGithubFailureSummary(failures) {
-    if (failures.length === 0) return ''
-    const lines = [
-        '## CI Check Failures',
-        '',
-        `Failed checks: ${failures.length}`,
-        '',
-        ...failures.flatMap(({check, outcome}) => {
-            const body = formatFailureBody(outcome)
-                .split('\n')
-                .map(line => line.replace(/^      /, '  '))
-                .join('\n')
-            return [
-                `### ${check.id}`,
-                '',
-                `- Category: ${check.category}`,
-                `- Report: \`health-dashboard/reports/checks/${check.id}.json\``,
-                body ? '' : undefined,
-                body || undefined,
-                '',
-            ].filter(Boolean)
-        }),
-    ]
-    return `${lines.join('\n')}\n`
 }
 
 async function appendGithubFailureSummary(failures) {

--- a/packages/measures/src/_runners/failure-summary.ts
+++ b/packages/measures/src/_runners/failure-summary.ts
@@ -53,3 +53,46 @@ export function errorSummaryForFailedOutcome(outcome: FailureSummaryInput & {rea
     }
     return undefined
 }
+
+type CheckFailure = {
+    readonly check: {readonly id: string; readonly category: string}
+    readonly outcome: FailureSummaryInput
+}
+
+// Terminal "failures:" section printed at the end of a capture-ci run.
+export function formatFailuresSection(failures: readonly CheckFailure[]): string {
+    if (failures.length === 0) return ''
+    const blocks = failures.map(({check, outcome}) => {
+        const body = formatFailureBody(outcome)
+        const bodyLine = body ? `${body}\n` : ''
+        return `  ✗ ${check.id}\n${bodyLine}      report: health-dashboard/reports/checks/${check.id}.json\n`
+    })
+    return `\n  failures:\n\n${blocks.join('\n')}`
+}
+
+// Markdown rendering appended to $GITHUB_STEP_SUMMARY when checks fail.
+export function formatGithubFailureSummary(failures: readonly CheckFailure[]): string {
+    if (failures.length === 0) return ''
+    const lines = [
+        '## CI Check Failures',
+        '',
+        `Failed checks: ${failures.length}`,
+        '',
+        ...failures.flatMap(({check, outcome}) => {
+            const body = formatFailureBody(outcome)
+                .split('\n')
+                .map(line => line.replace(/^      /, '  '))
+                .join('\n')
+            return [
+                `### ${check.id}`,
+                '',
+                `- Category: ${check.category}`,
+                `- Report: \`health-dashboard/reports/checks/${check.id}.json\``,
+                body ? '' : undefined,
+                body || undefined,
+                '',
+            ].filter(Boolean)
+        }),
+    ]
+    return `${lines.join('\n')}\n`
+}

--- a/packages/measures/src/checks/tier_4/analyzers/timing-budget-gate.test.ts
+++ b/packages/measures/src/checks/tier_4/analyzers/timing-budget-gate.test.ts
@@ -13,6 +13,7 @@ type ReportInput = {
     durationMs?: number
     status?: 'pass' | 'fail' | 'skip'
     measurePath?: string
+    jobId?: string
 }
 
 type BudgetInput = {wallClockMs: number; sumMs: number | null; perCheckMaxRatio: number}
@@ -41,7 +42,7 @@ async function withFixture<T>(
             startedAt: r.startedAt,
             endedAt: r.endedAt,
             timestamp: r.endedAt,
-            details: {measurePath},
+            details: {measurePath, ...(r.jobId ? {jobId: r.jobId} : {})},
         }), 'utf8')
     }
     for (const [tierStr, budget] of Object.entries(budgets)) {
@@ -64,7 +65,7 @@ function tierTiming(result: EvaluationResult, tier: number) {
 const TIER_1_BUDGET: BudgetInput = {wallClockMs: 5_000, sumMs: 10_000, perCheckMaxRatio: 0.5}
 
 describe('runTierBudgetGate — wall-clock aggregation', () => {
-    it('computes wall-clock as max(endedAt) - min(startedAt) per tier', async () => {
+    it('collapses checks with no jobId (local single-process runs) into one tier-wide span', async () => {
         await withFixture([
             {checkId: 'a', startedAt: '2026-01-01T00:00:00.000Z', endedAt: '2026-01-01T00:00:05.000Z'},
             {checkId: 'b', startedAt: '2026-01-01T00:00:02.000Z', endedAt: '2026-01-01T00:00:10.000Z'},
@@ -76,6 +77,37 @@ describe('runTierBudgetGate — wall-clock aggregation', () => {
             expect(t.sumMs).toBe(13_000) // 5s + 8s
             expect(t.checkCount).toBe(2)
             expect(t.slowest).toEqual({checkId: 'b', durationMs: 8_000})
+        })
+    })
+
+    it('takes the max per-job span — runner provisioning skew between parallel jobs does not count', async () => {
+        // Two parallel jobs on separate runners. Job A did 8s of work; job B's
+        // runner was slow to provision, so its 4s of work happened 35s later. The
+        // real wall-clock is the slowest single job (8s), NOT the 39s global span
+        // — the gap between independently scheduled runners is not work.
+        await withFixture([
+            {checkId: 'a1', jobId: 'job-a', startedAt: '2026-01-01T00:00:00.000Z', endedAt: '2026-01-01T00:00:08.000Z'},
+            {checkId: 'b1', jobId: 'job-b', startedAt: '2026-01-01T00:00:35.000Z', endedAt: '2026-01-01T00:00:39.000Z'},
+        ], {1: {wallClockMs: 30_000, sumMs: 30_000, perCheckMaxRatio: 0.99}}, async (opts) => {
+            const {result, exitCode} = await runTierBudgetGate(opts)
+            expect(exitCode).toBe(0)
+            const t = tierTiming(result, 1)
+            expect(t.wallClockMs).toBe(8_000) // max per-job span, not 39_000
+            expect(t.sumMs).toBe(12_000) // 8s + 4s, tier-global
+            expect(t.slowest).toEqual({checkId: 'a1', durationMs: 8_000})
+        })
+    })
+
+    it("a job's span covers all its own sequential checks (min-start to max-end within the job)", async () => {
+        // Job A runs two checks back-to-back (0–3s, 3–9s) → 9s span. Job B runs a
+        // single 5s check. Tier wall-clock = max(9s, 5s) = 9s.
+        await withFixture([
+            {checkId: 'a1', jobId: 'job-a', startedAt: '2026-01-01T00:00:00.000Z', endedAt: '2026-01-01T00:00:03.000Z'},
+            {checkId: 'a2', jobId: 'job-a', startedAt: '2026-01-01T00:00:03.000Z', endedAt: '2026-01-01T00:00:09.000Z'},
+            {checkId: 'b1', jobId: 'job-b', startedAt: '2026-01-01T00:00:01.000Z', endedAt: '2026-01-01T00:00:06.000Z'},
+        ], {1: {wallClockMs: 30_000, sumMs: 30_000, perCheckMaxRatio: 0.99}}, async (opts) => {
+            const {result} = await runTierBudgetGate(opts)
+            expect(tierTiming(result, 1).wallClockMs).toBe(9_000)
         })
     })
 


### PR DESCRIPTION
## Why
`budget-gate` flakes intermittently across PRs (it's the only red check on #254, and it alternates pass/fail on re-runs of the same branch). Root cause: the tier wall-clock budget computed wall-clock as `max(endedAt) − min(startedAt)` across **all** of a tier's checks, blind to which CI job each ran on. A tier like tier_0 runs as several independent `ubuntu-latest` jobs, so that span folds in **cross-runner provisioning skew** — time no runner spent on work.

Observed on #254: `tier_0 sum 16.1s · wall-clock 39.9s > budget 30.0s`. The ~24s gap is idle time between separately-scheduled runners, not work.

## Fix
Parallel jobs run concurrently, so a tier's real wall-clock is the **slowest single job's span**, never the gap between runners. The gate now groups a tier's checks by the runner's `jobId` and takes the **max per-job span**.

- `check-tier-budgets.ts` — `summarizeTier`: max per-job span. Reports with no `jobId` (local single-process runs) collapse into one group → the previous whole-tier span, unchanged. `sum`/`slowest` stay tier-global (sum gates total machine-time, a cost not a latency).
- `capture-ci-checks.ts` — records `details.jobId` from `$MEASURES_CI_JOB`.
- `gen-workflows.ts` — injects `MEASURES_CI_JOB` per job and per matrix leg (each leg = its own runner); generated workflow regenerated.
- `failure-summary.ts` — absorbs the two pure failure formatters relocated out of `capture-ci-checks.ts` (keeps it under the file-size gate without adding a sibling that would breach the directory-fanout gate; no limits raised).

## Verification
- `timing-budget-gate.test.ts`: 18 pass, incl. a new test proving skew between parallel jobs no longer counts (wall-clock 8s, not 39s).
- `workflows-drift.test.ts`: 10 pass — regenerated YAML matches the folder tree.
- Pre-commit tier-0 gate suite: all green (`directory-fanout`, `name-uniqueness`, lint, …), 0 failing.

Once merged to dev, the flake dies for every PR — including #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)