### PR TITLE
Terminal tree: hover-expand cards via overlay + blue awaiting-input icon

### DIFF
--- a/webapp/src/shell/UI/views/treeStyleTerminalTabs/TerminalTreeSidebar.tsx
+++ b/webapp/src/shell/UI/views/treeStyleTerminalTabs/TerminalTreeSidebar.tsx
@@ -245,15 +245,12 @@ function TreeNode({ treeNode, isActive, shortcutHint, onSelect, isCollapsed, onT
         ? renderSummaryChip(descendantSummary)
         : null;
 
-    return (
-        <div
-            className={`terminal-tree-node${isActive ? ' active' : ''}${terminal.isHeadless ? ' headless' : ''}${isAwaiting ? ' attn' : ''}${hasChildren ? ' has-children' : ''}`}
-            data-depth={depth}
-            data-terminal-id={terminalId}
-            onClick={handleClick}
-            onMouseDown={handleMouseDown}
-            aria-expanded={hasChildren ? !isCollapsed : undefined}
-        >
+    // Row content — rendered twice: once in the flex row (collapsed, ellipsised)
+    // and once inside the hover overlay (expanded, text wraps). Keeping it as one
+    // fragment means the two stay in lockstep; the only difference is the CSS the
+    // overlay applies to relax white-space.
+    const inner: JSX.Element = (
+        <>
             {/* Lifecycle indicator. Glyph (if any) supplied via CSS ::after. */}
             <span className={`terminal-tree-status ${statusClass}`} />
 
@@ -305,6 +302,28 @@ function TreeNode({ treeNode, isActive, shortcutHint, onSelect, isCollapsed, onT
             <button className="terminal-tree-close" onClick={handleClose}>
                 &times;
             </button>
+        </>
+    );
+
+    return (
+        <div
+            className={`terminal-tree-node${isActive ? ' active' : ''}${terminal.isHeadless ? ' headless' : ''}${isAwaiting ? ' attn' : ''}${hasChildren ? ' has-children' : ''}`}
+            data-depth={depth}
+            data-terminal-id={terminalId}
+            onClick={handleClick}
+            onMouseDown={handleMouseDown}
+            aria-expanded={hasChildren ? !isCollapsed : undefined}
+        >
+            {inner}
+
+            {/* Hover overlay — absolutely positioned, floats over the cards below.
+                Shown purely via CSS :hover (no JS state / re-render). Re-renders
+                the same row content with relaxed white-space so the full title,
+                worktree and status phrase wrap into view, with zero layout shift
+                on sibling nodes. */}
+            <div className="terminal-tree-hover-overlay">
+                {inner}
+            </div>
         </div>
     );
 }

--- a/webapp/src/shell/UI/views/treeStyleTerminalTabs/terminal-tree.css
+++ b/webapp/src/shell/UI/views/treeStyleTerminalTabs/terminal-tree.css
@@ -76,6 +76,57 @@
     border-color: var(--accent);
 }
 
+/* Hover overlay — floats over cards below, no layout displacement.
+   Always in the DOM (zero cost when hidden); shown purely via :hover — no JS
+   state or re-renders needed. */
+.terminal-tree-hover-overlay {
+    display: none;
+    position: absolute;
+    top: -1px;
+    left: -1px;
+    right: -1px;
+    z-index: 20;
+    background: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: 7px;
+    padding: 6px 10px;
+    align-items: flex-start;
+}
+.terminal-tree-node:hover .terminal-tree-hover-overlay {
+    display: flex;
+}
+.terminal-tree-hover-overlay .terminal-tree-title {
+    overflow: visible;
+}
+.terminal-tree-hover-overlay .terminal-tree-title-text,
+.terminal-tree-hover-overlay .terminal-tree-agent-id,
+.terminal-tree-hover-overlay .terminal-tree-worktree {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    word-break: break-word;
+}
+.terminal-tree-hover-overlay .terminal-tree-close {
+    opacity: 1;
+    align-self: flex-start;
+}
+/* Preserve row-tint colors in the overlay. The overlay floats OVER the cards
+   below it, so its background MUST be opaque — a bare rgba() tint would let the
+   covered card bleed through. We composite the tint over a solid --background
+   via a stacked gradient, giving the same hue as the node tint but fully opaque. */
+.terminal-tree-node.attn .terminal-tree-hover-overlay {
+    background:
+        linear-gradient(rgba(59, 130, 246, 0.22), rgba(59, 130, 246, 0.22)),
+        var(--background);
+    border-color: rgba(59, 130, 246, 0.7);
+}
+.terminal-tree-node.active:not(.attn) .terminal-tree-hover-overlay {
+    background:
+        linear-gradient(rgba(255, 200, 80, 0.2), rgba(255, 200, 80, 0.2)),
+        var(--background);
+    border-color: rgba(255, 200, 80, 0.5);
+}
+
 .terminal-tree-node.active {
     background: rgba(255, 200, 80, 0.15);
     border-color: rgba(255, 200, 80, 0.4);
@@ -219,11 +270,21 @@
     background: #d97706;
 }
 
-/* awaiting_input — agent blocked on user. Amber static dashed (paused, not
-   crashed). Row gets a blue tint via .node.attn — that's the actual signal. */
+/* awaiting_input — agent blocked on user. Blue circle with exclamation mark.
+   Blue (not amber) is deliberate: amber means "working" here (active spin / idle
+   solid), so an amber icon would read as urgent/busy. Blue is a calm "attention
+   wanted, not urgent" cue, and matches the blue .node.attn row tint — one
+   coherent signal. Distinct from green ✓ (done) and red ✕ (crashed). */
 .terminal-tree-status.lifecycle-awaiting_input {
-    background: transparent;
-    border: 2px dashed #f59e0b;
+    background: #3b82f6;
+    border: none;
+}
+.terminal-tree-status.lifecycle-awaiting_input::after {
+    content: "!";
+    font-size: 11px;
+    font-weight: 900;
+    color: white;
+    line-height: 1;
 }
 
 /* completed — exit code 0 OR agent self-reported done. Green check. */


### PR DESCRIPTION
Hovering an agent card now floats an absolutely-positioned overlay over the
cards below, revealing the full title, worktree and status phrase (text wraps)
with zero layout displacement of sibling nodes. The overlay is pure CSS :hover
(no JS state/re-render); its background composites the row tint over an opaque
--background so covered cards never bleed through.

awaiting_input status icon changed from an amber dashed ring (read as 'running')
to a calm blue circle with '!', matching its blue .node.attn row tint — amber is
reserved for 'working' (active spin / idle solid) in this view.

Row content is rendered once as a shared 'inner' fragment, used in both the
collapsed row and the overlay, so the two stay in lockstep.
