### PR TITLE
perf(test): size vitest forks from free host load, not total capacity

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,29 +1,16 @@
 import { configDefaults, defineConfig } from 'vitest/config'
 import { existsSync, readdirSync } from 'node:fs'
-import { availableParallelism, totalmem } from 'node:os'
 import { createRequire } from 'node:module'
 import path from 'path'
+import { readHostLoad, resolveMaxWorkers } from './vitest.workers'
 
 const require = createRequire(import.meta.url)
 
-// Worker concurrency derived from the HOST, not a magic constant — the same
-// config is fast on the 64c/188GB devbox and safe on a small CI runner, with no
-// box-specific number to go stale (the prior hardcoded `4` was calibrated for a
-// decommissioned 14c/15GB box). Mirrors the memory-aware ceiling in
-// packages/measures/src/_runners/capture-ci-checks.ts. The cap is the MIN of:
-//   • CPU knee — half the logical cores. Measured on the 64c/188GB devbox the
-//     full unit suite is 4f→208s, 16f→69s, 32f→64s, 64f→77s: past ~cores/2 the
-//     shared transform/collect phase thrashes and wall time REGRESSES (and
-//     timer-based tests flake more), so more forks is actively worse, not just
-//     wasteful.
-//   • RAM budget — 75% of total memory at ~1.5 GB/fork (measured peak). On a
-//     4c/16GB runner this binds first (→2 forks, ~3 GB) so we never reproduce
-//     the OOM cascade that reaped systemd on the old box.
-const PER_FORK_GB = 1.5
-const MEMORY_UTILISATION = 0.75
-const cpuCeiling = Math.max(1, Math.floor(availableParallelism() / 2))
-const memCeiling = Math.max(1, Math.floor((totalmem() / 1024 ** 3 * MEMORY_UTILISATION) / PER_FORK_GB))
-const maxWorkers = Math.min(cpuCeiling, memCeiling)
+// Worker concurrency is derived from what is CURRENTLY FREE on the host (not its
+// total capacity) so that the cap is fast on an idle box, safe on a small CI
+// runner, AND degrades gracefully when several suites run at once — see
+// ./vitest.workers.ts for the full rationale and the pure, unit-tested resolver.
+const maxWorkers = resolveMaxWorkers(readHostLoad())
 // TODO: drop the .worktrees handling below once migrate-worktrees-to-sibling.sh
 // has run and .worktrees/ is empty. Sibling vt-wts/ is outside the repo root,
 // so vitest never walks into it.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,29 @@
 import { configDefaults, defineConfig } from 'vitest/config'
 import { existsSync, readdirSync } from 'node:fs'
+import { availableParallelism, totalmem } from 'node:os'
 import { createRequire } from 'node:module'
 import path from 'path'
 
 const require = createRequire(import.meta.url)
+
+// Worker concurrency derived from the HOST, not a magic constant — the same
+// config is fast on the 64c/188GB devbox and safe on a small CI runner, with no
+// box-specific number to go stale (the prior hardcoded `4` was calibrated for a
+// decommissioned 14c/15GB box). Mirrors the memory-aware ceiling in
+// packages/measures/src/_runners/capture-ci-checks.ts. The cap is the MIN of:
+//   • CPU knee — half the logical cores. Measured on the 64c/188GB devbox the
+//     full unit suite is 4f→208s, 16f→69s, 32f→64s, 64f→77s: past ~cores/2 the
+//     shared transform/collect phase thrashes and wall time REGRESSES (and
+//     timer-based tests flake more), so more forks is actively worse, not just
+//     wasteful.
+//   • RAM budget — 75% of total memory at ~1.5 GB/fork (measured peak). On a
+//     4c/16GB runner this binds first (→2 forks, ~3 GB) so we never reproduce
+//     the OOM cascade that reaped systemd on the old box.
+const PER_FORK_GB = 1.5
+const MEMORY_UTILISATION = 0.75
+const cpuCeiling = Math.max(1, Math.floor(availableParallelism() / 2))
+const memCeiling = Math.max(1, Math.floor((totalmem() / 1024 ** 3 * MEMORY_UTILISATION) / PER_FORK_GB))
+const maxWorkers = Math.min(cpuCeiling, memCeiling)
 // TODO: drop the .worktrees handling below once migrate-worktrees-to-sibling.sh
 // has run and .worktrees/ is empty. Sibling vt-wts/ is outside the repo root,
 // so vitest never walks into it.
