### PR TITLE
fix(settings): prune file-backed agent prompt env keys

### DIFF
--- a/packages/libraries/app-config/src/settings/settings_IO.test.ts
+++ b/packages/libraries/app-config/src/settings/settings_IO.test.ts
@@ -1,0 +1,72 @@
+import {promises as fs} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {DEFAULT_SETTINGS} from '@vt/graph-model/settings';
+import type {VTSettings} from '@vt/graph-model/settings';
+import {VOICETREE_HOME_PATH_ENV} from '@vt/paths';
+import {SETTINGS_FILENAME} from '../config-files.ts';
+import {loadSettings, saveSettings} from './settings_IO.ts';
+
+let homeDir: string;
+let originalEnv: string | undefined;
+
+async function readSettingsFromDisk(): Promise<VTSettings> {
+  const raw: string = await fs.readFile(path.join(homeDir, SETTINGS_FILENAME), 'utf-8');
+  return JSON.parse(raw) as VTSettings;
+}
+
+describe('settings IO prompt env sanitization', () => {
+  beforeEach(async () => {
+    homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vt-settings-io-'));
+    originalEnv = process.env[VOICETREE_HOME_PATH_ENV];
+    process.env[VOICETREE_HOME_PATH_ENV] = homeDir;
+  });
+
+  afterEach(async () => {
+    await fs.rm(homeDir, {recursive: true, force: true});
+    if (originalEnv === undefined) delete process.env[VOICETREE_HOME_PATH_ENV];
+    else process.env[VOICETREE_HOME_PATH_ENV] = originalEnv;
+  });
+
+  it('prunes stale file-backed prompt env keys when loading existing settings', async () => {
+    await fs.mkdir(homeDir, {recursive: true});
+    await fs.writeFile(path.join(homeDir, SETTINGS_FILENAME), JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      INJECT_ENV_VARS: {
+        AGENT_PROMPT: '$AGENT_PROMPT_CORE',
+        AGENT_PROMPT_CORE: 'stale core body',
+        AGENT_PROMPT_LIGHTWEIGHT: 'stale lightweight body',
+        AGENT_PROMPT_FILE: '/tmp/stale-prompt-file',
+        CUSTOM_CONTEXT: 'keep me',
+      },
+    }, null, 2), 'utf-8');
+
+    const loaded: VTSettings = await loadSettings();
+    const onDisk: VTSettings = await readSettingsFromDisk();
+
+    expect(loaded.INJECT_ENV_VARS).toEqual({
+      AGENT_PROMPT: '$AGENT_PROMPT_CORE',
+      DEPTH_BUDGET: '12',
+      CUSTOM_CONTEXT: 'keep me',
+    });
+    expect(onDisk.INJECT_ENV_VARS).toEqual(loaded.INJECT_ENV_VARS);
+  });
+
+  it('prunes reserved AGENT_PROMPT_* env keys before saving settings', async () => {
+    await saveSettings({
+      ...DEFAULT_SETTINGS,
+      INJECT_ENV_VARS: {
+        AGENT_PROMPT: '$AGENT_PROMPT_CORE',
+        AGENT_PROMPT_CORE: 'stale core body',
+        AGENT_PROMPT_LIGHTWEIGHT: 'stale lightweight body',
+        CUSTOM_CONTEXT: 'keep me',
+      },
+    });
+
+    expect((await readSettingsFromDisk()).INJECT_ENV_VARS).toEqual({
+      AGENT_PROMPT: '$AGENT_PROMPT_CORE',
+      CUSTOM_CONTEXT: 'keep me',
+    });
+  });
+});

--- a/packages/libraries/app-config/src/settings/settings_IO.ts
+++ b/packages/libraries/app-config/src/settings/settings_IO.ts
@@ -2,7 +2,8 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import type { VTSettings } from '@vt/graph-model/settings';
 
-import {DEFAULT_SETTINGS} from '@vt/graph-model/settings';
+import {DEFAULT_SETTINGS, isReservedAgentPromptEnvKey} from '@vt/graph-model/settings';
+import type {EnvVarValue} from '@vt/graph-model/settings';
 import {getCallbacks} from '@vt/graph-model';
 import {resolveVoicetreeHomePath} from '@vt/paths';
 import {SETTINGS_FILENAME} from '../config-files.ts';
