### PR TITLE
Terminal tree: chevron collapse toggle + hover spotlight with explicit layering

### DIFF
--- a/webapp/src/shell/UI/views/treeStyleTerminalTabs/TerminalTreeSidebar.tsx
+++ b/webapp/src/shell/UI/views/treeStyleTerminalTabs/TerminalTreeSidebar.tsx
@@ -10,7 +10,7 @@
 
 import { createElement, useRef, useEffect, useCallback, useMemo, useState } from 'react';
 import type { JSX } from 'react';
-import { Play } from 'lucide-react';
+import { Play, ChevronRight } from 'lucide-react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { TerminalId } from '@/shell/edge/UI-edge/floating-windows/anchoring/types';
 import { getTerminalId } from '@/shell/edge/UI-edge/floating-windows/anchoring/types';
@@ -191,14 +191,19 @@ function TreeNode({ treeNode, isActive, shortcutHint, onSelect, isCollapsed, onT
     const { terminal, depth, hasChildren, directChildCount, descendantSummary } = treeNode;
     const terminalId: TerminalId = terminal.terminalId;
 
-    // Clicking a parent row both navigates to the orchestrator's terminal AND
-    // toggles its sub-agent group — replaces the old separate chevron control.
+    // Clicking a row only navigates to its terminal. Collapsing the sub-agent
+    // group is a separate concern owned by the chevron control (parents only),
+    // so a click on the row body never hides children unexpectedly.
     const handleClick: () => void = useCallback((): void => {
-        if (hasChildren) {
-            onToggleCollapse(terminalId, directChildCount);
-        }
         onSelect(terminal);
-    }, [onSelect, terminal, hasChildren, onToggleCollapse, terminalId, directChildCount]);
+    }, [onSelect, terminal]);
+
+    // Chevron toggles the sub-agent group without navigating. stopPropagation
+    // keeps the row's onClick (navigate) from also firing.
+    const handleToggleCollapse: (e: React.MouseEvent) => void = useCallback((e: React.MouseEvent): void => {
+        e.stopPropagation();
+        onToggleCollapse(terminalId, directChildCount);
+    }, [onToggleCollapse, terminalId, directChildCount]);
 
     const handleClose: (e: React.MouseEvent) => void = useCallback((e: React.MouseEvent): void => {
         e.stopPropagation();
@@ -251,6 +256,24 @@ function TreeNode({ treeNode, isActive, shortcutHint, onSelect, isCollapsed, onT
     // overlay applies to relax white-space.
     const inner: JSX.Element = (
         <>
+            {/* Collapse toggle for parents; an equal-width spacer for leaves so
+                every status dot stays vertically aligned. Decoupled from the row
+                click (which now only navigates). */}
+            {hasChildren ? (
+                <button
+                    className={`terminal-tree-chevron${isCollapsed ? '' : ' expanded'}`}
+                    type="button"
+                    onClick={handleToggleCollapse}
+                    onMouseDown={handleMouseDown}
+                    aria-label={isCollapsed ? 'Expand sub-agents' : 'Collapse sub-agents'}
+                    title={isCollapsed ? 'Expand sub-agents' : 'Collapse sub-agents'}
+                >
+                    <ChevronRight size={14} aria-hidden="true" />
+                </button>
+            ) : (
+                <span className="terminal-tree-chevron-spacer" aria-hidden="true" />
+            )}
+
             {/* Lifecycle indicator. Glyph (if any) supplied via CSS ::after. */}
             <span className={`terminal-tree-status ${statusClass}`} />
 

--- a/webapp/src/shell/UI/views/treeStyleTerminalTabs/terminal-tree.css
+++ b/webapp/src/shell/UI/views/treeStyleTerminalTabs/terminal-tree.css
@@ -68,12 +68,34 @@
     border-radius: 7px;
     background: var(--card);
     border: 1px solid var(--border);
-    transition: background 0.1s ease, border-color 0.1s ease;
+    transition: background 0.1s ease, border-color 0.1s ease, opacity 0.12s ease;
+    /* Baseline stacking layer. Explicit (not implied by opacity) so the layer
+       order is stable: the spotlight below dims cards with opacity, which would
+       otherwise turn each card into a stacking context and trap the hovered
+       card's overlay z-index, letting neighbours poke through mid-transition. */
+    z-index: 1;
 }
 
 .terminal-tree-node:hover {
     background: var(--accent);
     border-color: var(--accent);
+    /* Hovered card jumps to the top layer — instantly, since z-index isn't
+       animated — so its overlay always paints above every sibling regardless of
+       any in-flight opacity transition. */
+    z-index: 5;
+}
+
+/* Spotlight: while the cursor is anywhere over the list, recede every card and
+   keep only the hovered one at full opacity, so the expanded overlay reads
+   clearly against a muted backdrop. Gated on the CONTAINER's :hover (not "is any
+   node hovered") so the baseline stays stable across the inter-card margin gap —
+   otherwise the card you just left would flash back to full opacity for the gap
+   frame and then re-dim. */
+.terminal-tree-container:hover .terminal-tree-node {
+    opacity: 0.6;
+}
+.terminal-tree-container:hover .terminal-tree-node:hover {
+    opacity: 1;
 }
 
 /* Hover overlay — floats over cards below, no layout displacement.
@@ -91,6 +113,8 @@
     border-radius: 7px;
     padding: 6px 10px;
     align-items: flex-start;
+    /* Lifts the expanded card off the dimmed cards behind it. */
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.38);
 }
 .terminal-tree-node:hover .terminal-tree-hover-overlay {
     display: flex;
@@ -108,6 +132,12 @@
 }
 .terminal-tree-hover-overlay .terminal-tree-close {
     opacity: 1;
+    align-self: flex-start;
+}
+/* In the expanded overlay the title wraps to multiple lines, so pin the chevron
+   (and the leaf spacer) to the top rather than letting them center vertically. */
+.terminal-tree-hover-overlay .terminal-tree-chevron,
+.terminal-tree-hover-overlay .terminal-tree-chevron-spacer {
     align-self: flex-start;
 }
 /* Preserve row-tint colors in the overlay. The overlay floats OVER the cards
@@ -149,6 +179,41 @@
     background: rgba(59, 130, 246, 0.32);
     border-color: rgba(59, 130, 246, 0.75);
     box-shadow: inset 2px 0 0 rgba(59, 130, 246, 1);
+}
+
+/* ============================================================================
+ * Collapse chevron — toggles a parent's sub-agent group. A dedicated control so
+ * the row body's click stays free to navigate (it no longer also collapses).
+ * Leaf rows render an equal-width spacer instead, so every status dot lines up
+ * regardless of whether the row has children.
+ * ============================================================================ */
+.terminal-tree-chevron {
+    width: 16px;
+    height: 16px;
+    margin-right: 3px;
+    flex-shrink: 0;
+    border: none;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+    color: var(--muted-foreground);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    transition: transform 0.15s ease, color 0.1s ease;
+}
+.terminal-tree-chevron:hover {
+    color: var(--foreground);
+}
+/* Points right (collapsed) by default; rotates to point down when expanded. */
+.terminal-tree-chevron.expanded {
+    transform: rotate(90deg);
+}
+.terminal-tree-chevron-spacer {
+    width: 16px;
+    margin-right: 3px;
+    flex-shrink: 0;
 }
 
 /* Headless agent styling - background agents: smaller, less emphasis, dashed */


### PR DESCRIPTION
Three related sidebar UX changes:

1. Chevron collapse toggle. Collapsing a parent's sub-agent group moves from
   'click the row' to a dedicated chevron control (lucide ChevronRight, rotates
   when expanded). The row body's click now ONLY navigates — it no longer
   collapses children as a side effect. Leaf rows render an equal-width spacer
   so every status dot stays vertically aligned. The chevron lives in the shared
   'inner' fragment, so it appears consistently in both the row and the hover
   overlay.

2. Hover spotlight. While the cursor is over the list, the other cards recede to
   0.6 opacity and the hovered card stays full, so the expanded overlay reads
   clearly against a muted backdrop. Gated on the container's :hover (not 'is any
   node hovered') so the dim baseline stays stable across the inter-card margin
   gap — avoids the card you just left flashing back to full opacity for the gap
   frame. The overlay also gains a soft drop shadow to lift it off the backdrop.

3. Explicit stacking layers. Cards get an explicit z-index baseline (1) and the
   hovered card jumps to the top (5). This is required because the spotlight dims
   with opacity, which turns each card into a stacking context and would
   otherwise trap the hovered card's overlay z-index mid-transition, letting a
   neighbouring card poke through the overlay. With explicit, non-animated
   z-index the layer order is correct at every frame of the transition.

Pure CSS for 2 and 3; 1 is a small TSX + CSS change. tsc + eslint clean.
