### PR TITLE
feat: support scoped cross-project agent addresses

### DIFF
--- a/packages/systems/voicetree-cli/src/commands/daemon-client.ts
+++ b/packages/systems/voicetree-cli/src/commands/daemon-client.ts
@@ -23,6 +23,7 @@ import {
     ERROR_CODES,
     authTokenFilePath,
     discoverDaemonEndpoint,
+    discoverDaemonEndpointForProject,
     readAuthTokenFile,
     type ResolvedDaemonEndpoint,
 } from '@vt/vt-rpc'
@@ -104,6 +105,25 @@ async function buildResolvedClient(
     const tokenFilePath: string = authTokenFilePath(tokenProjectPath)
     const token: string = await loadToken(tokenProjectPath, tokenFilePath)
     return {endpoint, tokenProjectPath: tokenProjectPath, tokenFilePath, token}
+}
+
+async function buildResolvedClientForProject(
+    projectPath: string,
+    env: Record<string, string | undefined>,
+): Promise<ResolvedClient> {
+    const endpoint: ResolvedDaemonEndpoint | null = await discoverDaemonEndpointForProject(
+        projectPath,
+        {env: dropDaemonUrlOverride(env)},
+    )
+    if (!endpoint?.projectPath) {
+        throw new DaemonUnreachable(
+            `Cannot resolve VoiceTree daemon URL for project ${projectPath}. ` +
+            'Confirm the project has `.voicetree/rpc.port` and its daemon is running.',
+        )
+    }
+    const tokenFilePath: string = authTokenFilePath(endpoint.projectPath)
+    const token: string = await loadToken(endpoint.projectPath, tokenFilePath)
+    return {endpoint, tokenProjectPath: endpoint.projectPath, tokenFilePath, token}
 }
 
 async function loadToken(project: string, tokenFilePath: string): Promise<string> {
@@ -259,6 +279,30 @@ export async function callDaemon(
         outcome = await postRpc(client.endpoint.url, client.token, toolName, args, timeoutMs)
     }
 
+    if (outcome.kind === 'auth_required') {
+        const freshToken: string = await loadToken(client.tokenProjectPath, client.tokenFilePath)
+        outcome = await postRpc(client.endpoint.url, freshToken, toolName, args, timeoutMs)
+        if (outcome.kind === 'auth_required') {
+            throw new DaemonAuthRequired(
+                `Daemon at ${client.endpoint.url} rejected the bearer token after one retry. Re-check ${client.tokenFilePath} — the daemon may have been restarted with a new token.`,
+            )
+        }
+    }
+
+    if (outcome.envelope.error) throwForRpcError(outcome.envelope.error, client.tokenFilePath)
+    return outcome.envelope.result
+}
+
+export async function callDaemonForProject(
+    projectPath: string,
+    toolName: string,
+    args: Record<string, unknown>,
+): Promise<unknown> {
+    const env: Record<string, string | undefined> = process.env
+    const timeoutMs: number = getTimeoutMs(env)
+    const client: ResolvedClient = await buildResolvedClientForProject(projectPath, env)
+
+    let outcome: PostOutcome = await postRpc(client.endpoint.url, client.token, toolName, args, timeoutMs)
     if (outcome.kind === 'auth_required') {
         const freshToken: string = await loadToken(client.tokenProjectPath, client.tokenFilePath)
         outcome = await postRpc(client.endpoint.url, freshToken, toolName, args, timeoutMs)

--- a/packages/systems/voicetree-cli/src/commands/runtime/agent.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agent.ts
@@ -1,5 +1,10 @@
+import {existsSync} from 'node:fs'
+import {basename, dirname, isAbsolute, resolve} from 'node:path'
 import {requireTerminalId} from '../graph/core/args'
-import {callDaemon} from '../daemon-client'
+import {loadProjects} from '@vt/app-config/project'
+import {hasVoicetreeMarker} from '@vt/paths'
+import type {SavedProject} from '@vt/graph-model/project'
+import {callDaemon, callDaemonForProject} from '../daemon-client'
 import {error, output} from '../output'
 import {
     AGENT_CLOSE_SPEC,
@@ -175,6 +180,59 @@ type AgentListItem = {
     title: string
     status: string
     isHeadless?: boolean
+}
+
+type ScopedAgentAddress = {
+    projectRef: string
+    terminalId: string
+}
+
+function parseScopedAgentAddress(raw: string): ScopedAgentAddress | null {
+    if (raw.startsWith('/') || raw.startsWith('./') || raw.startsWith('../')) return null
+    const slashIndex: number = raw.indexOf('/')
+    if (slashIndex <= 0 || slashIndex === raw.length - 1) return null
+    return {
+        projectRef: raw.slice(0, slashIndex),
+        terminalId: raw.slice(slashIndex + 1),
+    }
+}
+
+function projectMatchesRef(project: SavedProject, projectRef: string): boolean {
+    return project.id === projectRef ||
+        project.name === projectRef ||
+        basename(project.path) === projectRef
+}
+
+function candidateProjectPaths(projectRef: string, currentProject: string | undefined): readonly string[] {
+    const fromRef: string = isAbsolute(projectRef) ? projectRef : resolve(process.cwd(), projectRef)
+    const candidates: string[] = [fromRef]
+    if (currentProject) {
+        candidates.push(resolve(dirname(currentProject), projectRef))
+    }
+    return [...new Set(candidates)]
+}
+
+async function resolveProjectRef(projectRef: string): Promise<string> {
+    const savedProjects: SavedProject[] = await loadProjects()
+    const savedMatch: SavedProject | undefined = savedProjects.find(
+        (project: SavedProject): boolean => projectMatchesRef(project, projectRef),
+    )
+    if (savedMatch) return savedMatch.path
+
+    const currentProject: string | undefined = process.env.VOICETREE_PROJECT_PATH
+    const existingCandidate: string | undefined = candidateProjectPaths(projectRef, currentProject)
+        .find((candidate: string): boolean => existsSync(candidate) && hasVoicetreeMarker(candidate))
+    if (existingCandidate) return existingCandidate
+
+    error(
+        `Unknown project "${projectRef}" in scoped agent address. ` +
+        'Use a saved project name/id/basename, or run from a sibling project path.',
+    )
+}
+
+function currentProjectScope(): string {
+    const projectPath: string | undefined = process.env.VOICETREE_PROJECT_PATH
+    return projectPath && projectPath.length > 0 ? basename(projectPath) : basename(process.cwd())
 }
 
 function formatAgentList(payload: JsonRecord): string {
@@ -398,6 +456,22 @@ export async function agentSend(
     const message: string = messageParts.join(' ').trim()
     if (message.length === 0) {
         error('`agent send` requires a non-empty message')
+    }
+
+    const scopedTarget: ScopedAgentAddress | null = parseScopedAgentAddress(targetTerminalId)
+    if (scopedTarget) {
+        const targetProjectPath: string = await resolveProjectRef(scopedTarget.projectRef)
+        const scopedCallerTerminalId: string = `${currentProjectScope()}/${callerTerminalId}`
+        const payload: JsonRecord = ensureSuccessfulPayload(
+            await callDaemonForProject(targetProjectPath, 'send_message', {
+                callerTerminalId: scopedCallerTerminalId,
+                terminalId: scopedTarget.terminalId,
+                message,
+            })
+        )
+
+        output(payload, formatStandardResponse)
+        return
     }
 
     const payload: JsonRecord = ensureSuccessfulPayload(

--- a/packages/systems/voicetree-cli/src/commands/runtime/agentSpecs.ts
+++ b/packages/systems/voicetree-cli/src/commands/runtime/agentSpecs.ts
@@ -92,8 +92,8 @@ export const AGENT_CLOSE_SPEC: SubcommandSpec = {
 export const AGENT_SEND_SPEC: SubcommandSpec = {
     verb: 'vt agent send',
     rpcTool: 'send_message',
-    usageTail: '<terminalId> <message>...',
-    summary: 'Send a message into an agent terminal (carriage return appended).',
+    usageTail: '<terminalId|project/terminalId> <message>...',
+    summary: 'Send a message into an agent terminal. Use project/terminalId for cross-project sends.',
     flags: [],
 }
 

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/completion/sendMessageTool.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/completion/sendMessageTool.test.ts
@@ -1,0 +1,95 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import * as O from 'fp-ts/lib/Option.js'
+import {
+    clearTerminalRecords,
+    recordTerminalSpawn,
+} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry'
+import type {TerminalData, TerminalId} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/types.ts'
+import {sendMessageTool} from '../sendMessageTool'
+
+const sent: Array<{terminalId: string; text: string}> = []
+
+vi.mock('@vt/vt-daemon/agent-runtime/inject/send-text-to-terminal.ts', () => ({
+    sendTextToTerminal: async (terminalId: string, text: string): Promise<{success: boolean}> => {
+        sent.push({terminalId, text})
+        return {success: true}
+    },
+}))
+
+function makeTerminalData(terminalId: TerminalId): TerminalData {
+    return {
+        type: 'Terminal',
+        terminalId,
+        attachedToContextNodeId: '/ctx',
+        terminalCount: 1,
+        title: 'target',
+        anchoredToNodeId: O.none,
+        initialEnvVars: {},
+        initialSpawnDirectory: '/tmp',
+        initialCommand: null,
+        executeCommand: true,
+        resizable: true,
+        shadowNodeDimensions: {width: 395, height: 380},
+        isPinned: true,
+        isDone: false,
+        lifecycle: 'running',
+        lastOutputTime: 0,
+        activityCount: 0,
+        parentTerminalId: null,
+        agentName: terminalId,
+        worktreeName: undefined,
+        isHeadless: false,
+        isMinimized: false,
+        contextContent: '',
+        agentTypeName: '',
+    }
+}
+
+function parsePayload(response: Awaited<ReturnType<typeof sendMessageTool>>): {
+    readonly success: boolean
+    readonly error?: string
+    readonly terminalId?: string
+} {
+    return JSON.parse(response.content[0]?.text ?? '{}')
+}
+
+describe('sendMessageTool scoped caller addresses', () => {
+    afterEach(() => {
+        clearTerminalRecords()
+        sent.length = 0
+    })
+
+    it('accepts a project-scoped external caller and preserves it in the reply hint', async () => {
+        const target: TerminalId = 'Emi-2' as TerminalId
+        recordTerminalSpawn(target, makeTerminalData(target))
+
+        const response = await sendMessageTool({
+            callerTerminalId: 'brain/Emi',
+            terminalId: target,
+            message: 'hello from another project',
+        })
+
+        expect(parsePayload(response)).toMatchObject({success: true, terminalId: target})
+        expect(sent).toHaveLength(1)
+        expect(sent[0]).toMatchObject({terminalId: target})
+        expect(sent[0]?.text).toContain('[From: brain/Emi] hello from another project')
+        expect(sent[0]?.text).toContain('vt agent send')
+        expect(sent[0]?.text).toContain('brain/Emi')
+    })
+
+    it('still rejects an unscoped unknown caller', async () => {
+        const target: TerminalId = 'Emi-2' as TerminalId
+        recordTerminalSpawn(target, makeTerminalData(target))
+
+        const response = await sendMessageTool({
+            callerTerminalId: 'unknown-caller',
+            terminalId: target,
+            message: 'hello',
+        })
+
+        const payload = parsePayload(response)
+        expect(payload.success).toBe(false)
+        expect(payload.error).toContain('Unknown caller terminal')
+        expect(sent).toHaveLength(0)
+    })
+})

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/sendMessageTool.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/sendMessageTool.ts
@@ -31,6 +31,11 @@ function buildHeadlessInputError(terminalId: string): McpToolResponse {
     return buildErrorResponse(`Cannot send message to headless agent "${terminalId}". Headless agents have no terminal input. They receive work via their task node and produce output as graph nodes. Use get_unseen_nodes_nearby to read their output.`)
 }
 
+function isScopedExternalCaller(callerTerminalId: string): boolean {
+    const slashIndex: number = callerTerminalId.indexOf('/')
+    return slashIndex > 0 && slashIndex < callerTerminalId.length - 1
+}
+
 function queuePendingTerminalMessage(terminalId: string, callerTerminalId: string, message: string): McpToolResponse {
     enqueuePendingTerminalMessage(terminalId, buildFromPrefixedMessage(callerTerminalId, message))
     return buildJsonResponse({
@@ -85,7 +90,7 @@ export async function sendMessageTool({
     message,
     callerTerminalId
 }: SendMessageParams): Promise<McpToolResponse> {
-    if (!terminalExists(callerTerminalId)) {
+    if (!terminalExists(callerTerminalId) && !isScopedExternalCaller(callerTerminalId)) {
         return buildErrorResponse(`Unknown caller terminal: ${callerTerminalId}`)
     }
 

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/spawnAgentTool.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/spawnAgentTool.ts
@@ -69,7 +69,8 @@ type BudgetResult = { readonly allowed: boolean; readonly childBudget: number | 
 
 type SpawnRuntime = {
     readonly callerTerminalId: string
-    readonly callerRecord: TerminalRecord
+    readonly callerRecord?: TerminalRecord
+    readonly isExternalCaller: boolean
     readonly resolvedAgentCommand: string | undefined
     readonly resolvedSpawnDirectory: string | undefined
     readonly envOverrides: Record<string, string>
@@ -102,8 +103,14 @@ function findCallerRecord(callerTerminalId: string, terminalRecords: readonly Te
     return {ok: true, value: callerRecord}
 }
 
-function resolveChildDepthBudget(depthBudget: number | undefined, callerRecord: TerminalRecord): number | undefined {
+function isScopedExternalCaller(callerTerminalId: string): boolean {
+    const slashIndex: number = callerTerminalId.indexOf('/')
+    return slashIndex > 0 && slashIndex < callerTerminalId.length - 1
+}
+
+function resolveChildDepthBudget(depthBudget: number | undefined, callerRecord: TerminalRecord | undefined): number | undefined {
     if (depthBudget !== undefined) return depthBudget
+    if (!callerRecord) return undefined
 
     const parentDepthBudget: string | undefined = callerRecord.terminalData.initialEnvVars?.DEPTH_BUDGET
     if (!parentDepthBudget) return undefined
@@ -133,10 +140,10 @@ function resolveNamedAgentCommand(agentName: string, agents: readonly AgentSetti
 
 async function resolveAgentCommand(
     agentName: string | undefined,
-    callerRecord: TerminalRecord,
+    callerRecord: TerminalRecord | undefined,
     deps: SpawnAgentDeps,
 ): Promise<Result<string | undefined>> {
-    const callerAgentTypeName: string | undefined = callerRecord.terminalData.agentTypeName
+    const callerAgentTypeName: string | undefined = callerRecord?.terminalData.agentTypeName
     if (!agentName && !callerAgentTypeName) return {ok: true, value: undefined}
 
     const settings: VTSettings = await deps.loadAgentSettings()
@@ -149,15 +156,15 @@ async function resolveAgentCommand(
     return {ok: true, value: inheritedAgent?.command}
 }
 
-function resolveSpawnDirectory(spawnDirectory: string | undefined, callerRecord: TerminalRecord): string | undefined {
-    return spawnDirectory ?? callerRecord.terminalData.initialSpawnDirectory
-}
-
 async function prepareSpawnRuntime(
     params: SpawnAgentParams,
     deps: SpawnAgentDeps,
-    callerRecord: TerminalRecord,
+    callerRecord: TerminalRecord | undefined,
 ): Promise<Result<SpawnRuntime>> {
+    if (!callerRecord && params.replaceSelf) {
+        return {ok: false, error: 'Cannot replace self from a scoped external caller'}
+    }
+
     const childDepthBudget: number | undefined = resolveChildDepthBudget(params.depthBudget, callerRecord)
     const budgetResult: BudgetResult = deps.consumeBudget(params.callerTerminalId)
     if (!budgetResult.allowed) return {ok: false, error: 'Global spawn budget exhausted'}
@@ -170,8 +177,9 @@ async function prepareSpawnRuntime(
         value: {
             callerTerminalId: params.callerTerminalId,
             callerRecord,
+            isExternalCaller: !callerRecord,
             resolvedAgentCommand: agentCommandResult.value,
-            resolvedSpawnDirectory: resolveSpawnDirectory(params.spawnDirectory, callerRecord),
+            resolvedSpawnDirectory: params.spawnDirectory ?? callerRecord?.terminalData.initialSpawnDirectory,
             envOverrides: buildEnvOverrides(childDepthBudget, budgetResult.childBudget),
             childDepthBudget,
         }
@@ -201,10 +209,10 @@ function taskNodeIdFromDelta(taskNodeDelta: GraphDelta): NodeIdAndFilePath | und
 
 function buildCallerContextUpdateDelta(
     graph: Graph,
-    callerRecord: TerminalRecord,
+    callerRecord: TerminalRecord | undefined,
     taskNodeId: NodeIdAndFilePath,
 ): GraphDelta {
-    const callerContextNodeId: string | undefined = callerRecord.terminalData.attachedToContextNodeId
+    const callerContextNodeId: string | undefined = callerRecord?.terminalData.attachedToContextNodeId
     if (!callerContextNodeId) return []
 
     const callerContextNode: GraphNode | undefined = graph.nodes[callerContextNodeId]
@@ -243,7 +251,7 @@ function claimNodeDelta(targetNode: GraphNode): GraphDelta {
 
 function parentTerminalIdForSpawn(runtime: SpawnRuntime, replaceSelf: boolean | undefined): string | undefined {
     return replaceSelf
-        ? (runtime.callerRecord.terminalData.parentTerminalId ?? undefined)
+        ? (runtime.callerRecord?.terminalData.parentTerminalId ?? undefined)
         : runtime.callerTerminalId
 }
 
@@ -270,10 +278,16 @@ async function spawnTerminalForNode(
 }
 
 function rememberAndMonitorChild(terminalId: string, params: SpawnAgentParams, runtime: SpawnRuntime, deps: SpawnAgentDeps): void {
-    if (params.replaceSelf) return
+    if (params.replaceSelf || runtime.isExternalCaller) return
 
     deps.rememberChild(runtime.callerTerminalId, terminalId)
     deps.monitorChildren(runtime.callerTerminalId, [terminalId], 5000)
+}
+
+function spawnSuccessMessage(baseMessage: string, runtime: SpawnRuntime): string {
+    return runtime.isExternalCaller
+        ? `${baseMessage} No local completion monitor was started for external caller ${runtime.callerTerminalId}.`
+        : `${baseMessage} You will be notified when the agent completes.`
 }
 
 async function spawnAgentForTask(
@@ -319,7 +333,7 @@ async function spawnAgentForTask(
             depthBudget: runtime.childDepthBudget,
             message: params.replaceSelf
                 ? `Replaced self — successor agent running as "${terminalId}"`
-                : `Created task node and spawned agent for "${taskDescription}". You will be notified when the agent completes.`
+                : spawnSuccessMessage(`Created task node and spawned agent for "${taskDescription}".`, runtime)
         })
     } catch (error) {
         return errorResponse(errorMessage(error))
@@ -352,7 +366,7 @@ async function spawnAgentForExistingNode(
             depthBudget: runtime.childDepthBudget,
             message: params.replaceSelf
                 ? `Replaced self — successor agent running as "${terminalId}"`
-                : `Spawned agent for node ${resolvedNodeId}. You will be notified when the agent completes.`
+                : spawnSuccessMessage(`Spawned agent for node ${resolvedNodeId}.`, runtime)
         })
     } catch (error) {
         return errorResponse(errorMessage(error))
@@ -365,9 +379,15 @@ export async function spawnAgentTool(
 ): Promise<McpToolResponse> {
     const terminalRecords: TerminalRecord[] = deps.listTerminalRecords()
     const callerRecordResult: Result<TerminalRecord> = findCallerRecord(params.callerTerminalId, terminalRecords)
-    if (!callerRecordResult.ok) return errorResponse(callerRecordResult.error)
+    if (!callerRecordResult.ok && !isScopedExternalCaller(params.callerTerminalId)) {
+        return errorResponse(callerRecordResult.error)
+    }
 
-    const runtimeResult: Result<SpawnRuntime> = await prepareSpawnRuntime(params, deps, callerRecordResult.value)
+    const runtimeResult: Result<SpawnRuntime> = await prepareSpawnRuntime(
+        params,
+        deps,
+        callerRecordResult.ok ? callerRecordResult.value : undefined,
+    )
     if (!runtimeResult.ok) return errorResponse(runtimeResult.error)
 
     const writeFolderPathResult: Result<string> = await loadWriteFolderPath(deps)


### PR DESCRIPTION
Auto-opened (draft) during remote worktree cleanup. Branch `scoped-agent-address` had 1 commit(s) of useful content ahead of `dev`. Promote from draft or close as appropriate.