### PR TITLE
Cross-project agent send/spawn + rescued base work

### DIFF
--- a/packages/measures/budgets/coupling/cross-package-value-symbol-budgets.ts
+++ b/packages/measures/budgets/coupling/cross-package-value-symbol-budgets.ts
@@ -276,7 +276,13 @@ export const CROSS_PACKAGE_VALUE_SYMBOL_BUDGETS: Readonly<Record<string, number>
     // tool), `findSpecByCliVerb` (verb resolution). These are the minimum
     // necessary — each verb of `vt manual` calls exactly one of them.
     'voicetree-cli -> vt-daemon-protocol': 4,
-    'voicetree-cli -> vt-rpc': 9,
+    // 2026-06-05 [cross-project agent send]: 9 -> 10. `vt agent send
+    // <project>/<terminalId>` resolves and talks to ANOTHER project's daemon,
+    // so the CLI now imports `discoverDaemonEndpointForProject` (the explicit-
+    // path endpoint resolver) alongside the cwd-relative `discoverDaemonEndpoint`
+    // it already used. The two are genuinely distinct entry points — one
+    // discovers from the ambient project, one from a caller-supplied path.
+    'voicetree-cli -> vt-rpc': 10,
     // 2026-05-27: collapse-paths. `resolveVoicetreeHomePath` is now
     // sourced from @vt/app-config (the canonical single-line resolver), not
     // from a CLI-local mirrored copy. The function body is 1 line — the

--- a/packages/systems/graph-db-server/src/.ckignore
+++ b/packages/systems/graph-db-server/src/.ckignore
@@ -1,0 +1,65 @@
+# .ckignore - Default patterns for ck semantic search
+# Created automatically during first index
+# Syntax: same as .gitignore (glob patterns, ! for negation)
+
+# Images
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.bmp
+*.svg
+*.ico
+*.webp
+*.tiff
+
+# Video
+*.mp4
+*.avi
+*.mov
+*.mkv
+*.wmv
+*.flv
+*.webm
+
+# Audio
+*.mp3
+*.wav
+*.flac
+*.aac
+*.ogg
+*.m4a
+
+# Binary/Compiled
+*.exe
+*.dll
+*.so
+*.dylib
+*.a
+*.lib
+*.obj
+*.o
+
+# Archives
+*.zip
+*.tar
+*.tar.gz
+*.tgz
+*.rar
+*.7z
+*.bz2
+*.gz
+
+# Data files
+*.db
+*.sqlite
+*.sqlite3
+*.parquet
+*.arrow
+
+# Config formats (issue #27)
+*.json
+*.yaml
+*.yml
+
+# Add your custom patterns below this line

--- a/packages/systems/voicetree-cli/src/commands/daemon-client.ts
+++ b/packages/systems/voicetree-cli/src/commands/daemon-client.ts
@@ -23,6 +23,7 @@ import {
     ERROR_CODES,
     authTokenFilePath,
     discoverDaemonEndpoint,
+    discoverDaemonEndpointForProject,
     readAuthTokenFile,
     type ResolvedDaemonEndpoint,
 } from '@vt/vt-rpc'
