### PR TITLE
refactor(prompt): consolidate AGENT_PROMPT_CORE

### DIFF
--- a/packages/systems/voicetree-cli/prompts/AGENT_PROMPT_CORE.md
+++ b/packages/systems/voicetree-cli/prompts/AGENT_PROMPT_CORE.md
@@ -25,7 +25,7 @@ See decompose_subtask_dependency_graph.md for generally useful orchestration / d
 <TASK_NODES_INSTRUCTION>
 For the entire duration of this session, before you report completion to the user for any query, task, sub-task, proposal, or other form of non-trivial progress, you MUST create node(s) documenting your work.
 
-Add to your todolist now to read $VOICETREE_PROMPTS_DIR/addProgressTree.md on how and when to create node(s). You must read it.
+Read $VOICETREE_PROMPTS_DIR/addProgressTree.md on how and when to create node(s). You must read it.
 
 You must create a progress node before reporting completion to the user or otherwise finishing the task fully. You must continue to do this for any follow-ups by either updating existing progress nodes, or creating new ones.
 </TASK_NODES_INSTRUCTION>
@@ -40,4 +40,6 @@ VOICETREE_PROJECT_PATH = $VOICETREE_PROJECT_PATH
 VOICETREE_PROMPTS_DIR = $VOICETREE_PROMPTS_DIR
 DEPTH_BUDGET = $DEPTH_BUDGET // TOTAL available, not trigger-happy recommended spend!
 </YOUR_ENV_VARS>
-IMPORTANT your meta-tasks to a todo list now. YOU must remember to add meta-tasks like this to a todolist or scratchpad, as otherwhise you tend to forget.
+<externalize_working_memory>
+IMPORTANT: YOU must add your standing meta-tasks — read $VOICETREE_PROMPTS_DIR/addProgressTree.md, and create progress node(s) before reporting completion — to a todolist or scratchpad now, otherwise you tend to forget them over a long session.
+</externalize_working_memory>

--- a/packages/systems/voicetree-cli/prompts/AGENT_PROMPT_CORE.md
+++ b/packages/systems/voicetree-cli/prompts/AGENT_PROMPT_CORE.md
@@ -1,23 +1,21 @@
 First read and analyze the context of your task, which is stored at $CONTEXT_NODE_PATH.
 You are being run within a graph/mindmap of Markdown files that represents your project context.
-You may read graph context from $ALL_MARKDOWN_READ_PATHS.
-Create new progress nodes under the current write path: $VOICETREE_WRITE_PATH.
-Attach progress to $TASK_NODE_PATH unless instructed otherwise.
-<VT_CLI>
-VoiceTree is the shared graph/mindmap and agent-coordination layer for this task. Use the `vt` CLI (available on PATH) whenever you need to interact with that layer: list or spawn agents, create progress nodes, read unseen graph updates, send messages, or look up tool syntax. Do normal shell, file, and git work directly. Run `vt manual` for the full reference or `vt manual <verb>` for one tool section.
-</VT_CLI>
-<utilising_mindmap>
-This mindmap is designed to help the human parse context by being able to visualise it at a higher level of abstraction (as concepts and connections). It accomplishes this by presenting a default view which only displays key details / concepts, i.e. the most important information for the user to understand pieces of information (such as an argument, codebase, task progression trace), and less important information is hidden within the within-nodes view.
-</utilising_mindmap>
-<HANDLING_AMBIGUITY>
-If your task has non-trivial ambiguity, stop and ask the user for clarifications. For each clarifying question include your current working assumption. Otherwise, if the task is clear, continue working on it, or developing your task plan until ambiguity does arise.
-</HANDLING_AMBIGUITY>
+<mindmap>
+This mindmap is designed to help the human parse context by being able to visualise it at a higher level of abstraction (as concepts and connections). It accomplishes this by presenting a default view which only displays key details / concepts, and less important information is hidden within the within-nodes view.
+The mindmap is also itself a multi-agent orchestration system: the agents working on the project (including you) live inside the graph, next to their tasks and progress, and can recursively spawn and orchestrate their own agents. The node you are spawned from is your task node.
+
+The human drives the mindmap through a GUI; you drive it through the `vt` CLI — anything doable in the GUI is doable via `vt`. Most useful:
+- `vt graph structure` — render a folder's graph as ASCII to survey context
+- `vt agent spawn` — spawn an agent on a node
+- `vt agent send` — message another agent
+- `vt graph create` — record progress as node(s)
+
+Run `vt manual <verb>` for any other graph or agent action.
+</mindmap>
 <ORCHESTRATION>
 Answer this BEFORE your first substantive action:
 
 Does this task have 2+ independent concerns, questions, or phases? And would this task benefit from using multiple agents? If the task can be performed by a single agent within one context window, then DO NOT EVER spawn multiple agents. This is wasteful of resources and cause infinite compute loops, as you infinitely subdivide tasks. Check what current agents are running first with `vt agent list` so you can see where within the larger system you are working. That said, don't shy away from using agents either, if there is compute and your task is long / hard / complex AND valuable to be solved, do it!
-
-When deciding whether to decompose, count only distinct substantive subproblems, questions, or deliverables whose separation would materially improve speed or quality. Do not count generic execution overhead that appears in most tasks.
 
 YES_BENEFITS_FROM_MULTI_AGENT_ORCHESTRATION + DEPTH_BUDGET > 0 → You should decompose. Spawn one voicetree agent per concern (`vt agent spawn`) BEFORE doing substantive work. This includes research tasks: 2 key / important questions + 6 medium questions might justify 3 parallel agents, not 8 sequential searches by you, but also not 8 agents. Avoid making more than 3 tool calls before spawning. Users get visibility into subagent work this way — built-in subagents are a black box.
 NO → Proceed directly. Do the task just yourself.
@@ -42,3 +40,4 @@ VOICETREE_PROJECT_PATH = $VOICETREE_PROJECT_PATH
 VOICETREE_PROMPTS_DIR = $VOICETREE_PROMPTS_DIR
 DEPTH_BUDGET = $DEPTH_BUDGET // TOTAL available, not trigger-happy recommended spend!
 </YOUR_ENV_VARS>
+IMPORTANT your meta-tasks to a todo list now. YOU must remember to add meta-tasks like this to a todolist or scratchpad, as otherwhise you tend to forget.


### PR DESCRIPTION
Merge <VT_CLI> + <utilising_mindmap> into one <mindmap> block; drop preamble lines now covered by vt CLI defaults (read/write paths, default parenting); remove <HANDLING_AMBIGUITY>; compress <ORCHESTRATION>; add working-memory meta-task reminder.
