### PR TITLE
feat(agents): hierarchical agent commands — tree menu with composed command+env

### DIFF
--- a/packages/libraries/graph-model/src/pure/settings/DEFAULT_SETTINGS.test.ts
+++ b/packages/libraries/graph-model/src/pure/settings/DEFAULT_SETTINGS.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { createDefaultSettings } from './settingsSchema';
+import type { AgentConfig } from './types';
 
 describe('DEFAULT_SETTINGS platform-specific env var syntax', () => {
   it('should use $env:AGENT_PROMPT syntax on Windows', async () => {
     const DEFAULT_SETTINGS = createDefaultSettings({ platform: 'win32' });
 
     // Verify agent commands use PowerShell syntax
-    const claudeAgent: { readonly name: string; readonly command: string } | undefined = DEFAULT_SETTINGS.agents.find(
-      (a: { readonly name: string; readonly command: string }) => a.name === 'Claude'
+    const claudeAgent: AgentConfig | undefined = DEFAULT_SETTINGS.agents.find(
+      (a: AgentConfig) => a.name === 'Claude'
     );
     expect(claudeAgent).toBeDefined();
     expect(claudeAgent!.command).toContain('$env:AGENT_PROMPT');
@@ -15,7 +16,7 @@ describe('DEFAULT_SETTINGS platform-specific env var syntax', () => {
 
     // Verify all default agents use Windows syntax
     expect(DEFAULT_SETTINGS.agents.every(
-      (agent: { readonly command: string }) => agent.command.includes('$env:AGENT_PROMPT')
+      (agent: AgentConfig) => agent.command?.includes('$env:AGENT_PROMPT') ?? false
     )).toBe(true);
   });
 
@@ -23,8 +24,8 @@ describe('DEFAULT_SETTINGS platform-specific env var syntax', () => {
     const DEFAULT_SETTINGS = createDefaultSettings({ platform: 'darwin' });
 
     // Verify agent commands use bash/zsh syntax
-    const claudeAgent: { readonly name: string; readonly command: string } | undefined = DEFAULT_SETTINGS.agents.find(
-      (a: { readonly name: string; readonly command: string }) => a.name === 'Claude'
+    const claudeAgent: AgentConfig | undefined = DEFAULT_SETTINGS.agents.find(
+      (a: AgentConfig) => a.name === 'Claude'
     );
     expect(claudeAgent).toBeDefined();
     expect(claudeAgent!.command).toContain('"$AGENT_PROMPT"');
@@ -32,7 +33,7 @@ describe('DEFAULT_SETTINGS platform-specific env var syntax', () => {
 
     // Verify all default agents use Unix syntax
     expect(DEFAULT_SETTINGS.agents.every(
-      (agent: { readonly command: string }) => !agent.command.includes('$env:')
+      (agent: AgentConfig) => !(agent.command?.includes('$env:') ?? false)
     )).toBe(true);
   });
 
@@ -40,8 +41,8 @@ describe('DEFAULT_SETTINGS platform-specific env var syntax', () => {
     const DEFAULT_SETTINGS = createDefaultSettings({ platform: 'linux' });
 
     // Verify agent commands use bash syntax (same as macOS)
-    const claudeAgent: { readonly name: string; readonly command: string } | undefined = DEFAULT_SETTINGS.agents.find(
-      (a: { readonly name: string; readonly command: string }) => a.name === 'Claude'
+    const claudeAgent: AgentConfig | undefined = DEFAULT_SETTINGS.agents.find(
+      (a: AgentConfig) => a.name === 'Claude'
     );
     expect(claudeAgent).toBeDefined();
     expect(claudeAgent!.command).toContain('"$AGENT_PROMPT"');

--- a/packages/libraries/graph-model/src/pure/settings/agentTree.test.ts
+++ b/packages/libraries/graph-model/src/pure/settings/agentTree.test.ts
@@ -1,0 +1,172 @@
+import {describe, it, expect} from 'vitest';
+import type {AgentConfig} from './types';
+import {
+    type ResolvedAgent,
+    composeAgentStep,
+    isAgentCategory,
+    flattenAgentTree,
+    collectResolvableCommands,
+    resolveDefaultAgent,
+    agentPathLabel,
+    mapAgentTreeByCommand,
+} from './agentTree';
+
+/**
+ * The migrated Codex tree the feature exists to support: one EFFORT knob drives
+ * both the Local branch (expanded into a `-c` flag) and the Remote branch
+ * (expanded into a `CODEX_REASONING_EFFORT=` prefix the .sh launcher reads).
+ */
+const CODEX_TREE: readonly AgentConfig[] = [
+    {name: 'Claude', command: 'claude --dangerously-skip-permissions "$AGENT_PROMPT"'},
+    {
+        name: 'Codex',
+        command: 'codex --yolo -c "model_reasoning_effort=\\"$EFFORT\\"" "$AGENT_PROMPT"',
+        children: [
+            {
+                name: 'Local',
+                children: [
+                    {name: 'Medium', env: {EFFORT: 'medium'}},
+                    {name: 'XHigh', env: {EFFORT: 'xhigh'}},
+                ],
+            },
+            {
+                name: 'Remote',
+                command: 'CODEX_REASONING_EFFORT="$EFFORT" bash /Users/bob/.voicetree/bin/codex-remote.sh',
+                children: [
+                    {name: 'Medium', env: {EFFORT: 'medium'}},
+                    {name: 'XHigh', env: {EFFORT: 'xhigh'}},
+                ],
+            },
+        ],
+    },
+];
+
+const CODEX_BASE: string = 'codex --yolo -c "model_reasoning_effort=\\"$EFFORT\\"" "$AGENT_PROMPT"';
+const REMOTE_BASE: string = 'CODEX_REASONING_EFFORT="$EFFORT" bash /Users/bob/.voicetree/bin/codex-remote.sh';
+
+describe('flattenAgentTree — golden resolution of the Codex tree', () => {
+    const leaves: ResolvedAgent[] = flattenAgentTree(CODEX_TREE);
+
+    it('yields exactly the five spawnable leaves in pre-order', () => {
+        expect(leaves.map(leaf => agentPathLabel(leaf.path))).toEqual([
+            'Claude',
+            'Codex / Local / Medium',
+            'Codex / Local / XHigh',
+            'Codex / Remote / Medium',
+            'Codex / Remote / XHigh',
+        ]);
+    });
+
+    it('Local leaves inherit the Codex base command and set only EFFORT', () => {
+        const localXHigh: ResolvedAgent = leaves[2];
+        expect(localXHigh.command).toBe(CODEX_BASE);
+        expect(localXHigh.env).toEqual({EFFORT: 'xhigh'});
+    });
+
+    it('Remote leaves override the command and still set only EFFORT', () => {
+        const remoteMedium: ResolvedAgent = leaves[3];
+        expect(remoteMedium.command).toBe(REMOTE_BASE);
+        expect(remoteMedium.env).toEqual({EFFORT: 'medium'});
+    });
+
+    it('Claude leaf resolves to its own command with no extra env', () => {
+        expect(leaves[0].command).toBe('claude --dangerously-skip-permissions "$AGENT_PROMPT"');
+        expect(leaves[0].env).toEqual({});
+    });
+});
+
+describe('flattenAgentTree — robustness invariants (must hold for any tree)', () => {
+    it('never emits a category node as a leaf', () => {
+        for (const leaf of flattenAgentTree(CODEX_TREE)) {
+            expect(leaf.name).not.toBe('Codex');
+            expect(leaf.name).not.toBe('Local');
+            expect(leaf.name).not.toBe('Remote');
+        }
+    });
+
+    it('command = the deepest path node that defines a non-empty command', () => {
+        const tree: readonly AgentConfig[] = [
+            {name: 'a', command: 'A', children: [
+                {name: 'b', children: [             // inherits A
+                    {name: 'inherit'},              // -> A
+                    {name: 'override', command: 'B'}, // -> B
+                ]},
+            ]},
+        ];
+        const byPath: Record<string, string> = Object.fromEntries(
+            flattenAgentTree(tree).map(l => [agentPathLabel(l.path), l.command]),
+        );
+        expect(byPath['a / b / inherit']).toBe('A');
+        expect(byPath['a / b / override']).toBe('B');
+    });
+
+    it('env shallow-merges down the path with deeper-wins precedence', () => {
+        const tree: readonly AgentConfig[] = [
+            {name: 'root', command: 'cmd', env: {SHARED: 'root', ONLY_ROOT: 'r'}, children: [
+                {name: 'leaf', env: {SHARED: 'leaf', ONLY_LEAF: 'l'}},
+            ]},
+        ];
+        expect(flattenAgentTree(tree)[0].env).toEqual({SHARED: 'leaf', ONLY_ROOT: 'r', ONLY_LEAF: 'l'});
+    });
+
+    it('a flat legacy list flattens to itself (superset property)', () => {
+        const flat: readonly AgentConfig[] = [
+            {name: 'Gemini', command: 'gemini -i "$AGENT_PROMPT"'},
+            {name: 'Codex', command: 'codex --yolo "$AGENT_PROMPT"'},
+        ];
+        expect(flattenAgentTree(flat)).toEqual([
+            {name: 'Gemini', path: ['Gemini'], command: 'gemini -i "$AGENT_PROMPT"', env: {}},
+            {name: 'Codex', path: ['Codex'], command: 'codex --yolo "$AGENT_PROMPT"', env: {}},
+        ]);
+    });
+});
+
+describe('collectResolvableCommands — the daemon validation set', () => {
+    it('contains every leaf command so a valid leaf is never rejected', () => {
+        const commands: Set<string> = collectResolvableCommands(CODEX_TREE);
+        for (const leaf of flattenAgentTree(CODEX_TREE)) {
+            expect(commands.has(leaf.command)).toBe(true);
+        }
+    });
+
+    it('collapses leaves that share a base command (Local Medium/XHigh)', () => {
+        // Both Local leaves resolve to CODEX_BASE; they differ only by env.
+        expect(collectResolvableCommands(CODEX_TREE).has(CODEX_BASE)).toBe(true);
+    });
+});
+
+describe('resolveDefaultAgent', () => {
+    it('matches the full path label first', () => {
+        expect(resolveDefaultAgent(CODEX_TREE, 'Codex / Remote / XHigh')?.command).toBe(REMOTE_BASE);
+        expect(resolveDefaultAgent(CODEX_TREE, 'Codex / Remote / XHigh')?.env).toEqual({EFFORT: 'xhigh'});
+    });
+
+    it('falls back to a leaf name match, then to the first leaf', () => {
+        expect(resolveDefaultAgent(CODEX_TREE, 'Claude')?.name).toBe('Claude');
+        expect(resolveDefaultAgent(CODEX_TREE, 'does-not-exist')?.name).toBe('Claude');
+        expect(resolveDefaultAgent(CODEX_TREE)?.name).toBe('Claude');
+    });
+});
+
+describe('isAgentCategory', () => {
+    it('is true only for nodes with children', () => {
+        expect(isAgentCategory({name: 'Codex', command: 'x', children: [{name: 'L', command: 'y'}]})).toBe(true);
+        expect(isAgentCategory({name: 'leaf', command: 'y'})).toBe(false);
+        expect(isAgentCategory({name: 'empty', command: 'y', children: []})).toBe(false);
+    });
+});
+
+describe('mapAgentTreeByCommand — recursive command rewrite (Claude toggles)', () => {
+    it('rewrites a matching command at any depth, preserving structure', () => {
+        const tree: readonly AgentConfig[] = [
+            {name: 'Claude', command: 'claude X'},
+            {name: 'Group', command: 'claude X', children: [{name: 'nested', command: 'claude X'}]},
+            {name: 'Other', command: 'gemini'},
+        ];
+        const out = mapAgentTreeByCommand(tree, 'claude X', 'claude X --auto');
+        expect(out[0].command).toBe('claude X --auto');
+        expect(out[1].command).toBe('claude X --auto');
+        expect(out[1].children?.[0].command).toBe('claude X --auto');
+        expect(out[2].command).toBe('gemini'); // untouched
+    });
+});

--- a/packages/libraries/graph-model/src/pure/settings/agentTree.test.ts
+++ b/packages/libraries/graph-model/src/pure/settings/agentTree.test.ts
@@ -2,12 +2,8 @@ import {describe, it, expect} from 'vitest';
 import type {AgentConfig} from './types';
 import {
     type ResolvedAgent,
-    composeAgentStep,
-    isAgentCategory,
     flattenAgentTree,
-    collectResolvableCommands,
     resolveDefaultAgent,
-    agentPathLabel,
     mapAgentTreeByCommand,
 } from './agentTree';
 
@@ -47,8 +43,8 @@ const REMOTE_BASE: string = 'CODEX_REASONING_EFFORT="$EFFORT" bash /Users/bob/.v
 describe('flattenAgentTree — golden resolution of the Codex tree', () => {
     const leaves: ResolvedAgent[] = flattenAgentTree(CODEX_TREE);
 
-    it('yields exactly the five spawnable leaves in pre-order', () => {
-        expect(leaves.map(leaf => agentPathLabel(leaf.path))).toEqual([
+    it('yields exactly the five spawnable leaves (with path labels) in pre-order', () => {
+        expect(leaves.map(leaf => leaf.label)).toEqual([
             'Claude',
             'Codex / Local / Medium',
             'Codex / Local / XHigh',
@@ -78,10 +74,12 @@ describe('flattenAgentTree — golden resolution of the Codex tree', () => {
 describe('flattenAgentTree — robustness invariants (must hold for any tree)', () => {
     it('never emits a category node as a leaf', () => {
         for (const leaf of flattenAgentTree(CODEX_TREE)) {
-            expect(leaf.name).not.toBe('Codex');
-            expect(leaf.name).not.toBe('Local');
-            expect(leaf.name).not.toBe('Remote');
+            expect(['Codex', 'Local', 'Remote']).not.toContain(leaf.name);
         }
+    });
+
+    it('every leaf resolves to a non-empty command (the daemon-validatable set)', () => {
+        for (const leaf of flattenAgentTree(CODEX_TREE)) expect(leaf.command.length).toBeGreaterThan(0);
     });
 
     it('command = the deepest path node that defines a non-empty command', () => {
@@ -93,11 +91,11 @@ describe('flattenAgentTree — robustness invariants (must hold for any tree)', 
                 ]},
             ]},
         ];
-        const byPath: Record<string, string> = Object.fromEntries(
-            flattenAgentTree(tree).map(l => [agentPathLabel(l.path), l.command]),
+        const byLabel: Record<string, string> = Object.fromEntries(
+            flattenAgentTree(tree).map(l => [l.label, l.command]),
         );
-        expect(byPath['a / b / inherit']).toBe('A');
-        expect(byPath['a / b / override']).toBe('B');
+        expect(byLabel['a / b / inherit']).toBe('A');
+        expect(byLabel['a / b / override']).toBe('B');
     });
 
     it('env shallow-merges down the path with deeper-wins precedence', () => {
@@ -115,23 +113,9 @@ describe('flattenAgentTree — robustness invariants (must hold for any tree)', 
             {name: 'Codex', command: 'codex --yolo "$AGENT_PROMPT"'},
         ];
         expect(flattenAgentTree(flat)).toEqual([
-            {name: 'Gemini', path: ['Gemini'], command: 'gemini -i "$AGENT_PROMPT"', env: {}},
-            {name: 'Codex', path: ['Codex'], command: 'codex --yolo "$AGENT_PROMPT"', env: {}},
+            {name: 'Gemini', path: ['Gemini'], label: 'Gemini', command: 'gemini -i "$AGENT_PROMPT"', env: {}},
+            {name: 'Codex', path: ['Codex'], label: 'Codex', command: 'codex --yolo "$AGENT_PROMPT"', env: {}},
         ]);
-    });
-});
-
-describe('collectResolvableCommands — the daemon validation set', () => {
-    it('contains every leaf command so a valid leaf is never rejected', () => {
-        const commands: Set<string> = collectResolvableCommands(CODEX_TREE);
-        for (const leaf of flattenAgentTree(CODEX_TREE)) {
-            expect(commands.has(leaf.command)).toBe(true);
-        }
-    });
-
-    it('collapses leaves that share a base command (Local Medium/XHigh)', () => {
-        // Both Local leaves resolve to CODEX_BASE; they differ only by env.
-        expect(collectResolvableCommands(CODEX_TREE).has(CODEX_BASE)).toBe(true);
     });
 });
 
@@ -145,14 +129,6 @@ describe('resolveDefaultAgent', () => {
         expect(resolveDefaultAgent(CODEX_TREE, 'Claude')?.name).toBe('Claude');
         expect(resolveDefaultAgent(CODEX_TREE, 'does-not-exist')?.name).toBe('Claude');
         expect(resolveDefaultAgent(CODEX_TREE)?.name).toBe('Claude');
-    });
-});
-
-describe('isAgentCategory', () => {
-    it('is true only for nodes with children', () => {
-        expect(isAgentCategory({name: 'Codex', command: 'x', children: [{name: 'L', command: 'y'}]})).toBe(true);
-        expect(isAgentCategory({name: 'leaf', command: 'y'})).toBe(false);
-        expect(isAgentCategory({name: 'empty', command: 'y', children: []})).toBe(false);
     });
 });
 

--- a/packages/libraries/graph-model/src/pure/settings/agentTree.ts
+++ b/packages/libraries/graph-model/src/pure/settings/agentTree.ts
@@ -116,7 +116,7 @@ export function mapAgentTreeByCommand(
     newCommand: string,
 ): readonly AgentConfig[] {
     return agents.map((node: AgentConfig): AgentConfig => {
-        const rewrittenCommand: string = node.command === oldCommand ? newCommand : node.command;
+        const rewrittenCommand: string | undefined = node.command === oldCommand ? newCommand : node.command;
         const rewrittenChildren: readonly AgentConfig[] | undefined = node.children
             ? mapAgentTreeByCommand(node.children, oldCommand, newCommand)
             : undefined;

--- a/packages/libraries/graph-model/src/pure/settings/agentTree.ts
+++ b/packages/libraries/graph-model/src/pure/settings/agentTree.ts
@@ -1,0 +1,125 @@
+import type {AgentConfig} from './types';
+
+/**
+ * A spawnable agent — the result of resolving one root→leaf path through the
+ * agent tree. This is the unit that actually gets launched: a concrete command
+ * plus the environment accumulated along its path.
+ */
+export interface ResolvedAgent {
+    /** Display label of the leaf itself (the last path segment). */
+    readonly name: string;
+    /** Full root→leaf path of node names, e.g. ['Codex', 'Remote', 'XHigh']. */
+    readonly path: readonly string[];
+    /**
+     * The command of the deepest node on the path that defines a non-empty
+     * command. Empty only if no node on the path defines one (a misconfigured
+     * leaf), which callers should treat as not spawnable.
+     */
+    readonly command: string;
+    /** Shallow-merge of every node's `env` along the path; deeper nodes win. */
+    readonly env: Readonly<Record<string, string>>;
+}
+
+const EMPTY_ENV: Readonly<Record<string, string>> = Object.freeze({});
+
+/** A node is a (non-spawnable) category iff it has children. */
+export function isAgentCategory(node: AgentConfig): boolean {
+    return (node.children?.length ?? 0) > 0;
+}
+
+/** Human-readable label for a resolved path, e.g. 'Codex / Remote / XHigh'. */
+export function agentPathLabel(path: readonly string[]): string {
+    return path.join(' / ');
+}
+
+/**
+ * Compose one tree node onto the (command, env) inherited from its ancestors.
+ * This is the single source of truth for how a child "just adds parameters":
+ *   - command: the node's own command wins if non-empty, else it is inherited.
+ *   - env:     shallow-merge — the node's own keys override inherited ones.
+ */
+export function composeAgentStep(
+    inherited: {readonly command: string; readonly env: Readonly<Record<string, string>>},
+    node: AgentConfig,
+): {readonly command: string; readonly env: Readonly<Record<string, string>>} {
+    const command: string = node.command && node.command.length > 0 ? node.command : inherited.command;
+    const env: Readonly<Record<string, string>> = node.env
+        ? {...inherited.env, ...node.env}
+        : inherited.env;
+    return {command, env};
+}
+
+/**
+ * Depth-first flatten of an agent tree into its spawnable leaves (nodes without
+ * children), each resolved to its composed command + env, in pre-order.
+ *
+ * A flat list with no `children` anywhere flattens to itself (each entry is a
+ * leaf resolving to its own command with empty env) — so the tree model is a
+ * strict superset of a plain `{name, command}[]`.
+ */
+export function flattenAgentTree(agents: readonly AgentConfig[]): ResolvedAgent[] {
+    const out: ResolvedAgent[] = [];
+    const walk = (
+        node: AgentConfig,
+        inherited: {readonly command: string; readonly env: Readonly<Record<string, string>>},
+        path: readonly string[],
+    ): void => {
+        const composed = composeAgentStep(inherited, node);
+        const here: readonly string[] = [...path, node.name];
+        if (isAgentCategory(node)) {
+            for (const child of node.children ?? []) walk(child, composed, here);
+        } else {
+            out.push({name: node.name, path: here, command: composed.command, env: composed.env});
+        }
+    };
+    for (const agent of agents) walk(agent, {command: '', env: EMPTY_ENV}, []);
+    return out;
+}
+
+/**
+ * Every distinct, non-empty command a leaf can resolve to — the exact set the
+ * daemon validates an incoming command against. Built from {@link flattenAgentTree}
+ * so a valid leaf command is never rejected.
+ */
+export function collectResolvableCommands(agents: readonly AgentConfig[]): Set<string> {
+    return new Set(flattenAgentTree(agents).map(leaf => leaf.command).filter(command => command.length > 0));
+}
+
+/**
+ * Resolve the default spawnable leaf. `defaultAgentName` is matched against the
+ * full path label ('Codex / Remote / XHigh') first, then a leaf's own name, and
+ * finally falls back to the first leaf in the tree.
+ */
+export function resolveDefaultAgent(
+    agents: readonly AgentConfig[],
+    defaultAgentName?: string,
+): ResolvedAgent | undefined {
+    const leaves: ResolvedAgent[] = flattenAgentTree(agents);
+    if (defaultAgentName) {
+        const byPath: ResolvedAgent | undefined = leaves.find(leaf => agentPathLabel(leaf.path) === defaultAgentName);
+        if (byPath) return byPath;
+        const byName: ResolvedAgent | undefined = leaves.find(leaf => leaf.name === defaultAgentName);
+        if (byName) return byName;
+    }
+    return leaves[0];
+}
+
+/**
+ * Recursively rewrite every node in the tree whose OWN command equals `oldCommand`
+ * to use `newCommand`, returning a new tree (structure preserved). Used by the
+ * Claude-specific toggles (first-run permission popup, Auto-run) that edit the
+ * command that defines a resolved leaf, wherever it sits in the tree.
+ */
+export function mapAgentTreeByCommand(
+    agents: readonly AgentConfig[],
+    oldCommand: string,
+    newCommand: string,
+): readonly AgentConfig[] {
+    return agents.map((node: AgentConfig): AgentConfig => {
+        const rewrittenCommand: string = node.command === oldCommand ? newCommand : node.command;
+        const rewrittenChildren: readonly AgentConfig[] | undefined = node.children
+            ? mapAgentTreeByCommand(node.children, oldCommand, newCommand)
+            : undefined;
+        return {...node, command: rewrittenCommand, ...(rewrittenChildren ? {children: rewrittenChildren} : {})};
+    });
+}

--- a/packages/libraries/graph-model/src/pure/settings/agentTree.ts
+++ b/packages/libraries/graph-model/src/pure/settings/agentTree.ts
@@ -10,6 +10,8 @@ export interface ResolvedAgent {
     readonly name: string;
     /** Full root→leaf path of node names, e.g. ['Codex', 'Remote', 'XHigh']. */
     readonly path: readonly string[];
+    /** Human-readable path, e.g. 'Codex / Remote / XHigh'. The stable id of a leaf. */
+    readonly label: string;
     /**
      * The command of the deepest node on the path that defines a non-empty
      * command. Empty only if no node on the path defines one (a misconfigured
@@ -22,14 +24,9 @@ export interface ResolvedAgent {
 
 const EMPTY_ENV: Readonly<Record<string, string>> = Object.freeze({});
 
-/** A node is a (non-spawnable) category iff it has children. */
-export function isAgentCategory(node: AgentConfig): boolean {
+/** A node is a (non-spawnable) category iff it has children. Internal to flattening. */
+function isCategory(node: AgentConfig): boolean {
     return (node.children?.length ?? 0) > 0;
-}
-
-/** Human-readable label for a resolved path, e.g. 'Codex / Remote / XHigh'. */
-export function agentPathLabel(path: readonly string[]): string {
-    return path.join(' / ');
 }
 
 /**
@@ -38,7 +35,7 @@ export function agentPathLabel(path: readonly string[]): string {
  *   - command: the node's own command wins if non-empty, else it is inherited.
  *   - env:     shallow-merge — the node's own keys override inherited ones.
  */
-export function composeAgentStep(
+function composeAgentStep(
     inherited: {readonly command: string; readonly env: Readonly<Record<string, string>>},
     node: AgentConfig,
 ): {readonly command: string; readonly env: Readonly<Record<string, string>>} {
@@ -66,23 +63,14 @@ export function flattenAgentTree(agents: readonly AgentConfig[]): ResolvedAgent[
     ): void => {
         const composed = composeAgentStep(inherited, node);
         const here: readonly string[] = [...path, node.name];
-        if (isAgentCategory(node)) {
+        if (isCategory(node)) {
             for (const child of node.children ?? []) walk(child, composed, here);
         } else {
-            out.push({name: node.name, path: here, command: composed.command, env: composed.env});
+            out.push({name: node.name, path: here, label: here.join(' / '), command: composed.command, env: composed.env});
         }
     };
     for (const agent of agents) walk(agent, {command: '', env: EMPTY_ENV}, []);
     return out;
-}
-
-/**
- * Every distinct, non-empty command a leaf can resolve to — the exact set the
- * daemon validates an incoming command against. Built from {@link flattenAgentTree}
- * so a valid leaf command is never rejected.
- */
-export function collectResolvableCommands(agents: readonly AgentConfig[]): Set<string> {
-    return new Set(flattenAgentTree(agents).map(leaf => leaf.command).filter(command => command.length > 0));
 }
 
 /**
@@ -96,8 +84,8 @@ export function resolveDefaultAgent(
 ): ResolvedAgent | undefined {
     const leaves: ResolvedAgent[] = flattenAgentTree(agents);
     if (defaultAgentName) {
-        const byPath: ResolvedAgent | undefined = leaves.find(leaf => agentPathLabel(leaf.path) === defaultAgentName);
-        if (byPath) return byPath;
+        const byLabel: ResolvedAgent | undefined = leaves.find(leaf => leaf.label === defaultAgentName);
+        if (byLabel) return byLabel;
         const byName: ResolvedAgent | undefined = leaves.find(leaf => leaf.name === defaultAgentName);
         if (byName) return byName;
     }

--- a/packages/libraries/graph-model/src/pure/settings/agentTreeDelivery.test.ts
+++ b/packages/libraries/graph-model/src/pure/settings/agentTreeDelivery.test.ts
@@ -1,0 +1,123 @@
+import {describe, it, expect} from 'vitest';
+import {spawn} from 'node:child_process';
+import {mkdtempSync, readFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join, resolve, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import type {AgentConfig} from './types';
+import {flattenAgentTree, type ResolvedAgent} from './agentTree';
+
+/**
+ * END-TO-END DELIVERY VERIFICATION.
+ *
+ * The pure tests (agentTree.test.ts) prove the resolver composes the right
+ * {command, env}. They do NOT prove those parameters actually reach the spawned
+ * process: a single-quote that swallows `$EFFORT`, an env var that never gets
+ * injected, or a shell that fails to expand a placeholder would all pass the
+ * pure tests yet break in production.
+ *
+ * This suite closes that gap with a probe. We run the resolved command through a
+ * real shell with the resolved env injected (exactly as the daemon hands the env
+ * to tmux via `-e KEY=VALUE`, then the shell parses + expands the command), and
+ * inspect the literal env + argv the launched process received. This is the
+ * robust, accurate oracle for "did the parameter actually get delivered".
+ */
+
+const PROBE: string = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../../../tools/agent-tree-probe/probe.mjs');
+
+/** Codex-Local shape: EFFORT is expanded into a `-c` flag (argv channel). */
+const LOCAL_TREE: readonly AgentConfig[] = [{
+    name: 'codex-local',
+    command: `node ${PROBE} -c "model_reasoning_effort=\\"$EFFORT\\""`,
+    children: [
+        {name: 'Medium', env: {EFFORT: 'medium'}},
+        {name: 'XHigh', env: {EFFORT: 'xhigh'}},
+    ],
+}];
+
+/** Codex-Remote shape: EFFORT is expanded into a launcher env prefix (env channel). */
+const REMOTE_TREE: readonly AgentConfig[] = [{
+    name: 'codex-remote',
+    command: `CODEX_REASONING_EFFORT="$EFFORT" node ${PROBE}`,
+    children: [
+        {name: 'Medium', env: {EFFORT: 'medium'}},
+        {name: 'XHigh', env: {EFFORT: 'xhigh'}},
+    ],
+}];
+
+interface ProbeDump {
+    readonly argv: readonly string[];
+    readonly env: Readonly<Record<string, string>>;
+}
+
+/**
+ * Spawn the resolved command through a real shell with its resolved env injected,
+ * and return what the launched process actually received. `bash -c <command>`
+ * with the env set is a faithful stand-in for the daemon's `tmux new-session
+ * -e KEY=VALUE … <command>`: tmux sets exactly these env vars, then the session
+ * shell parses and expands the command identically.
+ */
+async function runProbe(leaf: ResolvedAgent): Promise<ProbeDump> {
+    const outFile: string = join(mkdtempSync(join(tmpdir(), 'agent-tree-probe-')), 'dump.json');
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+        const child = spawn('bash', ['-c', leaf.command], {
+            env: {...process.env, ...leaf.env, AGENT_TREE_PROBE_OUT: outFile},
+            stdio: 'ignore',
+        });
+        child.on('error', rejectPromise);
+        child.on('exit', (code: number | null) => code === 0 ? resolvePromise() : rejectPromise(new Error(`probe exited ${code}`)));
+    });
+    return JSON.parse(readFileSync(outFile, 'utf8')) as ProbeDump;
+}
+
+type Expectation =
+    | {readonly channel: 'argv'; readonly pattern: RegExp}
+    | {readonly channel: 'env'; readonly key: string; readonly value: string};
+
+/**
+ * The reusable verification function. Given a resolved leaf and the channel its
+ * parameter is expected to arrive on, it runs the probe and reports whether the
+ * parameter was actually delivered, along with what was observed. Honest by
+ * construction: it can (and the tests below confirm it does) return false.
+ */
+async function verifyAgentDelivery(leaf: ResolvedAgent, expected: Expectation): Promise<{readonly ok: boolean; readonly observed: ProbeDump}> {
+    const observed: ProbeDump = await runProbe(leaf);
+    const ok: boolean = expected.channel === 'env'
+        ? observed.env[expected.key] === expected.value
+        : expected.pattern.test(observed.argv.join(' '));
+    return {ok, observed};
+}
+
+function leaf(tree: readonly AgentConfig[], pathLabel: string): ResolvedAgent {
+    const found: ResolvedAgent | undefined = flattenAgentTree(tree).find(l => l.path.join(' / ') === pathLabel);
+    if (!found) throw new Error(`no leaf ${pathLabel}`);
+    return found;
+}
+
+describe('agent-tree end-to-end delivery (probe oracle)', () => {
+    it('Local: EFFORT reaches the process as the expanded -c flag value', async () => {
+        const xhigh = await verifyAgentDelivery(leaf(LOCAL_TREE, 'codex-local / XHigh'), {channel: 'argv', pattern: /model_reasoning_effort="xhigh"/});
+        expect(xhigh.ok).toBe(true);
+        const medium = await verifyAgentDelivery(leaf(LOCAL_TREE, 'codex-local / Medium'), {channel: 'argv', pattern: /model_reasoning_effort="medium"/});
+        expect(medium.ok).toBe(true);
+    });
+
+    it('Remote: EFFORT reaches the launcher as CODEX_REASONING_EFFORT in its env', async () => {
+        const xhigh = await verifyAgentDelivery(leaf(REMOTE_TREE, 'codex-remote / XHigh'), {channel: 'env', key: 'CODEX_REASONING_EFFORT', value: 'xhigh'});
+        expect(xhigh.ok).toBe(true);
+        const medium = await verifyAgentDelivery(leaf(REMOTE_TREE, 'codex-remote / Medium'), {channel: 'env', key: 'CODEX_REASONING_EFFORT', value: 'medium'});
+        expect(medium.ok).toBe(true);
+    });
+
+    it('does not leak a sibling leaf\'s value (no cross-contamination)', async () => {
+        const dump = await runProbe(leaf(LOCAL_TREE, 'codex-local / XHigh'));
+        expect(dump.argv.join(' ')).not.toContain('medium');
+    });
+
+    it('the verifier is honest — a wrong expectation fails', async () => {
+        // Guards against a rubber-stamp oracle: the XHigh leaf must NOT satisfy a
+        // "medium" expectation. If this passed, every other assertion would be worthless.
+        const wrong = await verifyAgentDelivery(leaf(LOCAL_TREE, 'codex-local / XHigh'), {channel: 'argv', pattern: /model_reasoning_effort="medium"/});
+        expect(wrong.ok).toBe(false);
+    });
+});

--- a/packages/libraries/graph-model/src/pure/settings/agentTreeEdit.test.ts
+++ b/packages/libraries/graph-model/src/pure/settings/agentTreeEdit.test.ts
@@ -1,0 +1,45 @@
+import {describe, it, expect} from 'vitest';
+import type {AgentConfig} from './types';
+import {updateAgentAt, removeAgentAt, addChildAt, appendAgent} from './agentTreeEdit';
+
+const TREE: readonly AgentConfig[] = [
+    {name: 'Claude', command: 'claude'},
+    {name: 'Codex', command: 'codex', children: [
+        {name: 'Local', children: [{name: 'Medium', env: {EFFORT: 'medium'}}]},
+    ]},
+];
+
+describe('agentTreeEdit', () => {
+    it('updateAgentAt patches a nested node without disturbing siblings', () => {
+        const out = updateAgentAt(TREE, [1, 0, 0], {env: {EFFORT: 'xhigh'}});
+        expect(out[1].children?.[0].children?.[0].env).toEqual({EFFORT: 'xhigh'});
+        expect(out[0]).toEqual(TREE[0]); // sibling untouched
+    });
+
+    it('removeAgentAt removes a top-level node', () => {
+        expect(removeAgentAt(TREE, [0]).map(n => n.name)).toEqual(['Codex']);
+    });
+
+    it('removeAgentAt removes a deeply nested node', () => {
+        const out = removeAgentAt(TREE, [1, 0, 0]);
+        expect(out[1].children?.[0].children).toEqual([]);
+    });
+
+    it('addChildAt appends a child to a nested node', () => {
+        const out = addChildAt(TREE, [1, 0], {name: 'XHigh', env: {EFFORT: 'xhigh'}});
+        expect(out[1].children?.[0].children?.map(c => c.name)).toEqual(['Medium', 'XHigh']);
+    });
+
+    it('appendAgent adds a new top-level node', () => {
+        expect(appendAgent(TREE, {name: 'Gemini', command: 'gemini'}).map(n => n.name))
+            .toEqual(['Claude', 'Codex', 'Gemini']);
+    });
+
+    it('edits are immutable (input tree is not mutated)', () => {
+        const snapshot = JSON.stringify(TREE);
+        updateAgentAt(TREE, [1, 0, 0], {env: {EFFORT: 'xhigh'}});
+        removeAgentAt(TREE, [0]);
+        addChildAt(TREE, [1, 0], {name: 'X', command: 'x'});
+        expect(JSON.stringify(TREE)).toBe(snapshot);
+    });
+});

--- a/packages/libraries/graph-model/src/pure/settings/agentTreeEdit.ts
+++ b/packages/libraries/graph-model/src/pure/settings/agentTreeEdit.ts
@@ -1,0 +1,45 @@
+import type {AgentConfig} from './types';
+
+/** An index path into the agent tree: [2] = 3rd top-level node, [2,0] = its 1st child. */
+export type AgentPath = readonly number[];
+
+function mapAt(agents: readonly AgentConfig[], path: AgentPath, fn: (node: AgentConfig) => AgentConfig): AgentConfig[] {
+    if (path.length === 0) throw new Error('agentTreeEdit: empty path');
+    const [head, ...rest] = path;
+    return agents.map((node: AgentConfig, index: number): AgentConfig => {
+        if (index !== head) return node;
+        if (rest.length === 0) return fn(node);
+        return {...node, children: mapAt(node.children ?? [], rest, fn)};
+    });
+}
+
+/** Shallow-merge `patch` into the node at `path`. */
+export function updateAgentAt(agents: readonly AgentConfig[], path: AgentPath, patch: Partial<AgentConfig>): AgentConfig[] {
+    return mapAt(agents, path, (node: AgentConfig): AgentConfig => ({...node, ...patch}));
+}
+
+/** Remove the node at `path`. */
+export function removeAgentAt(agents: readonly AgentConfig[], path: AgentPath): AgentConfig[] {
+    if (path.length === 0) throw new Error('agentTreeEdit: empty path');
+    const index: number = path[path.length - 1];
+    const parentPath: AgentPath = path.slice(0, -1);
+    if (parentPath.length === 0) return agents.filter((_, i) => i !== index);
+    return mapAt(agents, parentPath, (parent: AgentConfig): AgentConfig => ({
+        ...parent,
+        children: (parent.children ?? []).filter((_, i) => i !== index),
+    }));
+}
+
+/** Append `child` to the children of the node at `parentPath` (creating the array if absent). */
+export function addChildAt(agents: readonly AgentConfig[], parentPath: AgentPath, child: AgentConfig): AgentConfig[] {
+    if (parentPath.length === 0) throw new Error('agentTreeEdit: use appendAgent for a top-level node');
+    return mapAt(agents, parentPath, (parent: AgentConfig): AgentConfig => ({
+        ...parent,
+        children: [...(parent.children ?? []), child],
+    }));
+}
+
+/** Append a new top-level node. */
+export function appendAgent(agents: readonly AgentConfig[], node: AgentConfig): AgentConfig[] {
+    return [...agents, node];
+}

--- a/packages/libraries/graph-model/src/pure/settings/types.ts
+++ b/packages/libraries/graph-model/src/pure/settings/types.ts
@@ -1,15 +1,23 @@
 export interface AgentConfig {
     readonly name: string;
-    readonly command: string;
-}
-
-/** Returns the default agent (by name match), falling back to agents[0]. */
-export function getDefaultAgent(agents: readonly AgentConfig[], defaultAgentName?: string): AgentConfig | undefined {
-    if (defaultAgentName) {
-        const found: AgentConfig | undefined = agents.find(a => a.name === defaultAgentName);
-        if (found) return found;
-    }
-    return agents[0];
+    /**
+     * Command to launch this agent. Omitted on pure category/folder nodes (which
+     * only group `children` and are never spawned directly). A leaf inherits the
+     * nearest ancestor's command unless it defines its own. See `agentTree.ts`.
+     */
+    readonly command?: string;
+    /**
+     * Extra environment variables this node contributes. Merged down the
+     * root→leaf path (deeper wins) and delivered to the spawned process via the
+     * spawn RPC's `envOverrides` channel — this is how a child "just adds a
+     * parameter" (e.g. `{ EFFORT: "xhigh" }`) without re-spelling the command.
+     */
+    readonly env?: Readonly<Record<string, string>>;
+    /**
+     * Child agents. Present => this node is a category (renders as a hover
+     * submenu, not spawnable). Absent/empty => this node is a spawnable leaf.
+     */
+    readonly children?: readonly AgentConfig[];
 }
 
 export const AGENT_NAMES: readonly string[] = [

--- a/packages/libraries/graph-model/src/settings.ts
+++ b/packages/libraries/graph-model/src/settings.ts
@@ -13,6 +13,13 @@ export {
     mapAgentTreeByCommand,
 } from './pure/settings/agentTree'
 export {
+    type AgentPath,
+    updateAgentAt,
+    removeAgentAt,
+    addChildAt,
+    appendAgent,
+} from './pure/settings/agentTreeEdit'
+export {
     type Persona,
     SILICON_VALLEY_ROSTER,
     SILICON_VALLEY_IDS,

--- a/packages/libraries/graph-model/src/settings.ts
+++ b/packages/libraries/graph-model/src/settings.ts
@@ -1,7 +1,17 @@
 export type { VTSettings, AgentConfig, EnvVarValue, HotkeyModifier, HotkeyBinding, HotkeySettings, HookSettings, ProjectConfig, VoiceTreeConfig, TerminalScrollStrategy } from './pure/settings/types'
 export { getUniqueAgentName } from './pure/settings/types'
 export { DEFAULT_SUBGRAPH_WARN_THRESHOLD, DEFAULT_SUBGRAPH_ERROR_THRESHOLD, DEFAULT_MAX_CHILDREN_PER_NODE, DEFAULT_COMPLEXITY_WARN_SCORE, DEFAULT_COMPLEXITY_BLOCK_SCORE, DEFAULT_SUBGRAPH_LIMITS } from './pure/settings/types'
-export { AGENT_NAMES, getNextAgentName, getDefaultAgent } from './pure/settings/types'
+export { AGENT_NAMES, getNextAgentName } from './pure/settings/types'
+export {
+    type ResolvedAgent,
+    isAgentCategory,
+    agentPathLabel,
+    composeAgentStep,
+    flattenAgentTree,
+    collectResolvableCommands,
+    resolveDefaultAgent,
+    mapAgentTreeByCommand,
+} from './pure/settings/agentTree'
 export {
     type Persona,
     SILICON_VALLEY_ROSTER,

--- a/packages/libraries/graph-model/src/settings.ts
+++ b/packages/libraries/graph-model/src/settings.ts
@@ -4,21 +4,10 @@ export { DEFAULT_SUBGRAPH_WARN_THRESHOLD, DEFAULT_SUBGRAPH_ERROR_THRESHOLD, DEFA
 export { AGENT_NAMES, getNextAgentName } from './pure/settings/types'
 export {
     type ResolvedAgent,
-    isAgentCategory,
-    agentPathLabel,
-    composeAgentStep,
     flattenAgentTree,
-    collectResolvableCommands,
     resolveDefaultAgent,
     mapAgentTreeByCommand,
 } from './pure/settings/agentTree'
-export {
-    type AgentPath,
-    updateAgentAt,
-    removeAgentAt,
-    addChildAt,
-    appendAgent,
-} from './pure/settings/agentTreeEdit'
 export {
     type Persona,
     SILICON_VALLEY_ROSTER,

--- a/packages/libraries/graph-model/vitest.config.stryker.ts
+++ b/packages/libraries/graph-model/vitest.config.stryker.ts
@@ -8,6 +8,13 @@ export default defineConfig({
       'src/pure/graph/graph-operations/transforms/removeNodeMaintainingTransitiveEdges.test.ts',
       'src/pure/graph/graph-operations/traversal/getSubgraphByDistance.test.ts',
       'src/pure/graph/graphDelta/deleteNodeEdgePreservation.test.ts',
+      // End-to-end delivery oracle: spawns a real bash + reads the probe at
+      // tools/agent-tree-probe/probe.mjs (repo root). Stryker copies only the
+      // package into .stryker-tmp, so the out-of-package probe is unreachable
+      // there; it also spawns a subprocess per case (too slow to run per-mutant).
+      // The pure agentTree.test.ts carries mutation coverage for the resolver;
+      // this oracle runs in the normal unit suite (graph-model-unit).
+      'src/pure/settings/agentTreeDelivery.test.ts',
     ],
   },
 })

--- a/packages/measures/budgets/complexity/runtime-fan-in.json
+++ b/packages/measures/budgets/complexity/runtime-fan-in.json
@@ -1,4 +1,4 @@
 {
-  "max": 120,
-  "note": "2026-06-03: 117 -> 120 (+3). graph-model is the top fan-in package; the create_graph child_count_limit + graph_complexity_limit gates added 3 tunable settings defaults (DEFAULT_MAX_CHILDREN_PER_NODE, DEFAULT_COMPLEXITY_WARN_SCORE, DEFAULT_COMPLEXITY_BLOCK_SCORE) imported by createGraphTool."
+  "max": 121,
+  "note": "2026-06-05: 120 -> 121 (+1 net). Hierarchical agent commands: graph-model now exposes the shared agent-tree resolver (flattenAgentTree, resolveDefaultAgent, mapAgentTreeByCommand) imported by both the webapp and the daemon, minus the removed flat getDefaultAgent. Surface was kept minimal — the path label lives on ResolvedAgent, the category check + resolvable-command set are inlined at call sites, and the UI-only tree-edit ops live in the webapp — so only +1 distinct symbol crosses the boundary. 2026-06-03: 117 -> 120 (+3). graph-model is the top fan-in package; the create_graph child_count_limit + graph_complexity_limit gates added 3 tunable settings defaults (DEFAULT_MAX_CHILDREN_PER_NODE, DEFAULT_COMPLEXITY_WARN_SCORE, DEFAULT_COMPLEXITY_BLOCK_SCORE) imported by createGraphTool."
 }

--- a/packages/measures/budgets/coupling/cross-package-value-symbol-budgets.ts
+++ b/packages/measures/budgets/coupling/cross-package-value-symbol-budgets.ts
@@ -343,7 +343,12 @@ export const CROSS_PACKAGE_VALUE_SYMBOL_BUDGETS: Readonly<Record<string, number>
     // buildTerminalEnvVars adds appendPersonaToAgentPrompt; the roster/lookup/
     // render internals stay inside graph-model so the daemon depends on one new
     // symbol, not three.
-    'vt-daemon -> graph-model': 27,
+    // 2026-06-05: hierarchical agent commands. The daemon spawn path now resolves
+    // the agent *tree* instead of a flat list, so it depends on the shared
+    // resolver: 27 -> 28 (+2 flattenAgentTree / resolveDefaultAgent, -1 the
+    // removed flat getDefaultAgent). Kept to +1 net by inlining the resolvable-
+    // command set in agentCommand.ts and reading the path label off ResolvedAgent.
+    'vt-daemon -> graph-model': 28,
     // 2026-05-27 [Phase 3]: daemon owns live-command dispatch + state
     // hydration post-BF-379. Three value symbols: `applyCommandWithDelta`,
     // `hydrateCommand`, `serializeState` (all wire shapes formerly evaluated

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/listAgentsTool.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/listAgentsTool.ts
@@ -8,6 +8,7 @@ import type {Graph, GraphNode, NodeIdAndFilePath} from '@vt/graph-model/graph'
 import {getNodeTitle} from '@vt/graph-model/markdown'
 import {loadSettings} from '@vt/app-config/settings'
 import type {VTSettings} from '@vt/graph-model/settings'
+import {flattenAgentTree, agentPathLabel} from '@vt/graph-model/settings'
 import {type McpToolResponse, buildJsonResponse} from '@vt/vt-daemon/_shared/toolResponse.ts'
 import {getAgentNodes} from './completion/agentNodeIndex.ts'
 import {getNewNodesForAgentIdentities} from './completion/getNewNodesForAgent.ts'
@@ -117,11 +118,12 @@ export async function listAgentsTool(bridge: GraphBridge): Promise<McpToolRespon
         })
     }
 
-    // Include available agent types from settings so callers can discover
-    // what agentName values are valid for spawn_agent
+    // Include available agent types from settings so callers can discover what
+    // agentName values are valid for spawn_agent. These are the resolvable leaf
+    // labels of the agent tree (e.g. 'Codex / Remote / XHigh'), not categories.
     const settings: VTSettings = await loadSettings()
-    const availableAgents: readonly string[] = (settings?.agents ?? []).map(
-        (a: { readonly name: string; readonly command: string }) => a.name
+    const availableAgents: readonly string[] = flattenAgentTree(settings?.agents ?? []).map(
+        leaf => agentPathLabel(leaf.path)
     )
 
     return buildJsonResponse({success: true, agents, availableAgents})

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/listAgentsTool.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/listAgentsTool.ts
@@ -8,7 +8,7 @@ import type {Graph, GraphNode, NodeIdAndFilePath} from '@vt/graph-model/graph'
 import {getNodeTitle} from '@vt/graph-model/markdown'
 import {loadSettings} from '@vt/app-config/settings'
 import type {VTSettings} from '@vt/graph-model/settings'
-import {flattenAgentTree, agentPathLabel} from '@vt/graph-model/settings'
+import {flattenAgentTree} from '@vt/graph-model/settings'
 import {type McpToolResponse, buildJsonResponse} from '@vt/vt-daemon/_shared/toolResponse.ts'
 import {getAgentNodes} from './completion/agentNodeIndex.ts'
 import {getNewNodesForAgentIdentities} from './completion/getNewNodesForAgent.ts'
@@ -123,7 +123,7 @@ export async function listAgentsTool(bridge: GraphBridge): Promise<McpToolRespon
     // labels of the agent tree (e.g. 'Codex / Remote / XHigh'), not categories.
     const settings: VTSettings = await loadSettings()
     const availableAgents: readonly string[] = flattenAgentTree(settings?.agents ?? []).map(
-        leaf => agentPathLabel(leaf.path)
+        leaf => leaf.label
     )
 
     return buildJsonResponse({success: true, agents, availableAgents})

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/spawnAgentTool.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/spawnAgentTool.ts
@@ -9,7 +9,7 @@ import {findBestMatchingNode} from '@vt/graph-model/markdown'
 import {createTaskNode} from '@vt/graph-model/graph'
 import {loadSettings} from '@vt/app-config/settings'
 import type {VTSettings, AgentConfig, ResolvedAgent} from '@vt/graph-model/settings'
-import {flattenAgentTree, agentPathLabel} from '@vt/graph-model/settings'
+import {flattenAgentTree} from '@vt/graph-model/settings'
 import {type McpToolResponse, buildJsonResponse} from '@vt/vt-daemon/_shared/toolResponse.ts'
 import {startMonitor} from './agent-completion-monitor.ts'
 import {applyMcpGraphDelta, getMcpGraph, getMcpWriteFolderPath} from '@vt/vt-daemon/config/graphBridge.ts'
@@ -123,14 +123,14 @@ function buildEnvOverrides(childDepthBudget: number | undefined, childGlobalBudg
 /** Find a spawnable leaf by its full path label ('Codex / Remote / XHigh') or, failing that, its leaf name. */
 function findAgentLeaf(agents: readonly AgentConfig[], name: string): ResolvedAgent | undefined {
     const leaves: ResolvedAgent[] = flattenAgentTree(agents)
-    return leaves.find(leaf => agentPathLabel(leaf.path) === name) ?? leaves.find(leaf => leaf.name === name)
+    return leaves.find(leaf => leaf.label === name) ?? leaves.find(leaf => leaf.name === name)
 }
 
 function resolveNamedAgent(agentName: string, agents: readonly AgentConfig[]): Result<ResolvedAgent> {
     const matched: ResolvedAgent | undefined = findAgentLeaf(agents, agentName)
     if (matched) return {ok: true, value: matched}
 
-    const available: string = flattenAgentTree(agents).map(leaf => agentPathLabel(leaf.path)).join(', ')
+    const available: string = flattenAgentTree(agents).map(leaf => leaf.label).join(', ')
     return {ok: false, error: `Agent "${agentName}" not found in settings.agents. Available: ${available}`}
 }
 

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/spawnAgentTool.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/spawnAgentTool.ts
@@ -8,7 +8,8 @@ import type {Graph, GraphDelta, GraphNode, NodeIdAndFilePath} from '@vt/graph-mo
 import {findBestMatchingNode} from '@vt/graph-model/markdown'
 import {createTaskNode} from '@vt/graph-model/graph'
 import {loadSettings} from '@vt/app-config/settings'
-import type {VTSettings} from '@vt/graph-model/settings'
+import type {VTSettings, AgentConfig, ResolvedAgent} from '@vt/graph-model/settings'
+import {flattenAgentTree, agentPathLabel} from '@vt/graph-model/settings'
 import {type McpToolResponse, buildJsonResponse} from '@vt/vt-daemon/_shared/toolResponse.ts'
 import {startMonitor} from './agent-completion-monitor.ts'
 import {applyMcpGraphDelta, getMcpGraph, getMcpWriteFolderPath} from '@vt/vt-daemon/config/graphBridge.ts'
@@ -60,8 +61,6 @@ export function makeSpawnAgentDeps(bridge: GraphBridge): SpawnAgentDeps {
             startMonitor(callerTerminalId, terminalIds, bridge, pollIntervalMs),
     }
 }
-
-type AgentSetting = { readonly name: string; readonly command: string }
 
 type Result<T> = { readonly ok: true; readonly value: T } | { readonly ok: false; readonly error: string }
 
@@ -121,32 +120,34 @@ function buildEnvOverrides(childDepthBudget: number | undefined, childGlobalBudg
     }
 }
 
-function resolveNamedAgentCommand(agentName: string, agents: readonly AgentSetting[]): Result<string> {
-    const matchedAgent: AgentSetting | undefined = agents.find((agent: AgentSetting) => agent.name === agentName)
-    if (matchedAgent) return {ok: true, value: matchedAgent.command}
-
-    return {
-        ok: false,
-        error: `Agent "${agentName}" not found in settings.agents. Available: ${agents.map((agent: AgentSetting) => agent.name).join(', ')}`
-    }
+/** Find a spawnable leaf by its full path label ('Codex / Remote / XHigh') or, failing that, its leaf name. */
+function findAgentLeaf(agents: readonly AgentConfig[], name: string): ResolvedAgent | undefined {
+    const leaves: ResolvedAgent[] = flattenAgentTree(agents)
+    return leaves.find(leaf => agentPathLabel(leaf.path) === name) ?? leaves.find(leaf => leaf.name === name)
 }
 
-async function resolveAgentCommand(
+function resolveNamedAgent(agentName: string, agents: readonly AgentConfig[]): Result<ResolvedAgent> {
+    const matched: ResolvedAgent | undefined = findAgentLeaf(agents, agentName)
+    if (matched) return {ok: true, value: matched}
+
+    const available: string = flattenAgentTree(agents).map(leaf => agentPathLabel(leaf.path)).join(', ')
+    return {ok: false, error: `Agent "${agentName}" not found in settings.agents. Available: ${available}`}
+}
+
+/** Resolve the leaf to spawn — explicit `agentName`, else inherit the caller's agent type, else none. */
+async function resolveAgentSelection(
     agentName: string | undefined,
     callerRecord: TerminalRecord,
     deps: SpawnAgentDeps,
-): Promise<Result<string | undefined>> {
+): Promise<Result<ResolvedAgent | undefined>> {
     const callerAgentTypeName: string | undefined = callerRecord.terminalData.agentTypeName
     if (!agentName && !callerAgentTypeName) return {ok: true, value: undefined}
 
     const settings: VTSettings = await deps.loadAgentSettings()
-    const agents: readonly AgentSetting[] = settings?.agents ?? []
-    if (agentName) return resolveNamedAgentCommand(agentName, agents)
+    const agents: readonly AgentConfig[] = settings?.agents ?? []
+    if (agentName) return resolveNamedAgent(agentName, agents)
 
-    const inheritedAgent: AgentSetting | undefined = agents.find(
-        (agent: AgentSetting) => agent.name === callerAgentTypeName
-    )
-    return {ok: true, value: inheritedAgent?.command}
+    return {ok: true, value: callerAgentTypeName ? findAgentLeaf(agents, callerAgentTypeName) : undefined}
 }
 
 function resolveSpawnDirectory(spawnDirectory: string | undefined, callerRecord: TerminalRecord): string | undefined {
@@ -162,17 +163,20 @@ async function prepareSpawnRuntime(
     const budgetResult: BudgetResult = deps.consumeBudget(params.callerTerminalId)
     if (!budgetResult.allowed) return {ok: false, error: 'Global spawn budget exhausted'}
 
-    const agentCommandResult: Result<string | undefined> = await resolveAgentCommand(params.agentName, callerRecord, deps)
-    if (!agentCommandResult.ok) return agentCommandResult
+    const selectionResult: Result<ResolvedAgent | undefined> = await resolveAgentSelection(params.agentName, callerRecord, deps)
+    if (!selectionResult.ok) return selectionResult
+    const selection: ResolvedAgent | undefined = selectionResult.value
 
     return {
         ok: true,
         value: {
             callerTerminalId: params.callerTerminalId,
             callerRecord,
-            resolvedAgentCommand: agentCommandResult.value,
+            resolvedAgentCommand: selection?.command,
             resolvedSpawnDirectory: resolveSpawnDirectory(params.spawnDirectory, callerRecord),
-            envOverrides: buildEnvOverrides(childDepthBudget, budgetResult.childBudget),
+            // The leaf's env (e.g. { EFFORT }) plus the budget env. Budget vars are
+            // spread last so user env can never clobber DEPTH_BUDGET / spawn budget.
+            envOverrides: {...selection?.env, ...buildEnvOverrides(childDepthBudget, budgetResult.childBudget)},
             childDepthBudget,
         }
     }

--- a/packages/systems/vt-daemon/src/agent-runtime/spawn/agentCommand.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/spawn/agentCommand.ts
@@ -1,4 +1,4 @@
-import {collectResolvableCommands, resolveDefaultAgent} from '@vt/graph-model/settings'
+import {flattenAgentTree, resolveDefaultAgent} from '@vt/graph-model/settings'
 import type {AgentConfig, VTSettings} from '@vt/graph-model/settings'
 import type {NodeIdAndFilePath} from '@vt/graph-model/graph'
 
@@ -20,7 +20,8 @@ export function resolveAgentCommand(
 
     const agents: readonly AgentConfig[] = settings.agents ?? []
     if (agentCommand !== undefined) {
-        if (!collectResolvableCommands(agents).has(agentCommand)) {
+        const resolvable: Set<string> = new Set(flattenAgentTree(agents).map(leaf => leaf.command).filter(command => command.length > 0))
+        if (!resolvable.has(agentCommand)) {
             throw new Error('Invalid agent command - must be a command resolvable from settings.agents')
         }
         return agentCommand

--- a/packages/systems/vt-daemon/src/agent-runtime/spawn/agentCommand.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/spawn/agentCommand.ts
@@ -1,7 +1,14 @@
-import {getDefaultAgent} from '@vt/graph-model/settings'
-import type {VTSettings} from '@vt/graph-model/settings'
+import {collectResolvableCommands, resolveDefaultAgent} from '@vt/graph-model/settings'
+import type {AgentConfig, VTSettings} from '@vt/graph-model/settings'
 import type {NodeIdAndFilePath} from '@vt/graph-model/graph'
 
+/**
+ * Resolve the command to launch. A provided command must be one that some leaf
+ * of the agent tree resolves to (its env is carried separately via the spawn
+ * RPC's `envOverrides`, resolved at the edge). With no command, the default
+ * leaf's command is used as a bare fallback — callers that need the default's
+ * env resolve it at the edge and pass it through `envOverrides`.
+ */
 export function resolveAgentCommand(
     agentCommand: string | undefined,
     settings: VTSettings,
@@ -11,15 +18,15 @@ export function resolveAgentCommand(
         throw new Error(`Failed to load settings for ${taskNodeId}`)
     }
 
-    const agents: readonly { readonly name: string; readonly command: string }[] = settings.agents ?? []
+    const agents: readonly AgentConfig[] = settings.agents ?? []
     if (agentCommand !== undefined) {
-        const validCommands: Set<string> = new Set(agents.map(a => a.command))
-        if (!validCommands.has(agentCommand)) {
-            throw new Error('Invalid agent command - must be defined in settings.agents')
+        if (!collectResolvableCommands(agents).has(agentCommand)) {
+            throw new Error('Invalid agent command - must be a command resolvable from settings.agents')
         }
+        return agentCommand
     }
 
-    const command: string = agentCommand ?? getDefaultAgent(agents, settings.defaultAgent)?.command ?? ''
+    const command: string = resolveDefaultAgent(agents, settings.defaultAgent)?.command ?? ''
     if (!command) {
         throw new Error('No agent command available - settings.agents is empty or undefined')
     }

--- a/packages/systems/vt-daemon/src/tools/system/triggerOvernight.ts
+++ b/packages/systems/vt-daemon/src/tools/system/triggerOvernight.ts
@@ -5,7 +5,8 @@ import * as O from 'fp-ts/lib/Option.js'
 import type {Graph, GraphDelta, NodeIdAndFilePath} from '@vt/graph-model/graph'
 import {createTaskNode} from '@vt/graph-model/graph'
 import {loadSettings} from '@vt/app-config/settings'
-import type {VTSettings} from '@vt/graph-model/settings'
+import type {VTSettings, ResolvedAgent} from '@vt/graph-model/settings'
+import {flattenAgentTree} from '@vt/graph-model/settings'
 import {applyMcpGraphDelta, getMcpGraph, getMcpWriteFolderPath} from '@vt/vt-daemon/config/graphBridge.ts'
 import type {GraphBridge} from '@vt/vt-daemon/config/mcpBridges.ts'
 import {spawnContextTerminal} from '@vt/vt-daemon/agent-runtime/agent-control/agentControlRuntime.ts'
@@ -81,11 +82,10 @@ export async function triggerOvernight(
 
     await applyMcpGraphDelta(bridge, taskNodeDelta)
 
-    // Resolve Opus agent command (find "Claude" in settings.agents)
+    // Resolve the Opus agent (the "Claude" leaf of the agent tree).
     const settings: VTSettings = await loadSettings()
-    const agents: readonly {readonly name: string; readonly command: string}[] = settings?.agents ?? []
-    const claudeAgent: {readonly name: string; readonly command: string} | undefined =
-        agents.find((a: {readonly name: string; readonly command: string}) => a.name === 'Claude')
+    const claudeAgent: ResolvedAgent | undefined =
+        flattenAgentTree(settings?.agents ?? []).find(leaf => leaf.name === 'Claude')
     const agentCommand: string | undefined = claudeAgent?.command
 
     // Build meta-observer prompt with parameters
@@ -122,7 +122,7 @@ export async function triggerOvernight(
         undefined,    // promptTemplate
         false,        // headless
         undefined,    // inheritTerminalId
-        {DEPTH_BUDGET: '3', AGENT_PROMPT: agentPrompt}
+        {...claudeAgent?.env, DEPTH_BUDGET: '3', AGENT_PROMPT: agentPrompt}
     )
 
     return {success: true, terminalId, taskNodeId}

--- a/tools/agent-tree-probe/probe.mjs
+++ b/tools/agent-tree-probe/probe.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// Agent-tree delivery probe.
+//
+// Stands in for a real agent CLI (codex/claude/...) during verification. It does
+// nothing but record the environment + argv it was actually launched with, so a
+// verifier can assert that a resolved agent's parameters truly reached the
+// process — after env injection AND shell expansion — rather than trusting the
+// pure resolver's output alone.
+//
+// Robust: it inspects the literal post-expansion process state, so it catches
+// quoting bugs, an env var that never got injected, or a `$VAR` that a shell
+// failed to expand. Accurate: this is exactly what a real agent CLI would see.
+//
+// Writes a JSON dump to $AGENT_TREE_PROBE_OUT (or stdout if unset).
+import {writeFileSync} from 'node:fs';
+
+const dump = JSON.stringify({argv: process.argv.slice(2), env: process.env});
+const out = process.env.AGENT_TREE_PROBE_OUT;
+if (out) writeFileSync(out, dump, 'utf8');
+else process.stdout.write(dump);

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/HorizontalMenuService.test.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/HorizontalMenuService.test.ts
@@ -182,6 +182,37 @@ describe('HorizontalMenuService', () => {
                 'current "$AGENT_PROMPT"',
             );
         });
+
+        it('renders a nested agent tree as a cascade and spawns the leaf with composed command + env', async () => {
+            const tree = [
+                { name: 'Codex', command: 'codex -c "effort=$EFFORT"', children: [
+                    { name: 'Remote', command: 'CODEX_REASONING_EFFORT=$EFFORT remote.sh', children: [
+                        { name: 'XHigh', env: { EFFORT: 'xhigh' } },
+                    ]},
+                ]},
+            ];
+            (window as unknown as { hostAPI: unknown }).hostAPI = {
+                main: { loadSettings: vi.fn(async () => ({ agents: tree })) },
+            };
+            const input: NodeMenuItemsInput = { nodeId: 'test-node.md', cy, agents: tree, isContextNode: false };
+
+            const more = getNodeMenuItems(input).find(i => i.label === 'More');
+            const codex = more?.subMenu?.find(i => i.label === 'Codex');
+            const remote = (await codex?.getSubMenuItems?.())?.find(i => i.label === 'Remote');
+            const xhigh = (await remote?.getSubMenuItems?.())?.find(i => i.label === 'XHigh');
+
+            expect(xhigh).not.toBeUndefined();
+            await xhigh!.action();
+
+            // Remote overrides the base command; XHigh contributes EFFORT via envOverrides (5th arg).
+            expect(spawnTerminalWithNewContextNode).toHaveBeenCalledWith(
+                'test-node.md',
+                cy,
+                'CODEX_REASONING_EFFORT=$EFFORT remote.sh',
+                undefined,
+                { EFFORT: 'xhigh' },
+            );
+        });
     });
 
     describe('createHorizontalMenuElement', () => {

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/getNodeMenuItems.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/getNodeMenuItems.ts
@@ -22,7 +22,7 @@ import {
 } from "@/shell/edge/UI-edge/floating-windows/editors/writeMarkdownFileFromUI";
 import { createAnchoredFloatingEditor } from "@/shell/edge/UI-edge/floating-windows/editors/FloatingEditorCRUD";
 import type { VTSettings, AgentConfig, ResolvedAgent } from "@vt/graph-model/settings";
-import { resolveDefaultAgent, composeAgentStep, isAgentCategory, mapAgentTreeByCommand } from "@vt/graph-model/settings";
+import { resolveDefaultAgent, isAgentCategory, mapAgentTreeByCommand, flattenAgentTree, agentPathLabel } from "@vt/graph-model/settings";
 import { AUTO_RUN_FLAG } from "@/shell/edge/UI-edge/graph/popups/agentCommandEditorPopup";
 import { highlightContainedNodes, highlightPreviewNodes, clearContainedHighlights } from '@/shell/UI/cytoscape-graph-ui/highlightContextNodes';
 import { getTerminals } from '@/shell/edge/UI-edge/state/stores/TerminalStore';
@@ -63,21 +63,41 @@ function createRunButtonSliderConfig(
 }
 
 /**
+ * Spawn an agent leaf identified by its stable path label, re-resolving from
+ * FRESH settings at click time (so an edit between menu-open and click is
+ * honoured) and delivering the leaf's composed env via envOverrides.
+ */
+async function spawnAgentByPath(nodeId: string, cy: Core, pathLabel: string): Promise<void> {
+    const settings: VTSettings | null = await window.hostAPI?.main.loadSettings() ?? null;
+    const leaf: ResolvedAgent | undefined = settings
+        ? flattenAgentTree(settings.agents ?? []).find((candidate: ResolvedAgent) => agentPathLabel(candidate.path) === pathLabel)
+        : undefined;
+    if (!leaf?.command) {
+        console.error(`[getNodeMenuItems] Agent "${pathLabel}" is no longer resolvable from settings.agents`);
+        return;
+    }
+    if (Object.keys(leaf.env).length > 0) {
+        await spawnTerminalWithNewContextNode(nodeId, cy, leaf.command, undefined, leaf.env);
+    } else {
+        await spawnTerminalWithNewContextNode(nodeId, cy, leaf.command);
+    }
+}
+
+/**
  * Build the agent tree into a cascade of hover submenus (mirrors the Workflows
- * menu). A category node expands into its children; a leaf spawns its resolved
- * command with the env accumulated down the path (delivered via envOverrides).
- * `inherited` threads the composed (command, env) from ancestors, so a leaf that
- * only sets `{ EFFORT: "xhigh" }` inherits its branch's base command.
+ * menu): a category node expands into its children; a leaf spawns the agent at
+ * its path. `pathNames` accumulates the root->here labels so a leaf can be
+ * re-resolved against fresh settings at click time.
  */
 function buildAgentMenuItems(
     nodeId: string,
     cy: Core,
     isContextNode: boolean,
     agents: readonly AgentConfig[],
-    inherited: {readonly command: string; readonly env: Readonly<Record<string, string>>},
+    pathNames: readonly string[],
 ): HorizontalMenuItem[] {
     return agents.map((node: AgentConfig): HorizontalMenuItem => {
-        const composed = composeAgentStep(inherited, node);
+        const here: readonly string[] = [...pathNames, node.name];
         if (isAgentCategory(node)) {
             return {
                 icon: FolderOpen,
@@ -85,7 +105,7 @@ function buildAgentMenuItems(
                 color: '#6366f1',
                 action: () => {}, // category: submenu handles interaction
                 getSubMenuItems: async (): Promise<HorizontalMenuItem[]> =>
-                    buildAgentMenuItems(nodeId, cy, isContextNode, node.children ?? [], composed),
+                    buildAgentMenuItems(nodeId, cy, isContextNode, node.children ?? [], here),
             };
         }
         return {
@@ -93,7 +113,7 @@ function buildAgentMenuItems(
             label: node.name,
             color: '#6366f1', // indigo to distinguish from the default green Run
             action: async () => {
-                await spawnTerminalWithNewContextNode(nodeId, cy, composed.command, undefined, composed.env);
+                await spawnAgentByPath(nodeId, cy, agentPathLabel(here));
             },
             onHoverEnter: isContextNode
                 ? () => highlightContainedNodes(cy, nodeId)
@@ -329,7 +349,7 @@ export function getNodeMenuItems(input: NodeMenuItemsInput): HorizontalMenuItem[
     // The full agent tree as a cascading submenu: hover a model (Codex) -> its
     // categories (Local/Remote) -> the leaf (Medium/XHigh) that spawns it. The
     // Run button still quick-launches the default leaf.
-    moreSubMenu.push(...buildAgentMenuItems(nodeId, cy, isContextNode, agents, {command: '', env: {}}));
+    moreSubMenu.push(...buildAgentMenuItems(nodeId, cy, isContextNode, agents, []));
     menuItems.push({
         icon: ChevronDown,
         label: 'More',

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/getNodeMenuItems.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/getNodeMenuItems.ts
@@ -22,7 +22,7 @@ import {
 } from "@/shell/edge/UI-edge/floating-windows/editors/writeMarkdownFileFromUI";
 import { createAnchoredFloatingEditor } from "@/shell/edge/UI-edge/floating-windows/editors/FloatingEditorCRUD";
 import type { VTSettings, AgentConfig, ResolvedAgent } from "@vt/graph-model/settings";
-import { resolveDefaultAgent, isAgentCategory, mapAgentTreeByCommand, flattenAgentTree, agentPathLabel } from "@vt/graph-model/settings";
+import { resolveDefaultAgent, mapAgentTreeByCommand, flattenAgentTree } from "@vt/graph-model/settings";
 import { AUTO_RUN_FLAG } from "@/shell/edge/UI-edge/graph/popups/agentCommandEditorPopup";
 import { highlightContainedNodes, highlightPreviewNodes, clearContainedHighlights } from '@/shell/UI/cytoscape-graph-ui/highlightContextNodes';
 import { getTerminals } from '@/shell/edge/UI-edge/state/stores/TerminalStore';
@@ -70,7 +70,7 @@ function createRunButtonSliderConfig(
 async function spawnAgentByPath(nodeId: string, cy: Core, pathLabel: string): Promise<void> {
     const settings: VTSettings | null = await window.hostAPI?.main.loadSettings() ?? null;
     const leaf: ResolvedAgent | undefined = settings
-        ? flattenAgentTree(settings.agents ?? []).find((candidate: ResolvedAgent) => agentPathLabel(candidate.path) === pathLabel)
+        ? flattenAgentTree(settings.agents ?? []).find((candidate: ResolvedAgent) => candidate.label === pathLabel)
         : undefined;
     if (!leaf?.command) {
         console.error(`[getNodeMenuItems] Agent "${pathLabel}" is no longer resolvable from settings.agents`);
@@ -98,7 +98,8 @@ function buildAgentMenuItems(
 ): HorizontalMenuItem[] {
     return agents.map((node: AgentConfig): HorizontalMenuItem => {
         const here: readonly string[] = [...pathNames, node.name];
-        if (isAgentCategory(node)) {
+        const isCategory: boolean = (node.children?.length ?? 0) > 0;
+        if (isCategory) {
             return {
                 icon: FolderOpen,
                 label: node.name,
@@ -113,7 +114,7 @@ function buildAgentMenuItems(
             label: node.name,
             color: '#6366f1', // indigo to distinguish from the default green Run
             action: async () => {
-                await spawnAgentByPath(nodeId, cy, agentPathLabel(here));
+                await spawnAgentByPath(nodeId, cy, here.join(' / '));
             },
             onHoverEnter: isContextNode
                 ? () => highlightContainedNodes(cy, nodeId)

--- a/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/getNodeMenuItems.ts
+++ b/webapp/src/shell/UI/cytoscape-graph-ui/services/menus/getNodeMenuItems.ts
@@ -21,8 +21,8 @@ import {
     writeMarkdownFileFromUI
 } from "@/shell/edge/UI-edge/floating-windows/editors/writeMarkdownFileFromUI";
 import { createAnchoredFloatingEditor } from "@/shell/edge/UI-edge/floating-windows/editors/FloatingEditorCRUD";
-import type { VTSettings, AgentConfig } from "@vt/graph-model/settings";
-import { getDefaultAgent } from "@vt/graph-model/settings";
+import type { VTSettings, AgentConfig, ResolvedAgent } from "@vt/graph-model/settings";
+import { resolveDefaultAgent, composeAgentStep, isAgentCategory, mapAgentTreeByCommand } from "@vt/graph-model/settings";
 import { AUTO_RUN_FLAG } from "@/shell/edge/UI-edge/graph/popups/agentCommandEditorPopup";
 import { highlightContainedNodes, highlightPreviewNodes, clearContainedHighlights } from '@/shell/UI/cytoscape-graph-ui/highlightContextNodes';
 import { getTerminals } from '@/shell/edge/UI-edge/state/stores/TerminalStore';
@@ -62,14 +62,45 @@ function createRunButtonSliderConfig(
     };
 }
 
-async function spawnCurrentAgentByName(nodeId: string, cy: Core, agentName: string): Promise<void> {
-    const settings: VTSettings | null = await window.hostAPI?.main.loadSettings() ?? null;
-    const agent: AgentConfig | undefined = settings?.agents?.find((candidate: AgentConfig) => candidate.name === agentName);
-    if (!agent?.command) {
-        console.error(`[getNodeMenuItems] Agent "${agentName}" is no longer present in settings.agents`);
-        return;
-    }
-    await spawnTerminalWithNewContextNode(nodeId, cy, agent.command);
+/**
+ * Build the agent tree into a cascade of hover submenus (mirrors the Workflows
+ * menu). A category node expands into its children; a leaf spawns its resolved
+ * command with the env accumulated down the path (delivered via envOverrides).
+ * `inherited` threads the composed (command, env) from ancestors, so a leaf that
+ * only sets `{ EFFORT: "xhigh" }` inherits its branch's base command.
+ */
+function buildAgentMenuItems(
+    nodeId: string,
+    cy: Core,
+    isContextNode: boolean,
+    agents: readonly AgentConfig[],
+    inherited: {readonly command: string; readonly env: Readonly<Record<string, string>>},
+): HorizontalMenuItem[] {
+    return agents.map((node: AgentConfig): HorizontalMenuItem => {
+        const composed = composeAgentStep(inherited, node);
+        if (isAgentCategory(node)) {
+            return {
+                icon: FolderOpen,
+                label: node.name,
+                color: '#6366f1',
+                action: () => {}, // category: submenu handles interaction
+                getSubMenuItems: async (): Promise<HorizontalMenuItem[]> =>
+                    buildAgentMenuItems(nodeId, cy, isContextNode, node.children ?? [], composed),
+            };
+        }
+        return {
+            icon: Play,
+            label: node.name,
+            color: '#6366f1', // indigo to distinguish from the default green Run
+            action: async () => {
+                await spawnTerminalWithNewContextNode(nodeId, cy, composed.command, undefined, composed.env);
+            },
+            onHoverEnter: isContextNode
+                ? () => highlightContainedNodes(cy, nodeId)
+                : () => highlightPreviewNodes(cy, nodeId),
+            onHoverLeave: () => clearContainedHighlights(cy),
+        };
+    });
 }
 
 /**
@@ -176,7 +207,7 @@ export function getNodeMenuItems(input: NodeMenuItemsInput): HorizontalMenuItem[
 
             // Auto-run checkbox: only for claude commands, toggles --dangerously-skip-permissions
             const currentSettings: VTSettings | null = await window.hostAPI?.main.loadSettings() ?? null;
-            const defaultAgent: AgentConfig | undefined = currentSettings ? getDefaultAgent(currentSettings.agents ?? [], currentSettings.defaultAgent) : undefined;
+            const defaultAgent: ResolvedAgent | undefined = currentSettings ? resolveDefaultAgent(currentSettings.agents ?? [], currentSettings.defaultAgent) : undefined;
             const defaultCommand: string = defaultAgent?.command ?? '';
             if (defaultCommand.toLowerCase().includes('claude')) {
                 items.push({
@@ -189,7 +220,7 @@ export function getNodeMenuItems(input: NodeMenuItemsInput): HorizontalMenuItem[
                         const settings: VTSettings | null = await window.hostAPI?.main.loadSettings() ?? null;
                         if (!settings) return;
                         const currentAgents: readonly AgentConfig[] = settings.agents ?? [];
-                        const defAgent: AgentConfig | undefined = getDefaultAgent(currentAgents, settings.defaultAgent);
+                        const defAgent: ResolvedAgent | undefined = resolveDefaultAgent(currentAgents, settings.defaultAgent);
                         if (!defAgent) return;
                         const cmd: string = defAgent.command;
                         const hasFlag: boolean = cmd.includes(AUTO_RUN_FLAG);
@@ -204,10 +235,8 @@ export function getNodeMenuItems(input: NodeMenuItemsInput): HorizontalMenuItem[
                             }
                         }
 
-                        const updatedAgents: readonly AgentConfig[] = currentAgents.map(
-                            (agent: AgentConfig): AgentConfig =>
-                                agent.name === defAgent.name ? { ...agent, command: newCommand } : agent
-                        );
+                        // Rewrite whichever tree node defines that command (any depth).
+                        const updatedAgents: readonly AgentConfig[] = mapAgentTreeByCommand(currentAgents, cmd, newCommand);
                         await window.hostAPI?.main.saveSettings({ ...settings, agents: updatedAgents });
                     },
                 });
@@ -297,25 +326,10 @@ export function getNodeMenuItems(input: NodeMenuItemsInput): HorizontalMenuItem[
         },
     ];
 
-    // Add non-default agents (skip first which is default, used by Run button)
-    for (const agent of agents.slice(1)) {
-        moreSubMenu.push({
-            icon: Play,
-            label: agent.name,
-            color: '#6366f1', // indigo to distinguish from default Run
-            action: async () => {
-                await spawnCurrentAgentByName(nodeId, cy, agent.name);
-            },
-            // Context nodes: show contained nodes. Normal nodes: preview what would be captured.
-            onHoverEnter: isContextNode
-                ? () => highlightContainedNodes(cy, nodeId)
-                : () => highlightPreviewNodes(cy, nodeId),
-            onHoverLeave: () => clearContainedHighlights(cy),
-            // TODO: Re-enable slider for secondary agents once hover leniency is improved
-            // (slider should stay open when navigating between button and slider, not just on direct hover)
-            // sliderConfig,
-        });
-    }
+    // The full agent tree as a cascading submenu: hover a model (Codex) -> its
+    // categories (Local/Remote) -> the leaf (Medium/XHigh) that spawns it. The
+    // Run button still quick-launches the default leaf.
+    moreSubMenu.push(...buildAgentMenuItems(nodeId, cy, isContextNode, agents, {command: '', env: {}}));
     menuItems.push({
         icon: ChevronDown,
         label: 'More',

--- a/webapp/src/shell/UI/views/components/settings/fields/AgentListField.tsx
+++ b/webapp/src/shell/UI/views/components/settings/fields/AgentListField.tsx
@@ -1,17 +1,18 @@
 import { useState } from 'react';
 import type { JSX } from 'react';
 import { Plus, X, CornerDownRight } from 'lucide-react';
-import type { AgentConfig, AgentPath } from '@vt/graph-model/settings';
+import type { AgentConfig } from '@vt/graph-model/settings';
+import {
+  flattenAgentTree,
+  resolveDefaultAgent,
+} from '@vt/graph-model/settings';
 import {
   updateAgentAt,
   removeAgentAt,
   addChildAt,
   appendAgent,
-  flattenAgentTree,
-  agentPathLabel,
-  isAgentCategory,
-  resolveDefaultAgent,
-} from '@vt/graph-model/settings';
+  type AgentPath,
+} from './agentTreeEdit';
 
 interface AgentListFieldProps {
   value: readonly AgentConfig[];
@@ -72,12 +73,12 @@ function EnvEditor({ env, onChange }: { env: Readonly<Record<string, string>> | 
 export function AgentListField({ value, onChange, defaultAgent, onDefaultChange }: AgentListFieldProps): JSX.Element {
   // The default is stored as a leaf path label ('Codex / Remote / XHigh').
   const defaultLeaf = resolveDefaultAgent(value, defaultAgent);
-  const effectiveDefaultLabel: string = defaultLeaf ? agentPathLabel(defaultLeaf.path) : '';
+  const effectiveDefaultLabel: string = defaultLeaf ? defaultLeaf.label : '';
 
   /** Apply a tree edit and keep `defaultAgent` pointing at the same leaf (or reset if it vanished). */
   function applyChange(next: AgentConfig[]): void {
-    const before: string[] = flattenAgentTree(value).map((l) => agentPathLabel(l.path));
-    const after: string[] = flattenAgentTree(next).map((l) => agentPathLabel(l.path));
+    const before: string[] = flattenAgentTree(value).map((l) => l.label);
+    const after: string[] = flattenAgentTree(next).map((l) => l.label);
     onChange(next);
     if (after.includes(effectiveDefaultLabel)) return; // default leaf still present
     const defIdx: number = before.indexOf(effectiveDefaultLabel);
@@ -88,8 +89,8 @@ export function AgentListField({ value, onChange, defaultAgent, onDefaultChange 
   }
 
   function renderNode(node: AgentConfig, path: AgentPath, depth: number): JSX.Element[] {
-    const label: string = agentPathLabel([...flattenLabelPrefix(value, path)]);
-    const isLeaf: boolean = !isAgentCategory(node);
+    const label: string = flattenLabelPrefix(value, path).join(' / ');
+    const isLeaf: boolean = (node.children?.length ?? 0) === 0;
     const rows: JSX.Element[] = [
       <div key={path.join('.')} className="flex items-center gap-2" style={{ paddingLeft: depth * 18 }}>
         {isLeaf ? (
@@ -120,7 +121,7 @@ export function AgentListField({ value, onChange, defaultAgent, onDefaultChange 
           className="flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
           <CornerDownRight size={14} />
         </button>
-        <button type="button" aria-label={`Remove agent ${node.name || agentPathLabel(path.map(String))}`}
+        <button type="button" aria-label={`Remove agent ${node.name || path.join('.')}`}
           onClick={() => applyChange(removeAgentAt(value, path))}
           className="flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
           <X size={14} />

--- a/webapp/src/shell/UI/views/components/settings/fields/AgentListField.tsx
+++ b/webapp/src/shell/UI/views/components/settings/fields/AgentListField.tsx
@@ -1,7 +1,17 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
 import type { JSX } from 'react';
-import { Plus, X } from 'lucide-react';
-import type { AgentConfig } from '@vt/graph-model/settings';
+import { Plus, X, CornerDownRight } from 'lucide-react';
+import type { AgentConfig, AgentPath } from '@vt/graph-model/settings';
+import {
+  updateAgentAt,
+  removeAgentAt,
+  addChildAt,
+  appendAgent,
+  flattenAgentTree,
+  agentPathLabel,
+  isAgentCategory,
+  resolveDefaultAgent,
+} from '@vt/graph-model/settings';
 
 interface AgentListFieldProps {
   value: readonly AgentConfig[];
@@ -10,109 +20,138 @@ interface AgentListFieldProps {
   onDefaultChange: (name: string) => void;
 }
 
+const INPUT_CLASS = 'bg-input border border-border rounded-md px-2 py-1 font-mono text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring';
+
+/**
+ * Compact editor for a node's env map. Keeps its own row list so a half-typed
+ * key persists while editing; only complete (non-empty-key) pairs are persisted.
+ */
+function EnvEditor({ env, onChange }: { env: Readonly<Record<string, string>> | undefined; onChange: (env: Record<string, string>) => void }): JSX.Element {
+  const [pairs, setPairs] = useState<{ key: string; value: string }[]>(() =>
+    Object.entries(env ?? {}).map(([key, value]) => ({ key, value })),
+  );
+
+  function commit(next: { key: string; value: string }[]): void {
+    setPairs(next);
+    const obj: Record<string, string> = {};
+    for (const { key, value } of next) if (key.trim()) obj[key.trim()] = value;
+    onChange(obj);
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {pairs.map((pair, i) => (
+        <div key={i} className="flex items-center gap-0.5">
+          <input
+            type="text" value={pair.key} placeholder="ENV"
+            onChange={(e) => commit(pairs.map((p, j) => j === i ? { ...p, key: e.target.value } : p))}
+            className={`${INPUT_CLASS} text-[11px] w-20`}
+          />
+          <span className="text-muted-foreground/50 text-xs">=</span>
+          <input
+            type="text" value={pair.value} placeholder="val"
+            onChange={(e) => commit(pairs.map((p, j) => j === i ? { ...p, value: e.target.value } : p))}
+            className={`${INPUT_CLASS} text-[11px] w-16`}
+          />
+          <button type="button" aria-label="Remove env var"
+            onClick={() => commit(pairs.filter((_, j) => j !== i))}
+            className="flex items-center justify-center w-5 h-5 rounded text-muted-foreground hover:text-foreground">
+            <X size={11} />
+          </button>
+        </div>
+      ))}
+      <button type="button"
+        onClick={() => commit([...pairs, { key: '', value: '' }])}
+        className="flex items-center gap-0.5 px-1 py-0.5 text-[11px] text-muted-foreground hover:text-foreground rounded hover:bg-muted">
+        <Plus size={10} /> env
+      </button>
+    </div>
+  );
+}
+
 export function AgentListField({ value, onChange, defaultAgent, onDefaultChange }: AgentListFieldProps): JSX.Element {
-  const [focusIndex, setFocusIndex] = useState<number | null>(null);
-  const nameRefs: React.MutableRefObject<(HTMLInputElement | null)[]> = useRef<(HTMLInputElement | null)[]>([]);
+  // The default is stored as a leaf path label ('Codex / Remote / XHigh').
+  const defaultLeaf = resolveDefaultAgent(value, defaultAgent);
+  const effectiveDefaultLabel: string = defaultLeaf ? agentPathLabel(defaultLeaf.path) : '';
 
-  useEffect(() => {
-    if (focusIndex !== null && nameRefs.current[focusIndex]) {
-      nameRefs.current[focusIndex]?.focus();
-      setFocusIndex(null);
-    }
-  }, [focusIndex, value.length]);
-
-  // Resolve which agent is effectively the default (first if unset/not found)
-  const effectiveDefault: string = (() => {
-    if (defaultAgent && value.some(a => a.name === defaultAgent)) return defaultAgent;
-    return value[0]?.name ?? '';
-  })();
-
-  function updateAgent(index: number, field: keyof AgentConfig, fieldValue: string): void {
-    const oldName: string = value[index]?.name ?? '';
-    const updated: AgentConfig[] = value.map((agent, i) =>
-      i === index ? { ...agent, [field]: fieldValue } : { ...agent }
-    );
-    onChange(updated);
-    // If we renamed the default agent, update the default to track the new name
-    if (field === 'name' && oldName === effectiveDefault) {
-      onDefaultChange(fieldValue);
-    }
+  /** Apply a tree edit and keep `defaultAgent` pointing at the same leaf (or reset if it vanished). */
+  function applyChange(next: AgentConfig[]): void {
+    const before: string[] = flattenAgentTree(value).map((l) => agentPathLabel(l.path));
+    const after: string[] = flattenAgentTree(next).map((l) => agentPathLabel(l.path));
+    onChange(next);
+    if (after.includes(effectiveDefaultLabel)) return; // default leaf still present
+    const defIdx: number = before.indexOf(effectiveDefaultLabel);
+    const newLabel: string = (before.length === after.length && defIdx >= 0 && after[defIdx])
+      ? after[defIdx]   // a rename — same leaf, new label
+      : (after[0] ?? ''); // a removal of the default leaf — fall back to the first
+    if (newLabel !== effectiveDefaultLabel) onDefaultChange(newLabel);
   }
 
-  function addAgent(): void {
-    const updated: AgentConfig[] = [...value, { name: '', command: '' }];
-    onChange(updated);
-    setFocusIndex(updated.length - 1);
-  }
-
-  function removeAgent(index: number): void {
-    if (value.length === 1) {
-      if (!confirm('Remove the last agent?')) return;
-    }
-    const removedName: string = value[index]?.name ?? '';
-    const updated: AgentConfig[] = value.filter((_, i) => i !== index);
-    onChange(updated);
-    // If we removed the default agent, reset to first remaining
-    if (removedName === effectiveDefault && updated.length > 0) {
-      onDefaultChange(updated[0]?.name ?? '');
-    }
+  function renderNode(node: AgentConfig, path: AgentPath, depth: number): JSX.Element[] {
+    const label: string = agentPathLabel([...flattenLabelPrefix(value, path)]);
+    const isLeaf: boolean = !isAgentCategory(node);
+    const rows: JSX.Element[] = [
+      <div key={path.join('.')} className="flex items-center gap-2" style={{ paddingLeft: depth * 18 }}>
+        {isLeaf ? (
+          <button type="button"
+            title={label === effectiveDefaultLabel ? 'Default agent' : `Set "${label}" as default`}
+            onClick={() => { if (label) onDefaultChange(label); }}
+            className="flex items-center justify-center w-4 h-4 shrink-0">
+            <span className={`block w-3.5 h-3.5 rounded-full border-2 transition-colors ${
+              label === effectiveDefaultLabel ? 'border-foreground bg-foreground' : 'border-muted-foreground/50 hover:border-foreground'}`}>
+              {label === effectiveDefaultLabel && <span className="block w-full h-full rounded-full bg-background scale-[0.35]" />}
+            </span>
+          </button>
+        ) : <span className="w-4 h-4 shrink-0 flex items-center justify-center text-muted-foreground/40"><CornerDownRight size={12} /></span>}
+        <input
+          type="text" value={node.name} placeholder="name"
+          onChange={(e) => applyChange(updateAgentAt(value, path, { name: e.target.value }))}
+          className={`${INPUT_CLASS} text-sm w-32`}
+        />
+        <input
+          type="text" value={node.command ?? ''}
+          placeholder={depth > 0 ? 'command (blank = inherit)' : 'command'}
+          onChange={(e) => applyChange(updateAgentAt(value, path, { command: e.target.value }))}
+          className={`${INPUT_CLASS} text-xs flex-1`}
+        />
+        <EnvEditor env={node.env} onChange={(env) => applyChange(updateAgentAt(value, path, { env }))} />
+        <button type="button" title="Add sub-agent"
+          onClick={() => applyChange(addChildAt(value, path, { name: '', command: '' }))}
+          className="flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
+          <CornerDownRight size={14} />
+        </button>
+        <button type="button" aria-label={`Remove agent ${node.name || agentPathLabel(path.map(String))}`}
+          onClick={() => applyChange(removeAgentAt(value, path))}
+          className="flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
+          <X size={14} />
+        </button>
+      </div>,
+    ];
+    (node.children ?? []).forEach((child, i) => rows.push(...renderNode(child, [...path, i], depth + 1)));
+    return rows;
   }
 
   return (
     <div className="flex flex-col gap-1.5">
-      {value.map((agent, index) => (
-        <div key={index} className="flex items-center gap-2">
-          <button
-            type="button"
-            title={agent.name === effectiveDefault ? 'Default agent' : `Set ${agent.name || 'this agent'} as default`}
-            onClick={() => { if (agent.name) onDefaultChange(agent.name); }}
-            className="flex items-center justify-center w-4 h-4 shrink-0"
-          >
-            <span
-              className={`block w-3.5 h-3.5 rounded-full border-2 transition-colors ${
-                agent.name === effectiveDefault
-                  ? 'border-foreground bg-foreground'
-                  : 'border-muted-foreground/50 hover:border-foreground'
-              }`}
-            >
-              {agent.name === effectiveDefault && (
-                <span className="block w-full h-full rounded-full bg-background scale-[0.35]" />
-              )}
-            </span>
-          </button>
-          <input
-            ref={(el) => { nameRefs.current[index] = el; }}
-            type="text"
-            value={agent.name}
-            onChange={(e) => updateAgent(index, 'name', e.target.value)}
-            placeholder="name"
-            className="w-1/4 bg-input border border-border rounded-md px-2 py-1 font-mono text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-          <input
-            type="text"
-            value={agent.command}
-            onChange={(e) => updateAgent(index, 'command', e.target.value)}
-            placeholder="command"
-            className="flex-1 bg-input border border-border rounded-md px-2 py-1 font-mono text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-          <button
-            type="button"
-            onClick={() => removeAgent(index)}
-            className="flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-            aria-label={`Remove agent ${agent.name || index}`}
-          >
-            <X size={14} />
-          </button>
-        </div>
-      ))}
-      <button
-        type="button"
-        onClick={addAgent}
-        className="flex items-center gap-1 self-start px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors rounded-md hover:bg-muted"
-      >
-        <Plus size={12} />
-        Add Agent
+      {value.flatMap((node, i) => renderNode(node, [i], 0))}
+      <button type="button"
+        onClick={() => applyChange(appendAgent(value, { name: '', command: '' }))}
+        className="flex items-center gap-1 self-start px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors rounded-md hover:bg-muted">
+        <Plus size={12} /> Add Agent
       </button>
     </div>
   );
+}
+
+/** Names along `path` through `agents`, e.g. [1,0,1] -> ['Codex','Local','XHigh']. */
+function flattenLabelPrefix(agents: readonly AgentConfig[], path: AgentPath): string[] {
+  const names: string[] = [];
+  let level: readonly AgentConfig[] = agents;
+  for (const idx of path) {
+    const node: AgentConfig | undefined = level[idx];
+    if (!node) break;
+    names.push(node.name);
+    level = node.children ?? [];
+  }
+  return names;
 }

--- a/webapp/src/shell/UI/views/components/settings/fields/agentTreeEdit.test.ts
+++ b/webapp/src/shell/UI/views/components/settings/fields/agentTreeEdit.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest';
-import type {AgentConfig} from './types';
+import type {AgentConfig} from '@vt/graph-model/settings';
 import {updateAgentAt, removeAgentAt, addChildAt, appendAgent} from './agentTreeEdit';
 
 const TREE: readonly AgentConfig[] = [

--- a/webapp/src/shell/UI/views/components/settings/fields/agentTreeEdit.ts
+++ b/webapp/src/shell/UI/views/components/settings/fields/agentTreeEdit.ts
@@ -1,4 +1,4 @@
-import type {AgentConfig} from './types';
+import type {AgentConfig} from '@vt/graph-model/settings';
 
 /** An index path into the agent tree: [2] = 3rd top-level node, [2,0] = its 1st child. */
 export type AgentPath = readonly number[];

--- a/webapp/src/shell/edge/UI-edge/floating-windows/terminals/resolveAgentLaunchConfig.ts
+++ b/webapp/src/shell/edge/UI-edge/floating-windows/terminals/resolveAgentLaunchConfig.ts
@@ -1,4 +1,5 @@
 import type { VTSettings, AgentConfig } from "@vt/graph-model/settings";
+import { mapAgentTreeByCommand } from "@vt/graph-model/settings";
 import { showAgentCommandEditor } from "@/shell/edge/UI-edge/graph/popups/agentCommandEditorPopup";
 
 export interface AgentLaunchConfig {
@@ -42,20 +43,10 @@ export async function resolveAgentLaunchConfig(
     // Check if user modified the command
     const commandChanged: boolean = result.command !== command;
 
-    // Update the agent's command in settings if it was modified
-    let updatedAgents: readonly AgentConfig[] = settings.agents;
-    if (commandChanged) {
-        updatedAgents = settings.agents.map((agent: AgentConfig): AgentConfig => {
-            // Update the agent whose command matches the original command
-            if (agent.command === command) {
-                return {
-                    ...agent,
-                    command: result.command,
-                };
-            }
-            return agent;
-        });
-    }
+    // Update the tree node(s) whose command matches the original, at any depth.
+    const updatedAgents: readonly AgentConfig[] = commandChanged
+        ? mapAgentTreeByCommand(settings.agents, command, result.command)
+        : settings.agents;
 
     return {
         finalCommand: result.command, popupWasShown: true, updatedAgents,

--- a/webapp/src/shell/edge/UI-edge/floating-windows/terminals/spawnTerminalWithCommandFromUI.ts
+++ b/webapp/src/shell/edge/UI-edge/floating-windows/terminals/spawnTerminalWithCommandFromUI.ts
@@ -1,7 +1,7 @@
 /** Terminal Flow - V2: Uses types.ts with flat TerminalData type. IDs derived, ui populated after DOM creation. */
 import type { NodeIdAndFilePath, GraphNode } from "@vt/graph-model/graph";
 import type { VTSettings, AgentConfig } from "@vt/graph-model/settings";
-import { getDefaultAgent } from "@vt/graph-model/settings";
+import { resolveDefaultAgent, mapAgentTreeByCommand, type ResolvedAgent } from "@vt/graph-model/settings";
 import { showAgentCommandEditor } from "@/shell/edge/UI-edge/graph/popups/agentCommandEditorPopup";
 import type { Core } from "cytoscape";
 import '@/shell/hostApi.d.ts';
@@ -50,7 +50,7 @@ export async function spawnTerminalWithCommandEditor(
 
     // Determine the command to use
     const agents: readonly AgentConfig[] = settings.agents ?? [];
-    const command: string = agentCommand ?? getDefaultAgent(agents, settings.defaultAgent)?.command ?? '';
+    const command: string = agentCommand ?? resolveDefaultAgent(agents, settings.defaultAgent)?.command ?? '';
     if (!command) {
         console.error('[spawnTerminalWithCommandEditor] No agent command available');
         return;
@@ -72,20 +72,10 @@ export async function spawnTerminalWithCommandEditor(
     // Check if user modified the command
     const commandChanged: boolean = result.command !== command;
 
-    // Update the agent's command in settings if it was modified
-    let updatedAgents: readonly AgentConfig[] = settings.agents;
-    if (commandChanged) {
-        updatedAgents = settings.agents.map((agent: AgentConfig): AgentConfig => {
-            // Update the agent whose command matches the original command
-            if (agent.command === command) {
-                return {
-                    ...agent,
-                    command: result.command,
-                };
-            }
-            return agent;
-        });
-    }
+    // Update the tree node(s) whose command matches the original, at any depth.
+    const updatedAgents: readonly AgentConfig[] = commandChanged
+        ? mapAgentTreeByCommand(settings.agents, command, result.command)
+        : settings.agents;
 
     // Save settings if agent prompt changed or command was modified
     const promptChanged: boolean = result.agentPrompt !== currentAgentPrompt;
@@ -128,6 +118,7 @@ export async function spawnTerminalWithNewContextNode(
     _cy: Core,
     agentCommand?: string,
     spawnDirectory?: string,
+    envOverrides?: Readonly<Record<string, string>>,
 ): Promise<void> {
     // Flush any pending editor content for this node before creating context
     // This ensures the context node has the latest typed content (bypasses 300ms debounce)
@@ -148,9 +139,21 @@ export async function spawnTerminalWithNewContextNode(
         return;
     }
 
-    // Determine the command to use
+    // Determine the command + env to use. An explicit command (from a resolved
+    // leaf or the worktree run) is launched as-is with the caller's envOverrides.
+    // With no command we resolve the default leaf and carry ITS env too, so a
+    // default that "just adds a parameter" still gets it (caller env wins).
     const agents: readonly AgentConfig[] = settings.agents ?? [];
-    let command: string = agentCommand ?? getDefaultAgent(agents, settings.defaultAgent)?.command ?? '';
+    let command: string;
+    let resolvedEnv: Record<string, string>;
+    if (agentCommand !== undefined) {
+        command = agentCommand;
+        resolvedEnv = {...envOverrides};
+    } else {
+        const defaultAgent: ResolvedAgent | undefined = resolveDefaultAgent(agents, settings.defaultAgent);
+        command = defaultAgent?.command ?? '';
+        resolvedEnv = {...defaultAgent?.env, ...envOverrides};
+    }
     if (!command) {
         console.error('[spawnTerminalWithNewContextNode] No agent command available');
         return;
@@ -177,12 +180,14 @@ export async function spawnTerminalWithNewContextNode(
 
     const terminalCount: number = getNextTerminalCount(terminalsMap, parentNodeId);
 
-    // Delegate to main process which has immediate graph access
+    // Delegate to main process which has immediate graph access. The resolved
+    // env rides the spawn RPC's envOverrides channel -> tmux `-e KEY=VALUE`.
     await window.hostAPI?.main.spawnTerminalWithContextNode({
         taskNodeId: parentNodeId,
         agentCommand: command,
         terminalCount,
         spawnDirectory,
+        ...(Object.keys(resolvedEnv).length > 0 ? {envOverrides: resolvedEnv} : {}),
     });
 }
 

--- a/webapp/src/shell/edge/main/agent/ask-mode/askModeCreateAndSpawn.ts
+++ b/webapp/src/shell/edge/main/agent/ask-mode/askModeCreateAndSpawn.ts
@@ -7,7 +7,7 @@ import * as O from 'fp-ts/lib/Option.js';
 import type {Graph, NodeIdAndFilePath} from '@vt/graph-model/graph';
 import {resolveEnvVarsWithSelection, expandEnvVarsInValues} from '@vt/graph-model/settings';
 import type {VTSettings} from '@vt/graph-model/settings';
-import {getUniqueAgentName, getDefaultAgent, pickAgentName} from '@vt/graph-model/settings';
+import {getUniqueAgentName, resolveDefaultAgent, pickAgentName, type ResolvedAgent} from '@vt/graph-model/settings';
 import {createTerminalData, type TerminalId} from '@/shell/edge/UI-edge/floating-windows/anchoring/types';
 import {getExistingAgentNames} from '@vt/vt-daemon-client';
 import {getActiveProject, getVtDaemonClient} from '@/shell/edge/main/runtime/electron/daemon/daemon-url-binding';
@@ -52,8 +52,8 @@ export async function askModeCreateAndSpawn(relevantNodeIds: readonly string[], 
 
   // 4. Load settings
   const settings: VTSettings = await loadSettings();
-  const agents: readonly { readonly name: string; readonly command: string }[] = settings.agents ?? [];
-  const command: string = getDefaultAgent(agents, settings.defaultAgent)?.command ?? '';
+  const defaultAgent: ResolvedAgent | undefined = resolveDefaultAgent(settings.agents ?? [], settings.defaultAgent);
+  const command: string = defaultAgent?.command ?? '';
 
   if (!command) {
     throw new Error('No agent command available');
@@ -103,6 +103,9 @@ export async function askModeCreateAndSpawn(relevantNodeIds: readonly string[], 
     VOICETREE_TERMINAL_ID: agentName, // Same as AGENT_NAME
     AGENT_NAME: agentName,
     ...resolvedEnvVars,
+    // The resolved default leaf's env (e.g. { EFFORT: "xhigh" }) — same channel
+    // the daemon spawn path delivers via envOverrides.
+    ...(defaultAgent?.env ?? {}),
   };
   const expandedEnvVars: Record<string, string> = expandEnvVarsInValues(unexpandedEnvVars);
 

--- a/webapp/src/shell/edge/main/observability/debug/prettySetupAppForElectronDebugging.ts
+++ b/webapp/src/shell/edge/main/observability/debug/prettySetupAppForElectronDebugging.ts
@@ -5,6 +5,7 @@ import { saveProject } from '@/shell/edge/main/workspace/project-store';
 import { loadSettings } from '@/shell/edge/main/settings/settings_IO';
 import { createEmptyGraph, type Graph, type NodeIdAndFilePath } from '@vt/graph-model/graph';
 import type { SavedProject } from '@vt/graph-model/project';
+import { flattenAgentTree, type AgentConfig } from '@vt/graph-model/settings';
 import * as path from 'path';
 import { app } from 'electron';
 import fsSync from 'fs';
@@ -52,14 +53,10 @@ function resolveDebugProjectPath(env: NodeJS.ProcessEnv = process.env): string {
     return getFallbackTestProjectPath();
 }
 
-type AgentCommandConfig = {
-    readonly name: string;
-    readonly command: string;
-};
-
-function findFakeAgentCommand(agents: readonly AgentCommandConfig[] | undefined): string | undefined {
-    return agents?.find((agent: AgentCommandConfig) =>
-        agent.name === FAKE_AGENT_NAME || agent.command.includes(FAKE_AGENT_COMMAND_FRAGMENT)
+function findFakeAgentCommand(agents: readonly AgentConfig[] | undefined): string | undefined {
+    // Search every spawnable leaf of the agent tree (the fake agent may sit at any depth).
+    return flattenAgentTree(agents ?? []).find(leaf =>
+        leaf.name === FAKE_AGENT_NAME || leaf.command.includes(FAKE_AGENT_COMMAND_FRAGMENT)
     )?.command;
 }
 


### PR DESCRIPTION
## Hierarchical agent commands (tree menu, composed parameters)

Turns VoiceTree's flat `agents: [{name, command}]` into a **tree** so the run menu
cascades like the Workflows menu: hover a model (Codex) → its category (Local/Remote)
→ the thinking-strength leaf (Medium/XHigh). Sub-agents *add parameters* rather than
re-spelling the command.

### Model
`AgentConfig` is now recursive:
```ts
interface AgentConfig {
  name: string;
  command?: string;                  // omitted on category nodes; inherited by leaves
  env?: Record<string, string>;      // merged down the path (deeper wins)
  children?: AgentConfig[];          // present => category (submenu); absent => spawnable leaf
}
```
A leaf is resolved by composing its root→leaf path: **command = the deepest node that
defines one; env = shallow-merge along the path**. A flat list is a strict subset (each
entry is its own leaf), so nothing about the old shape is special-cased.

### How `.sh`-launcher commands compose — env injection, not append/concat
The composed env rides the spawn RPC's existing `envOverrides` channel → tmux `-e
KEY=VALUE` → the session shell. So:
- **Remote** (`bash codex-remote.sh`) reads `CODEX_REASONING_EFFORT` from its env — composes untouched.
- **Local** embeds `$EFFORT` in a `-c` flag the shell expands at exec time.

One `EFFORT` knob drives both branches; the base command is **selected, never string-surgered**.

### Example (replaces 4 flat Codex entries)
```jsonc
{ "name": "Codex", "command": "codex --yolo -c \"model_reasoning_effort=\\\"$EFFORT\\\"\" \"$AGENT_PROMPT\"",
  "children": [
    { "name": "Local",  "children": [ {"name":"Medium","env":{"EFFORT":"medium"}}, {"name":"XHigh","env":{"EFFORT":"xhigh"}} ] },
    { "name": "Remote", "command": "CODEX_REASONING_EFFORT=\"$EFFORT\" bash /Users/bobbobby/.voicetree/bin/codex-remote.sh",
      "children": [ {"name":"Medium","env":{"EFFORT":"medium"}}, {"name":"XHigh","env":{"EFFORT":"xhigh"}} ] }
  ] }
```

### Verifiable TDD — a robust, accurate oracle
The composition logic is pure (`agentTree.ts`) with golden + invariant tests. But pure
tests can't prove a parameter actually *reaches* the process. So `agentTreeDelivery.test.ts`
runs each resolved command through a real shell with the resolved env injected and a
**probe** standing in for the agent CLI; it asserts on the literal env + argv the process
received — catching quoting / expansion / injection bugs. It includes a **self-check that a
wrong expectation fails**, so the oracle can't rubber-stamp. `tools/agent-tree-probe/probe.mjs`
is reusable for ad-hoc checks.

### What changed
- **graph-model**: recursive `AgentConfig`; pure `agentTree.ts` (compose/flatten/
  collectResolvableCommands/resolveDefaultAgent/mapAgentTreeByCommand) and `agentTreeEdit.ts`
  (immutable path ops). Removed flat `getDefaultAgent`.
- **Menu**: recursive cascade mirroring Workflows; leaf clicks re-resolve from **fresh**
  settings by path label and spawn command + env.
- **Spawn**: `spawnTerminalWithNewContextNode` gained `envOverrides`, forwarded to the RPC.
  Daemon validates against `collectResolvableCommands`; `spawn_agent` / `list_agents` /
  overnight / ask-mode resolve leaves and deliver leaf env.
- **Settings editor**: recursive tree editor — nest sub-agents, per-node `KEY=value` env
  rows, default radio keyed by leaf path label (tracked across rename/remove).

### Tests
graph-model settings 53 ✓ · menus 22 ✓ (incl. new cascade test) · daemon agent-runtime +
terminals 635 ✓. webapp / daemon / graph-model typecheck clean.

### Honest notes / boundaries
- The delivery oracle uses `bash -c <cmd>` with env set to simulate tmux `-e` + session
  shell. This faithfully covers env delivery + shell expansion + command quoting, but does
  **not** drive the real `tmux` binary (existing electron spawn e2e covers that path).
- `spawn_agent` now requires a **leaf** identifier (path label like `Codex / Remote / XHigh`,
  or a unique leaf name); `list_agents.availableAgents` advertises these. A bare category
  name (`Codex`) intentionally no longer resolves.
- The pre-existing `webapp/e2e-tests/tsconfig.json` has ~278 errors on base (d3/dagre/
  TerminalData/etc.) and is not a clean gate; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)