@@ -96,13 +116,10 @@ export default defineConfig({
       'default',
       [ciCheckReporter, ciCheck],
     ],
-    // Cap concurrency: vitest defaults to availableParallelism(), which on the
-    // 14-core devbox + 15 GB RAM with no swap = ~14 workers × ~1.3 GB each =
-    // OOM cascade that reaps systemd. 4 is the safe ceiling (~6 GB peak).
     pool: 'forks',
     poolOptions: {
-      forks: { maxForks: 4 },
-      threads: { maxThreads: 4 },
+      forks: { maxForks: maxWorkers },
+      threads: { maxThreads: maxWorkers },
     },
     // Codebase-health tests parse the whole repo and can exceed the default 5s
     // budget under parallel-worker CPU contention.

--- a/vitest.workers.test.ts
+++ b/vitest.workers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { resolveMaxWorkers, type HostLoad } from './vitest.workers'
+
+// Black-box: feed a HostLoad snapshot, assert the fork count. No mocking — the
+// host-reading impurity lives in readHostLoad(); resolveMaxWorkers is pure.
+
+const DEVBOX: HostLoad = { cores: 64, loadAvg1m: 0, availableMemGb: 180 }
+
+describe('resolveMaxWorkers', () => {
+  it('claims ~half the cores on an idle 64c box (the measured knee, not all cores)', () => {
+    expect(resolveMaxWorkers(DEVBOX)).toBe(32)
+  })
+
+  it('backs off when other work already loads the box, so concurrent suites share it', () => {
+    // A sibling suite saturating ~32 cores leaves ~32 idle → claim ~half of those.
+    const underSiblingRun = resolveMaxWorkers({ ...DEVBOX, loadAvg1m: 32 })
+    expect(underSiblingRun).toBe(16)
+    // Heavier still → keeps shrinking rather than piling on.
+    expect(resolveMaxWorkers({ ...DEVBOX, loadAvg1m: 48 })).toBe(8)
+  })
+
+  it('never drops below 1 even when the box is fully saturated', () => {
+    expect(resolveMaxWorkers({ ...DEVBOX, loadAvg1m: 64 })).toBe(1)
+    expect(resolveMaxWorkers({ ...DEVBOX, loadAvg1m: 200 })).toBe(1)
+  })
+
+  it('lets RAM bind first when memory is the scarce resource (the OOM guard)', () => {
+    // Idle CPU would allow 32, but only 6 GB free → 0.75*6/1.5 = 3 forks.
+    expect(resolveMaxWorkers({ ...DEVBOX, availableMemGb: 6 })).toBe(3)
+    // Almost no free RAM → serial, never 0 (which would hang vitest).
+    expect(resolveMaxWorkers({ ...DEVBOX, availableMemGb: 0.5 })).toBe(1)
+  })
+
+  it('stays safe on a small CI runner (4c/16GB → ~2 forks, no oversubscription)', () => {
+    expect(resolveMaxWorkers({ cores: 4, loadAvg1m: 0, availableMemGb: 16 })).toBe(2)
+  })
+
+  it('honours an explicit VITEST_MAX_FORKS pin over the heuristic', () => {
+    expect(resolveMaxWorkers({ ...DEVBOX, envOverride: 8 })).toBe(8)
+    expect(resolveMaxWorkers({ ...DEVBOX, envOverride: 4.9 })).toBe(4) // floored
+    // A bogus override is ignored; the heuristic resumes.
+    expect(resolveMaxWorkers({ ...DEVBOX, envOverride: 0 })).toBe(32)
+    expect(resolveMaxWorkers({ ...DEVBOX, envOverride: NaN })).toBe(32)
+  })
+})

--- a/vitest.workers.ts
+++ b/vitest.workers.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs'
+import { availableParallelism, freemem, loadavg } from 'node:os'
+
+// How many vitest worker forks to run, derived from the host — and, crucially,
+// from what is CURRENTLY FREE on it, not its total capacity. The same config is
+// fast on the idle 64c/188GB devbox, safe on a small CI runner, AND degrades
+// gracefully when several suites run at once (this devbox routinely has many
+// agents working in parallel, each able to start `npm run test`).
+//
+// Sizing each run to the WHOLE box — the prior `min(cores/2, total-RAM-budget)` —
+// is a tragedy of the commons: every concurrent run independently claims the
+// whole machine, so they collectively oversubscribe. On the 64c/188GB devbox
+// (measured: 4f→208s, 16f→69s, 32f→64s, 64f→77s) two runs already reach the
+// cores/2 knee past which wall time REGRESSES and timer tests flake, and ~4 runs
+// at 1.5 GB/fork exceed physical RAM and re-trigger the OOM cascade the cap
+// exists to prevent. The fix is to react to live load on both axes.
+
+export const PER_FORK_GB = 1.5
+export const MEMORY_UTILISATION = 0.75
+
+export type HostLoad = {
+  /** Logical cores (availableParallelism). */
+  cores: number
+  /** 1-minute load average — cores currently busy with OTHER work. */
+  loadAvg1m: number
+  /** Memory that can be claimed without paging — Linux MemAvailable, else freemem. */
+  availableMemGb: number
+  /** VITEST_MAX_FORKS, if set: a deterministic pin that overrides the heuristic. */
+  envOverride?: number
+}
+
+/**
+ * Pure: HostLoad → fork count. Both ceilings react to live load so that N
+ * concurrent suites SHARE the host instead of each claiming all of it:
+ *   • CPU — target the ~cores/2 knee, but on the IDLE cores only (cores minus
+ *     the load average). A single run on an idle box still claims ~cores/2; a
+ *     run starting while another saturates the box sees few idle cores and backs
+ *     off. (Two equal runs settle near cores/3 each — a mild overshoot of the
+ *     knee, not the 2x thrash of two full-box runs.)
+ *   • RAM — budget against AVAILABLE memory at ~1.5 GB/fork. This is the hard
+ *     guard: a run that starts while others hold forks sees less headroom and
+ *     sizes toward serial, so total fork RAM can never push the box past
+ *     physical memory. Unlike load average it reacts instantly (no 1-min lag),
+ *     so it also covers two runs that start in the same minute.
+ * VITEST_MAX_FORKS pins the count when a deterministic budget is wanted.
+ */
+export const resolveMaxWorkers = (host: HostLoad): number => {
+  if (host.envOverride !== undefined && Number.isFinite(host.envOverride) && host.envOverride > 0) {
+    return Math.max(1, Math.floor(host.envOverride))
+  }
+  const idleCores = Math.max(2, host.cores - Math.round(host.loadAvg1m))
+  const cpuCeiling = Math.max(1, Math.floor(idleCores / 2))
+  const memCeiling = Math.max(1, Math.floor((host.availableMemGb * MEMORY_UTILISATION) / PER_FORK_GB))
+  return Math.min(cpuCeiling, memCeiling)
+}
+
+/**
+ * os.freemem() on Linux is MemFree (excludes reclaimable page cache), which
+ * badly under-reports after an IO-heavy suite and would needlessly serialise the
+ * next run. Prefer MemAvailable from /proc/meminfo; fall back to freemem()
+ * elsewhere (macOS CI, etc.).
+ */
+const readAvailableMemGb = (): number => {
+  try {
+    const match = readFileSync('/proc/meminfo', 'utf8').match(/^MemAvailable:\s+(\d+)\s+kB/m)
+    if (match) return Number(match[1]) / 1024 ** 2
+  } catch {
+    // not Linux, or /proc unreadable — fall through to freemem()
+  }
+  return freemem() / 1024 ** 3
+}
+
+/** Impure shell: snapshot the live host into a HostLoad. */
+export const readHostLoad = (): HostLoad => {
+  const fromEnv = Number(process.env.VITEST_MAX_FORKS)
+  return {
+    cores: availableParallelism(),
+    loadAvg1m: loadavg()[0],
+    availableMemGb: readAvailableMemGb(),
+    envOverride: Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : undefined,
+  }
+}


### PR DESCRIPTION
Auto-opened (draft) during remote worktree cleanup. Branch `core-test-parallelism` had 2 commit(s) of useful content ahead of `dev`. Promote from draft or close as appropriate.