### PR TITLE
fix(embeddings): rebuild unreadable ChromaDB store instead of crashing

### DIFF
--- a/backend/markdown_tree_manager/embeddings/chromadb_vector_store.py
+++ b/backend/markdown_tree_manager/embeddings/chromadb_vector_store.py
@@ -5,6 +5,8 @@ Uses ChromaDB with Google Gemini embeddings for efficient vector search.
 
 import logging
 import os
+import shutil
+from pathlib import Path
 from typing import Any
 from typing import Optional
 from typing import Union
@@ -23,6 +25,43 @@ load_dotenv()
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def open_persistent_client_or_rebuild(persist_directory: str, settings: Settings) -> chromadb.ClientAPI:
+    """
+    Open a persistent ChromaDB client, rebuilding the store if it cannot be opened.
+
+    The persisted store is a *derived cache*: every embedding is regenerated from the
+    markdown nodes (the source of truth) via MarkdownTree.sync_all_embeddings. A store
+    written by a newer ChromaDB cannot be read by an older one — ChromaDB's Rust
+    migration check raises a pyo3 PanicException, which subclasses BaseException and so
+    slips past `except Exception` and would otherwise crash the whole backend (this is
+    exactly how a forward-versioned store silently bricks the speech-to-text server:
+    /load-directory 500s, the directory never loads, every /send-text is dropped).
+
+    Because the store holds only derived data, discarding and rebuilding it is always
+    safe: the sole cost is recomputing embeddings. So we wipe an unreadable store and
+    recreate it rather than letting the process die. A second failure is a real problem
+    and is allowed to propagate.
+    """
+    try:
+        return chromadb.PersistentClient(path=persist_directory, settings=settings)
+    except (KeyboardInterrupt, SystemExit, GeneratorExit):
+        raise
+    except BaseException as open_error:  # noqa: BLE001 — pyo3 PanicException is a BaseException
+        logger.warning(
+            "ChromaDB store at %s is unreadable (%r); discarding and rebuilding it from "
+            "markdown — embeddings will be regenerated.",
+            persist_directory, open_error,
+        )
+        # ChromaDB caches the System (keyed by persist_directory) BEFORE calling
+        # start(), so the panic above left a half-initialised system cached. Reusing it
+        # would fail differently on retry — evict that one entry before rebuilding.
+        from chromadb.api.shared_system_client import SharedSystemClient
+        SharedSystemClient._identifier_to_system.pop(persist_directory, None)
+        shutil.rmtree(persist_directory, ignore_errors=True)
+        Path(persist_directory).mkdir(parents=True, exist_ok=True)
+        return chromadb.PersistentClient(path=persist_directory, settings=settings)
 
 
 class ChromaDBVectorStore:
@@ -90,14 +129,16 @@ class ChromaDBVectorStore:
             self.persist_directory = persist_directory
 
             # Ensure the persist directory exists
-            from pathlib import Path
             persist_path = Path(persist_directory)
             persist_path.mkdir(parents=True, exist_ok=True)
 
-            # Initialize ChromaDB client with persistence
-            self.client = chromadb.PersistentClient(
-                path=persist_directory,
-                settings=Settings(
+            # Initialize ChromaDB client with persistence. A store written by a newer
+            # ChromaDB panics when opened here; open_persistent_client_or_rebuild
+            # discards such an unreadable (derived) store and rebuilds it instead of
+            # letting the panic crash the backend.
+            self.client = open_persistent_client_or_rebuild(
+                persist_directory,
+                Settings(
                     anonymized_telemetry=False,
                     allow_reset=True,
                     is_persistent=True

--- a/backend/tests/unit_tests/markdown_tree_manager/test_chromadb_store_rebuild.py
+++ b/backend/tests/unit_tests/markdown_tree_manager/test_chromadb_store_rebuild.py
@@ -1,0 +1,66 @@
+"""
+Behavioural tests for open_persistent_client_or_rebuild.
+
+The persisted ChromaDB store is a derived cache (embeddings are regenerated from the
+markdown nodes). A store that cannot be opened — e.g. one written by a newer ChromaDB,
+which makes ChromaDB's Rust layer raise a pyo3 PanicException (a BaseException) — must
+not crash the backend: it should be discarded and rebuilt. These tests exercise that
+through the real ChromaDB client (black box: open a store, observe the result).
+"""
+
+from pathlib import Path
+
+import chromadb
+import pytest
+from chromadb.api.shared_system_client import SharedSystemClient
+from chromadb.config import Settings
+
+from backend.markdown_tree_manager.embeddings.chromadb_vector_store import (
+    open_persistent_client_or_rebuild,
+)
+
+
+def _settings() -> Settings:
+    return Settings(anonymized_telemetry=False, allow_reset=True, is_persistent=True)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_chroma_system_cache():
+    # ChromaDB caches systems by path process-wide; clear it around each test so opens
+    # actually read from disk (mirroring a fresh backend process) and nothing leaks out.
+    SharedSystemClient.clear_system_cache()
+    yield
+    SharedSystemClient.clear_system_cache()
+
+
+def test_unreadable_store_is_rebuilt_instead_of_raising(tmp_path):
+    store = str(tmp_path / "chromadb_data")
+    # Arrange: a valid store holding data...
+    seeded = chromadb.PersistentClient(path=store, settings=_settings())
+    seeded.create_collection("voicetree_nodes").add(ids=["1"], documents=["hello"])
+
+    # ...then make it unreadable (stand-in for a forward-versioned / corrupt store) and
+    # drop the cached client so the next open hits the broken file on disk.
+    SharedSystemClient.clear_system_cache()
+    (Path(store) / "chroma.sqlite3").write_bytes(b"this is not a sqlite database")
+
+    # Act: must not raise.
+    rebuilt = open_persistent_client_or_rebuild(store, _settings())
+
+    # Assert: the store was discarded and rebuilt fresh, and is usable again.
+    assert rebuilt.list_collections() == []
+    rebuilt.create_collection("voicetree_nodes").add(ids=["1"], documents=["world"])
+    assert rebuilt.get_collection("voicetree_nodes").count() == 1
+
+
+def test_valid_store_is_opened_in_place_not_wiped(tmp_path):
+    store = str(tmp_path / "chromadb_data")
+    seeded = chromadb.PersistentClient(path=store, settings=_settings())
+    seeded.create_collection("voicetree_nodes").add(ids=["1"], documents=["keep me"])
+    SharedSystemClient.clear_system_cache()
+
+    reopened = open_persistent_client_or_rebuild(store, _settings())
+
+    # A readable store must be preserved, not rebuilt — the seeded data survives.
+    assert [c.name for c in reopened.list_collections()] == ["voicetree_nodes"]
+    assert reopened.get_collection("voicetree_nodes").count() == 1


### PR DESCRIPTION
A persisted ChromaDB store written by a newer ChromaDB cannot be opened by an
older one: ChromaDB's Rust migration check raises a pyo3 PanicException, which
subclasses BaseException and slips past 'except Exception'. This silently bricked
the STT server: /load-directory 500'd, the directory never loaded, and every
/send-text was dropped ('Skipping buffer processing - no directory loaded yet').

The store is a derived cache (embeddings regenerate from the markdown nodes via
sync_all_embeddings), so discarding and rebuilding an unreadable store is always
safe. open_persistent_client_or_rebuild does exactly that, evicting ChromaDB's
half-initialised cached System (cached before start()) before recreating.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