@@ -104,6 +105,25 @@ async function buildResolvedClient(
     const tokenFilePath: string = authTokenFilePath(tokenProjectPath)
     const token: string = await loadToken(tokenProjectPath, tokenFilePath)
     return {endpoint, tokenProjectPath: tokenProjectPath, tokenFilePath, token}
+}
+
+async function buildResolvedClientForProject(
+    projectPath: string,
+    env: Record<string, string | undefined>,
+): Promise<ResolvedClient> {
+    const endpoint: ResolvedDaemonEndpoint | null = await discoverDaemonEndpointForProject(
+        projectPath,
+        {env: dropDaemonUrlOverride(env)},
+    )
+    if (!endpoint?.projectPath) {
+        throw new DaemonUnreachable(
+            `Cannot resolve VoiceTree daemon URL for project ${projectPath}. ` +
+            'Confirm the project has `.voicetree/rpc.port` and its daemon is running.',
+        )
+    }
+    const tokenFilePath: string = authTokenFilePath(endpoint.projectPath)
+    const token: string = await loadToken(endpoint.projectPath, tokenFilePath)
+    return {endpoint, tokenProjectPath: endpoint.projectPath, tokenFilePath, token}
 }
 
 async function loadToken(project: string, tokenFilePath: string): Promise<string> {
@@ -259,6 +279,30 @@ export async function callDaemon(
         outcome = await postRpc(client.endpoint.url, client.token, toolName, args, timeoutMs)
     }
 
+    if (outcome.kind === 'auth_required') {
+        const freshToken: string = await loadToken(client.tokenProjectPath, client.tokenFilePath)
+        outcome = await postRpc(client.endpoint.url, freshToken, toolName, args, timeoutMs)
+        if (outcome.kind === 'auth_required') {
+            throw new DaemonAuthRequired(
+                `Daemon at ${client.endpoint.url} rejected the bearer token after one retry. Re-check ${client.tokenFilePath} — the daemon may have been restarted with a new token.`,
+            )
+        }
+    }
+
+    if (outcome.envelope.error) throwForRpcError(outcome.envelope.error, client.tokenFilePath)
+    return outcome.envelope.result
+}
+
+export async function callDaemonForProject(
+    projectPath: string,
+    toolName: string,
+    args: Record<string, unknown>,
+): Promise<unknown> {
+    const env: Record<string, string | undefined> = process.env
+    const timeoutMs: number = getTimeoutMs(env)
+    const client: ResolvedClient = await buildResolvedClientForProject(projectPath, env)
+
+    let outcome: PostOutcome = await postRpc(client.endpoint.url, client.token, toolName, args, timeoutMs)
     if (outcome.kind === 'auth_required') {
         const freshToken: string = await loadToken(client.tokenProjectPath, client.tokenFilePath)
         outcome = await postRpc(client.endpoint.url, freshToken, toolName, args, timeoutMs)

--- a/packages/systems/voicetree-cli/src/commands/runtime/agent.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agent.ts
@@ -1,5 +1,10 @@
+import {existsSync} from 'node:fs'
+import {basename, dirname, isAbsolute, resolve} from 'node:path'
 import {requireTerminalId} from '../graph/core/args'
-import {callDaemon} from '../daemon-client'
+import {loadProjects} from '@vt/app-config/project'
+import {hasVoicetreeMarker} from '@vt/paths'
+import type {SavedProject} from '@vt/graph-model/project'
+import {callDaemon, callDaemonForProject} from '../daemon-client'
 import {error, output} from '../output'
 import {formatForkResult, type ForkOutcome} from './agentForkFormat'
 import {formatResumeResult, type ResumeOutcome} from './agentResumeFormat'
@@ -179,6 +184,59 @@ type AgentListItem = {
     title: string
     status: string
     isHeadless?: boolean
+}
+
+type ScopedAgentAddress = {
+    projectRef: string
+    terminalId: string
+}
+
+function parseScopedAgentAddress(raw: string): ScopedAgentAddress | null {
+    if (raw.startsWith('/') || raw.startsWith('./') || raw.startsWith('../')) return null
+    const slashIndex: number = raw.indexOf('/')
+    if (slashIndex <= 0 || slashIndex === raw.length - 1) return null
+    return {
+        projectRef: raw.slice(0, slashIndex),
+        terminalId: raw.slice(slashIndex + 1),
+    }
+}
+
+function projectMatchesRef(project: SavedProject, projectRef: string): boolean {
+    return project.id === projectRef ||
+        project.name === projectRef ||
+        basename(project.path) === projectRef
+}
+
+function candidateProjectPaths(projectRef: string, currentProject: string | undefined): readonly string[] {
+    const fromRef: string = isAbsolute(projectRef) ? projectRef : resolve(process.cwd(), projectRef)
+    const candidates: string[] = [fromRef]
+    if (currentProject) {
+        candidates.push(resolve(dirname(currentProject), projectRef))
+    }
+    return [...new Set(candidates)]
+}
+
+async function resolveProjectRef(projectRef: string): Promise<string> {
+    const savedProjects: SavedProject[] = await loadProjects()
+    const savedMatch: SavedProject | undefined = savedProjects.find(
+        (project: SavedProject): boolean => projectMatchesRef(project, projectRef),
+    )
+    if (savedMatch) return savedMatch.path
+
+    const currentProject: string | undefined = process.env.VOICETREE_PROJECT_PATH
+    const existingCandidate: string | undefined = candidateProjectPaths(projectRef, currentProject)
+        .find((candidate: string): boolean => existsSync(candidate) && hasVoicetreeMarker(candidate))
+    if (existingCandidate) return existingCandidate
+
+    error(
+        `Unknown project "${projectRef}" in scoped agent address. ` +
+        'Use a saved project name/id/basename, or run from a sibling project path.',
+    )
+}
+
+function currentProjectScope(): string {
+    const projectPath: string | undefined = process.env.VOICETREE_PROJECT_PATH
+    return projectPath && projectPath.length > 0 ? basename(projectPath) : basename(process.cwd())
 }
 
 function formatAgentList(payload: JsonRecord): string {
@@ -462,6 +520,22 @@ export async function agentSend(
     const message: string = messageParts.join(' ').trim()
     if (message.length === 0) {
         error('`agent send` requires a non-empty message')
+    }
+
+    const scopedTarget: ScopedAgentAddress | null = parseScopedAgentAddress(targetTerminalId)
+    if (scopedTarget) {
+        const targetProjectPath: string = await resolveProjectRef(scopedTarget.projectRef)
+        const scopedCallerTerminalId: string = `${currentProjectScope()}/${callerTerminalId}`
+        const payload: JsonRecord = ensureSuccessfulPayload(
+            await callDaemonForProject(targetProjectPath, 'send_message', {
+                callerTerminalId: scopedCallerTerminalId,
+                terminalId: scopedTarget.terminalId,
+                message,
+            })
+        )
+
+        output(payload, formatStandardResponse)
+        return
     }
 
     const payload: JsonRecord = ensureSuccessfulPayload(

--- a/packages/systems/voicetree-cli/src/commands/runtime/agentSpecs.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agentSpecs.ts
@@ -108,8 +108,8 @@ export const AGENT_FORK_SPEC: SubcommandSpec = {
 export const AGENT_SEND_SPEC: SubcommandSpec = {
     verb: 'vt agent send',
     rpcTool: 'send_message',
-    usageTail: '<terminalId> <message>...',
-    summary: 'Send a message into an agent terminal (carriage return appended).',
+    usageTail: '<terminalId|project/terminalId> <message>...',
+    summary: 'Send a message into an agent terminal. Use project/terminalId for cross-project sends.',
     flags: [],
 }
 

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/sendMessageTool.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/sendMessageTool.ts
@@ -31,6 +31,11 @@ function buildHeadlessInputError(terminalId: string): McpToolResponse {
     return buildErrorResponse(`Cannot send message to headless agent "${terminalId}". Headless agents have no terminal input. They receive work via their task node and produce output as graph nodes. Use get_unseen_nodes_nearby to read their output.`)
 }
 
+function isScopedExternalCaller(callerTerminalId: string): boolean {
+    const slashIndex: number = callerTerminalId.indexOf('/')
+    return slashIndex > 0 && slashIndex < callerTerminalId.length - 1
+}
+
 function queuePendingTerminalMessage(terminalId: string, callerTerminalId: string, message: string): McpToolResponse {
     enqueuePendingTerminalMessage(terminalId, buildFromPrefixedMessage(callerTerminalId, message))
     return buildJsonResponse({
@@ -85,7 +90,7 @@ export async function sendMessageTool({
     message,
     callerTerminalId
 }: SendMessageParams): Promise<McpToolResponse> {
-    if (!terminalExists(callerTerminalId)) {
+    if (!terminalExists(callerTerminalId) && !isScopedExternalCaller(callerTerminalId)) {
         return buildErrorResponse(`Unknown caller terminal: ${callerTerminalId}`)
     }
 

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/spawnAgentTool.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/spawnAgentTool.ts
@@ -69,7 +69,8 @@ type BudgetResult = { readonly allowed: boolean; readonly childBudget: number | 
 
 type SpawnRuntime = {
     readonly callerTerminalId: string
-    readonly callerRecord: TerminalRecord
+    readonly callerRecord?: TerminalRecord
+    readonly isExternalCaller: boolean
     readonly resolvedAgentCommand: string | undefined
     readonly resolvedSpawnDirectory: string | undefined
     readonly envOverrides: Record<string, string>
@@ -102,8 +103,14 @@ function findCallerRecord(callerTerminalId: string, terminalRecords: readonly Te
     return {ok: true, value: callerRecord}
 }
 
-function resolveChildDepthBudget(depthBudget: number | undefined, callerRecord: TerminalRecord): number | undefined {
+function isScopedExternalCaller(callerTerminalId: string): boolean {
+    const slashIndex: number = callerTerminalId.indexOf('/')
+    return slashIndex > 0 && slashIndex < callerTerminalId.length - 1
+}
+
+function resolveChildDepthBudget(depthBudget: number | undefined, callerRecord: TerminalRecord | undefined): number | undefined {
     if (depthBudget !== undefined) return depthBudget
+    if (!callerRecord) return undefined
 
     const parentDepthBudget: string | undefined = callerRecord.terminalData.initialEnvVars?.DEPTH_BUDGET
     if (!parentDepthBudget) return undefined
@@ -133,10 +140,10 @@ function resolveNamedAgentCommand(agentName: string, agents: readonly AgentSetti
 
 async function resolveAgentCommand(
     agentName: string | undefined,
-    callerRecord: TerminalRecord,
+    callerRecord: TerminalRecord | undefined,
     deps: SpawnAgentDeps,
 ): Promise<Result<string | undefined>> {
-    const callerAgentTypeName: string | undefined = callerRecord.terminalData.agentTypeName
+    const callerAgentTypeName: string | undefined = callerRecord?.terminalData.agentTypeName
     if (!agentName && !callerAgentTypeName) return {ok: true, value: undefined}
 
     const settings: VTSettings = await deps.loadAgentSettings()
@@ -149,15 +156,15 @@ async function resolveAgentCommand(
     return {ok: true, value: inheritedAgent?.command}
 }
 
-function resolveSpawnDirectory(spawnDirectory: string | undefined, callerRecord: TerminalRecord): string | undefined {
-    return spawnDirectory ?? callerRecord.terminalData.initialSpawnDirectory
-}
-
 async function prepareSpawnRuntime(
     params: SpawnAgentParams,
     deps: SpawnAgentDeps,
-    callerRecord: TerminalRecord,
+    callerRecord: TerminalRecord | undefined,
 ): Promise<Result<SpawnRuntime>> {
+    if (!callerRecord && params.replaceSelf) {
+        return {ok: false, error: 'Cannot replace self from a scoped external caller'}
+    }
+
     const childDepthBudget: number | undefined = resolveChildDepthBudget(params.depthBudget, callerRecord)
     const budgetResult: BudgetResult = deps.consumeBudget(params.callerTerminalId)
     if (!budgetResult.allowed) return {ok: false, error: 'Global spawn budget exhausted'}
@@ -170,8 +177,9 @@ async function prepareSpawnRuntime(
         value: {
             callerTerminalId: params.callerTerminalId,
             callerRecord,
+            isExternalCaller: !callerRecord,
             resolvedAgentCommand: agentCommandResult.value,
-            resolvedSpawnDirectory: resolveSpawnDirectory(params.spawnDirectory, callerRecord),
+            resolvedSpawnDirectory: params.spawnDirectory ?? callerRecord?.terminalData.initialSpawnDirectory,
             envOverrides: buildEnvOverrides(childDepthBudget, budgetResult.childBudget),
             childDepthBudget,
         }
@@ -201,10 +209,10 @@ function taskNodeIdFromDelta(taskNodeDelta: GraphDelta): NodeIdAndFilePath | und
 
 function buildCallerContextUpdateDelta(
     graph: Graph,
-    callerRecord: TerminalRecord,
+    callerRecord: TerminalRecord | undefined,
     taskNodeId: NodeIdAndFilePath,
 ): GraphDelta {
-    const callerContextNodeId: string | undefined = callerRecord.terminalData.attachedToContextNodeId
+    const callerContextNodeId: string | undefined = callerRecord?.terminalData.attachedToContextNodeId
     if (!callerContextNodeId) return []
 
     const callerContextNode: GraphNode | undefined = graph.nodes[callerContextNodeId]
@@ -243,7 +251,7 @@ function claimNodeDelta(targetNode: GraphNode): GraphDelta {
 
 function parentTerminalIdForSpawn(runtime: SpawnRuntime, replaceSelf: boolean | undefined): string | undefined {
     return replaceSelf
-        ? (runtime.callerRecord.terminalData.parentTerminalId ?? undefined)
+        ? (runtime.callerRecord?.terminalData.parentTerminalId ?? undefined)
         : runtime.callerTerminalId
 }
 
@@ -270,10 +278,16 @@ async function spawnTerminalForNode(
 }
 
 function rememberAndMonitorChild(terminalId: string, params: SpawnAgentParams, runtime: SpawnRuntime, deps: SpawnAgentDeps): void {
-    if (params.replaceSelf) return
+    if (params.replaceSelf || runtime.isExternalCaller) return
 
     deps.rememberChild(runtime.callerTerminalId, terminalId)
     deps.monitorChildren(runtime.callerTerminalId, [terminalId], 5000)
+}
+
+function spawnSuccessMessage(baseMessage: string, runtime: SpawnRuntime): string {
+    return runtime.isExternalCaller
+        ? `${baseMessage} No local completion monitor was started for external caller ${runtime.callerTerminalId}.`
+        : `${baseMessage} You will be notified when the agent completes.`
 }
 
 async function spawnAgentForTask(
@@ -319,7 +333,7 @@ async function spawnAgentForTask(
             depthBudget: runtime.childDepthBudget,
             message: params.replaceSelf
                 ? `Replaced self — successor agent running as "${terminalId}"`
-                : `Created task node and spawned agent for "${taskDescription}". You will be notified when the agent completes.`
+                : spawnSuccessMessage(`Created task node and spawned agent for "${taskDescription}".`, runtime)
         })
     } catch (error) {
         return errorResponse(errorMessage(error))
@@ -352,7 +366,7 @@ async function spawnAgentForExistingNode(
             depthBudget: runtime.childDepthBudget,
             message: params.replaceSelf
                 ? `Replaced self — successor agent running as "${terminalId}"`
-                : `Spawned agent for node ${resolvedNodeId}. You will be notified when the agent completes.`
+                : spawnSuccessMessage(`Spawned agent for node ${resolvedNodeId}.`, runtime)
         })
     } catch (error) {
         return errorResponse(errorMessage(error))
@@ -365,9 +379,15 @@ export async function spawnAgentTool(
 ): Promise<McpToolResponse> {
     const terminalRecords: TerminalRecord[] = deps.listTerminalRecords()
     const callerRecordResult: Result<TerminalRecord> = findCallerRecord(params.callerTerminalId, terminalRecords)
-    if (!callerRecordResult.ok) return errorResponse(callerRecordResult.error)
+    if (!callerRecordResult.ok && !isScopedExternalCaller(params.callerTerminalId)) {
+        return errorResponse(callerRecordResult.error)
+    }
 
-    const runtimeResult: Result<SpawnRuntime> = await prepareSpawnRuntime(params, deps, callerRecordResult.value)
+    const runtimeResult: Result<SpawnRuntime> = await prepareSpawnRuntime(
+        params,
+        deps,
+        callerRecordResult.ok ? callerRecordResult.value : undefined,
+    )
     if (!runtimeResult.ok) return errorResponse(runtimeResult.error)
 
     const writeFolderPathResult: Result<string> = await loadWriteFolderPath(deps)

--- a/uv.lock
+++ b/uv.lock
@@ -2502,6 +2502,7 @@ dependencies = [
     { name = "termcolor" },
     { name = "typing-extensions" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -2547,6 +2548,7 @@ requires-dist = [
     { name = "termcolor", specifier = ">=2.0.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.23.0" },
+    { name = "websockets", specifier = ">=13.0" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
Rescues uncommitted work that was stranded in the read-only base checkout, moved onto this worktree and split into clean groups.

## Commits
1. **feat(agent): cross-project send/spawn via `project/terminalId` addressing** — the substantive change. Lets `vt agent send <project>/<terminalId>` (and spawn) target an agent in another VoiceTree project/daemon.
   - **CLI** resolves the project ref (saved name/id/basename, or a sibling `.voicetree` path), discovers *that* project's daemon endpoint, authenticates with *that* project's bearer token, and labels its own caller id as `<ownProject>/<caller>`.
   - **Daemon** accepts a scoped external caller (no local `TerminalRecord`): `send_message` skips the caller-exists check; spawn treats `callerRecord` as optional, refuses `replaceSelf`, and starts no local completion monitor (honestly reported in the success message).
2. **chore(deps): sync uv.lock** — the `voicetree` pyproject already declares `websockets>=13.0`; lockfile regenerated to match.
3. **docs(recovery): document surviving-agents recovery wiring.**
4. **chore(search): add ck ignore patterns for graph-db-server/src.**

## Deliberately excluded
- `webapp/.../graphviz/layout/quality/` — a **superseded duplicate** of the already-landed `packages/libraries/layout-quality/` (the name-uniqueness gate flagged the collision). Dropped, not committed.
- Agent scratch/vault dirs (`get_dev_healthy/`, `vt_layout_fixes/`), the `.claude/worktrees` dev symlink, and `webapp/playwright-report-*/` test output — left in place, not work to commit.

## Reviewer notes / known smells
- The scoped-caller heuristic (`slashIndex > 0 && < len-1`) is **duplicated in 3 sites** (`agent.ts`, `sendMessageTool.ts`, `spawnAgentTool.ts`) — candidate for a shared `ScopedAddress` parser.
- Cross-daemon spawn is fire-and-forget (no remote completion bridge) — stated to the user, not yet solved.
- Trust rests entirely on the transport bearer token; the daemon does not verify the claimed `project/terminal` exists. Worth an inline comment at the guard sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)