@@ -16,6 +17,24 @@ export function clearSettingsCache(): void {
   // No-op: loadSettings reads from disk on every call so cross-process writes are visible immediately.
 }
 
+function sanitizeInjectEnvVars(envVars: Record<string, EnvVarValue> | undefined): Record<string, EnvVarValue> {
+  const entries: readonly (readonly [string, EnvVarValue])[] = Object
+    .entries(envVars ?? {})
+    .filter(([key]: readonly [string, EnvVarValue]): boolean => !isReservedAgentPromptEnvKey(key));
+  return Object.fromEntries(entries) as Record<string, EnvVarValue>;
+}
+
+function hasReservedAgentPromptEnvKey(envVars: Record<string, EnvVarValue> | undefined): boolean {
+  return Object.keys(envVars ?? {}).some(isReservedAgentPromptEnvKey);
+}
+
+function sanitizeSettingsForPersistence(settings: VTSettings): VTSettings {
+  return {
+    ...settings,
+    INJECT_ENV_VARS: sanitizeInjectEnvVars(settings.INJECT_ENV_VARS),
+  };
+}
+
 export async function loadSettings(): Promise<VTSettings> {
   const voicetreeHomePath: string = resolveVoicetreeHomePath();
   const settingsPath: string = getSettingsPath(voicetreeHomePath);
@@ -23,8 +42,9 @@ export async function loadSettings(): Promise<VTSettings> {
     const data: string = await fs.readFile(settingsPath, 'utf-8');
     const userSettings: Partial<VTSettings> = JSON.parse(data) as Partial<VTSettings>;
     // Shallow merge at top level; deep-merge INJECT_ENV_VARS so new default keys always reach users
-    // without clobbering user-owned overrides such as AGENT_PROMPT_CORE.
-    const settings: VTSettings = {
+    // without clobbering user-owned env vars. Prompt-template bodies are no longer
+    // settings-owned; they live in ~/.voicetree/prompts and are pruned below.
+    const mergedSettings: VTSettings = {
       ...DEFAULT_SETTINGS,
       ...userSettings,
       INJECT_ENV_VARS: {
@@ -32,11 +52,16 @@ export async function loadSettings(): Promise<VTSettings> {
         ...userSettings.INJECT_ENV_VARS,
       },
     };
+    const settings: VTSettings = sanitizeSettingsForPersistence(mergedSettings);
+    if (hasReservedAgentPromptEnvKey(userSettings.INJECT_ENV_VARS)) {
+      await saveSettings(settings);
+    }
     return settings;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      await saveSettings(DEFAULT_SETTINGS);
-      return DEFAULT_SETTINGS;
+      const settings: VTSettings = sanitizeSettingsForPersistence(DEFAULT_SETTINGS);
+      await saveSettings(settings);
+      return settings;
     }
     throw error;
   }
@@ -173,10 +198,10 @@ export async function saveSettings(settings: VTSettings): Promise<boolean> {
   const voicetreeHomePath: string = resolveVoicetreeHomePath();
   const settingsPath: string = getSettingsPath(voicetreeHomePath);
   const settingsDir: string = path.dirname(settingsPath);
+  const settingsToWrite: VTSettings = sanitizeSettingsForPersistence(settings);
 
   await fs.mkdir(settingsDir, { recursive: true });
-  await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+  await fs.writeFile(settingsPath, JSON.stringify(settingsToWrite, null, 2), 'utf-8');
   getCallbacks().onSettingsChanged?.();
   return true;
 }
-

--- a/packages/libraries/graph-model/src/pure/settings/promptEnvKeys.ts
+++ b/packages/libraries/graph-model/src/pure/settings/promptEnvKeys.ts
@@ -1,0 +1,8 @@
+/**
+ * `AGENT_PROMPT` is the user-editable composition hook. Every `AGENT_PROMPT_*`
+ * sibling is runtime-managed: prompt templates come from ~/.voicetree/prompts,
+ * and AGENT_PROMPT_FILE is generated during terminal launch.
+ */
+export function isReservedAgentPromptEnvKey(key: string): boolean {
+    return key.startsWith('AGENT_PROMPT_');
+}

--- a/packages/libraries/graph-model/src/settings.ts
+++ b/packages/libraries/graph-model/src/settings.ts
@@ -26,6 +26,7 @@ export {
     appendPersonaToAgentPrompt,
 } from './pure/agents/siliconValleyRoster'
 export { expandEnvVarsInValues, resolveEnvVars, resolveEnvVarsWithSelection } from './pure/settings/resolve-environment-variable'
+export { isReservedAgentPromptEnvKey } from './pure/settings/promptEnvKeys'
 export {
     agentPromptVariableForPlatform,
     createDefaultSettings,

--- a/packages/systems/vt-daemon/src/agent-runtime/spawn/buildTerminalEnvVars.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/spawn/buildTerminalEnvVars.ts
@@ -63,8 +63,8 @@ export async function buildTerminalEnvVars(params: {
     // AGENT_PROMPT_* templates are .md files in the single per-machine prompts
     // location ~/.voicetree/prompts (NO per-project prompts dir) — symlinks to the
     // canonical shipped source, kept in sync at daemon/Electron startup. A file is
-    // authoritative over any settings default of the same name; a settings value
-    // only applies when no file exists (e.g. a test that blanks the prompt).
+    // authoritative over any settings value of the same name; persisted settings
+    // prune these reserved keys so stale UI values cannot shadow the files.
     // --prompt-template selects which one becomes AGENT_PROMPT.
     const voicetreePromptsDir: string = path.join(voicetreeHomePath, 'prompts')
     const promptTemplates: Record<string, string> = await readPromptTemplates(voicetreePromptsDir)

--- a/webapp/src/shell/UI/views/components/settings/SettingsSection.test.tsx
+++ b/webapp/src/shell/UI/views/components/settings/SettingsSection.test.tsx
@@ -82,4 +82,56 @@ describe('SettingsSection agent environment variables', () => {
             AGENT_PROMPT: 'base prompt',
         });
     });
+
+    it('hides runtime-managed AGENT_PROMPT_* variables from the editor', () => {
+        render(
+            <EnvSettingsHarness
+                initialSettings={{
+                    ...DEFAULT_SETTINGS,
+                    INJECT_ENV_VARS: {
+                        AGENT_PROMPT: '$AGENT_PROMPT_CORE',
+                        AGENT_PROMPT_CORE: 'stale core body',
+                        AGENT_PROMPT_LIGHTWEIGHT: 'stale lightweight body',
+                        CUSTOM_CONTEXT: 'visible',
+                    },
+                }}
+            />,
+        );
+
+        expect(screen.getByText('AGENT_PROMPT')).toBeTruthy();
+        expect(screen.getByText('CUSTOM_CONTEXT')).toBeTruthy();
+        expect(screen.queryByText('AGENT_PROMPT_CORE')).toBeNull();
+        expect(screen.queryByText('AGENT_PROMPT_LIGHTWEIGHT')).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Remove environment variable AGENT_PROMPT_CORE' })).toBeNull();
+    });
+
+    it('does not allow adding runtime-managed AGENT_PROMPT_* variables', () => {
+        render(
+            <EnvSettingsHarness
+                initialSettings={{
+                    ...DEFAULT_SETTINGS,
+                    INJECT_ENV_VARS: {
+                        AGENT_PROMPT: '$AGENT_PROMPT_CORE',
+                    },
+                }}
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText('New environment variable name'), {
+            target: { value: 'AGENT_PROMPT_CORE' },
+        });
+        fireEvent.change(screen.getByLabelText('New environment variable value'), {
+            target: { value: 'should not persist' },
+        });
+
+        const addButton: HTMLButtonElement = screen.getByRole('button', { name: 'Add environment variable' });
+        expect(addButton.disabled).toBe(true);
+        expect(screen.getByText('AGENT_PROMPT_* variables are managed by prompt files. Edit AGENT_PROMPT to change prompt composition.')).toBeTruthy();
+
+        fireEvent.click(addButton);
+
+        expect(readRenderedEnvVars()).toEqual({
+            AGENT_PROMPT: '$AGENT_PROMPT_CORE',
+        });
+    });
 });

--- a/webapp/src/shell/UI/views/components/settings/SettingsSection.tsx
+++ b/webapp/src/shell/UI/views/components/settings/SettingsSection.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import type { JSX } from 'react';
 import { Plus, X } from 'lucide-react';
 import type { VTSettings, HotkeySettings, HotkeyBinding, HookSettings, EnvVarValue, AgentConfig } from '@vt/graph-model/settings';
-import { DEFAULT_HOTKEYS } from '@vt/graph-model/settings';
+import { DEFAULT_HOTKEYS, isReservedAgentPromptEnvKey } from '@vt/graph-model/settings';
 import { SECTION_MAP, HIDDEN_KEYS, NUMBER_FIELD_CONFIG, SELECT_FIELD_OPTIONS, inferFieldType, keyToLabel } from './settingsUtils';
 import type { Section, FieldType, NumberFieldConfig, SelectOption } from './settingsUtils';
 import { ToggleField } from './fields/ToggleField';
@@ -117,10 +117,12 @@ function EnvVarCreator({ existingKeys, onAdd }: {
     const [valueInput, setValueInput] = useState<string>('');
     const normalizedKey: string = normalizeEnvVarKey(keyInput);
     const isDuplicate: boolean = existingKeys.includes(normalizedKey);
-    const canAdd: boolean = isValidEnvVarKey(normalizedKey) && !isDuplicate;
+    const isReserved: boolean = isReservedAgentPromptEnvKey(normalizedKey);
+    const canAdd: boolean = isValidEnvVarKey(normalizedKey) && !isDuplicate && !isReserved;
     const validationMessage: string | null = (() => {
         if (normalizedKey.length === 0) return null;
         if (!isValidEnvVarKey(normalizedKey)) return 'Names must start with a letter or underscore and contain only letters, numbers, and underscores.';
+        if (isReserved) return 'AGENT_PROMPT_* variables are managed by prompt files. Edit AGENT_PROMPT to change prompt composition.';
         if (isDuplicate) return 'That environment variable already exists.';
         return null;
     })();
@@ -189,17 +191,20 @@ export function SettingsSection({ settings, section, onUpdate }: SettingsSection
     }, [settings.hooks, onUpdate]);
 
     const handleEnvVarUpdate: (envKey: string, value: string) => void = useCallback((envKey: string, value: string): void => {
+        if (isReservedAgentPromptEnvKey(envKey)) return;
         const currentVars: Record<string, EnvVarValue> = settings.INJECT_ENV_VARS ?? {};
         onUpdate('INJECT_ENV_VARS', { ...currentVars, [envKey]: value });
     }, [settings.INJECT_ENV_VARS, onUpdate]);
 
     const handleEnvVarAdd: (envKey: string, value: string) => void = useCallback((envKey: string, value: string): void => {
+        if (isReservedAgentPromptEnvKey(envKey)) return;
         const currentVars: Record<string, EnvVarValue> = settings.INJECT_ENV_VARS ?? {};
         if (Object.prototype.hasOwnProperty.call(currentVars, envKey)) return;
         onUpdate('INJECT_ENV_VARS', { ...currentVars, [envKey]: value });
     }, [settings.INJECT_ENV_VARS, onUpdate]);
 
     const handleEnvVarRemove: (envKey: string) => void = useCallback((envKey: string): void => {
+        if (isReservedAgentPromptEnvKey(envKey)) return;
         const currentVars: Record<string, EnvVarValue> = settings.INJECT_ENV_VARS ?? {};
         const { [envKey]: _removed, ...remaining } = currentVars;
         onUpdate('INJECT_ENV_VARS', remaining);
@@ -322,6 +327,9 @@ export function SettingsSection({ settings, section, onUpdate }: SettingsSection
 
                     case 'key-value': {
                         const envVars: Record<string, EnvVarValue> = (value as Record<string, EnvVarValue>) ?? {};
+                        const visibleEnvVars: Record<string, EnvVarValue> = Object.fromEntries(
+                            Object.entries(envVars).filter(([envKey]: readonly [string, EnvVarValue]): boolean => !isReservedAgentPromptEnvKey(envKey)),
+                        ) as Record<string, EnvVarValue>;
                         return (
                             <div key={key} className="space-y-2">
                                 <div className="font-mono text-sm text-foreground font-medium">{label}</div>
@@ -329,7 +337,7 @@ export function SettingsSection({ settings, section, onUpdate }: SettingsSection
                                     existingKeys={Object.keys(envVars)}
                                     onAdd={handleEnvVarAdd}
                                 />
-                                {Object.entries(envVars).map(([envKey, envValue]) => (
+                                {Object.entries(visibleEnvVars).map(([envKey, envValue]) => (
                                     <EnvVarEntry
                                         key={envKey}
                                         envKey={envKey}


### PR DESCRIPTION
Auto-opened (draft) during remote worktree cleanup. 1 commit ahead of `dev`. Promote or close as appropriate.