### PR TITLE
docs(readme): rewrite Development section; raise README line budget

### DIFF
--- a/packages/measures/budgets/shape/readme-line-budget.json
+++ b/packages/measures/budgets/shape/readme-line-budget.json
@@ -1,3 +1,3 @@
 {
-  "limitExclusive": 150
+  "limitExclusive": 180
 }

--- a/readme.md
+++ b/readme.md
@@ -123,11 +123,33 @@ Capture ideas hands-free with speech-to-graph.
 
 ## Development
 
-**Prerequisites:** Node.js 18+, pnpm 10 (`corepack enable`), Python 3.13, uv
+A **pnpm monorepo** (app in `webapp/`) with a **Python** backend.
 
+**Prereqs:** Node 22+, pnpm 10 (`corepack enable`); Python 3.13 + uv for python backend only. Run `pnpm install` once (and after deps change).
+
+### Run the app
 ```bash
-pnpm install && pnpm --filter voicetree-webapp run electron  # App (run from repo root)
-uv sync && uv run pytest                                     # Backend
+pnpm --filter voicetree-webapp run electron                   # Electron desktop app (the packaged build)
+vt webapp --project <path> [--port <n>] [--lan] [--no-open]   # Browser webapp; <> required, [] optional
+```
+`--port` default 3000
+
+`--lan` expose to phone/tablet on your network
+
+`--no-open` don't auto-open browser.
+
+**Perf stack:** Electron auto-attaches local profiling (Grafana/Tempo/Loki/Pyroscope, Go binaries) at the `lite` tier. Skip it with `PERF_STACK=0`. `vt webapp` never attaches it.
+
+### **Python** Backend
+```bash
+uv sync && uv run pytest
+```
+
+### Workflow
+```bash
+vt-sync                 # catch up (use instead of git pull)
+git commit -am "..."    # commit as you go
+vt-pr "feat: ..."       # push + open PR into dev
 ```
 
 ## License


### PR DESCRIPTION
Rewrites the readme's **Development** section (previously conflated three concerns into one code block) and **raises the README line budget** so it fits without trimming other prose.

## Changes (2 files)
- `readme.md` — Development section only; the rest of the readme (How It Works / In Detail / etc.) is unchanged:
  - Splits into **Run the app** / **Python Backend** / **Workflow**.
  - Adds `vt webapp` (browser mode) with `<>`-required / `[]`-optional usage + flag legend.
  - Notes Electron perf-stack auto-attach + `PERF_STACK=0` opt-out (`vt webapp` never attaches it).
  - Documents `vt-sync` / `git commit` / `vt-pr` flow. Node 18+ → 22+.
- `packages/measures/budgets/shape/readme-line-budget.json` — `limitExclusive` 150 → 180.

## Why the budget bump
The fuller dev guide pushes `readme.md` to 168 lines, over the prior 150-line cap. Per maintainer decision, accommodate the dev guide by raising the budget rather than trimming the readme's other prose. 168 sits under the new 180 limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)