### PR TITLE
feat(perf-stack): make LGTM perf stack opt-in via PERF_STACK=1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ ANTHROPIC_API_KEY=
 
 # Optional: disable analytics (matches webapp/.env switch).
 # VITE_DISABLE_ANALYTICS=true
+
+# Optional: attach the local LGTM perf stack on `npm run electron(:prod)`.
+# Off by default (NDJSON-only, no resident collector services). Set to 1 to
+# install + bring the stack up and export OTLP. See infra/perf-stack/README.md.
+# PERF_STACK=1

--- a/infra/perf-stack/README.md
+++ b/infra/perf-stack/README.md
@@ -17,12 +17,20 @@ All services bind to `127.0.0.1`. Backend storage lives under
 `-- --persist` is passed. Plain run artifacts under `~/.voicetree/perf/<uuid>/`
 are never touched by lifecycle commands.
 
-## Auto-attach on `npm run electron(:prod)`
+## Opt-in on `npm run electron(:prod)` — `PERF_STACK=1`
 
-Running the app locally attaches the stack automatically — no manual
-`perf:install` / `perf:up` first. The webapp `electron` and `electron:prod`
-scripts wrap their launch in `scripts/ensure-perf-stack.mjs`, an idempotent
-preflight that:
+The perf stack is **off by default**: a normal `npm run electron` runs
+NDJSON-only with no resident collector services and no first-run install. Set
+`PERF_STACK=1` to attach it — no manual `perf:install` / `perf:up` first:
+
+```sh
+PERF_STACK=1 npm run electron
+```
+
+(or put `PERF_STACK=1` in your `.env` to make it your standing default.)
+
+The webapp `electron` and `electron:prod` scripts wrap their launch in
+`scripts/ensure-perf-stack.mjs`, an idempotent preflight that, when enabled:
 
 1. installs the native binaries on first run (one-time download into `bin/`),
 2. brings the stack up if it isn't already (a warm stack is a fast no-op), and
@@ -33,17 +41,10 @@ Both `vt-electron-main` and the `vt-graphd` daemon it spawns then export OTLP to
 the collector; the launch prints `Grafana: http://localhost:2999` so the
 dashboards are one click away.
 
-### Opt-out — `PERF_STACK=0`
-
-```sh
-PERF_STACK=0 npm run electron
-```
-
-Skips the preflight entirely: no install, no `up`, and `VOICETREE_OTLP_ENDPOINT`
+Without `PERF_STACK=1` (or with any falsy value — absent, `0`, `false`) the
+preflight is a complete no-op: no install, no `up`, and `VOICETREE_OTLP_ENDPOINT`
 is left unset so the OTLP exporter never attaches. Only the always-on NDJSON
-exporter under `~/.voicetree/traces/` runs — i.e. exactly the pre-auto-attach
-behavior. Use this when you don't want the six resident perf-stack services on
-your machine for a given launch.
+exporter under `~/.voicetree/traces/` runs.
 
 ## Trace to profile correlation
 

--- a/packages/measures/src/_shared/discovery/run-git.ts
+++ b/packages/measures/src/_shared/discovery/run-git.ts
@@ -1,23 +1,34 @@
 import {execFileSync, type ExecFileSyncOptionsWithStringEncoding} from 'node:child_process'
 
-// Git exports GIT_DIR (and sometimes GIT_WORK_TREE) into the environment of any
-// hook it runs (pre-commit, pre-push, …). When GIT_DIR is set WITHOUT
-// GIT_WORK_TREE, working-tree commands such as `git ls-files` abort with
-//   fatal: this operation must be run in a work tree
-// because the inherited GIT_DIR overrides the cwd-based repository discovery
-// those commands rely on. Server-side CI is unaffected (no hook wrapper exports
-// GIT_DIR there), so the breakage only bites git operations invoked from a local
-// hook — e.g. the architecture-drift / source-of-truth health checks during a
-// local push, which silently report as failures.
+// Git exports its location-pointing variables (GIT_DIR, GIT_WORK_TREE, and —
+// inside a linked worktree — GIT_COMMON_DIR, plus GIT_INDEX_FILE / GIT_PREFIX)
+// into the environment of any hook it runs (pre-commit, pre-push, …). When any
+// of these is inherited, working-tree commands run against the HOOK's repo
+// rather than the cwd we point them at:
+//   - `git ls-files` aborts with "fatal: this operation must be run in a work tree"
+//   - `git init` in a sandbox writes refs to the leaked GIT_COMMON_DIR and dies
+//     with "<sandbox>/.git/refs/heads: No such file or directory"
+// Server-side CI is unaffected (no hook wrapper exports these there), so the
+// breakage only bites git operations invoked from a local hook — e.g. the
+// architecture-drift / source-of-truth health checks during a local push.
 //
-// Stripping both overrides restores cwd-based resolution, which is exactly what
-// every measure git call already wants: they each pass an explicit `cwd` and
-// never depend on an ambient GIT_DIR.
+// Stripping every location override restores cwd-based resolution, which is
+// exactly what every measure git call already wants: they each pass an explicit
+// `cwd` and never depend on an ambient GIT_DIR.
+const GIT_LOCATION_OVERRIDE_VARS = new Set([
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_COMMON_DIR',
+    'GIT_INDEX_FILE',
+    'GIT_OBJECT_DIRECTORY',
+    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+    'GIT_NAMESPACE',
+    'GIT_PREFIX',
+])
+
 function envWithoutGitLocationOverrides(): NodeJS.ProcessEnv {
     return Object.fromEntries(
-        Object.entries(process.env).filter(
-            ([key]) => key !== 'GIT_DIR' && key !== 'GIT_WORK_TREE',
-        ),
+        Object.entries(process.env).filter(([key]) => !GIT_LOCATION_OVERRIDE_VARS.has(key)),
     )
 }
 

--- a/packages/measures/src/health/coupling/architecture-drift/architecture-drift.test.ts
+++ b/packages/measures/src/health/coupling/architecture-drift/architecture-drift.test.ts
@@ -1,9 +1,9 @@
-import {execFileSync} from 'node:child_process'
 import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import {join, relative, resolve} from 'node:path'
 import {fileURLToPath} from 'node:url'
 import {describe, expect, it} from 'vitest'
+import {runGitWorktreeCommand} from '../../../_shared/discovery/run-git'
 import {recordHealthMetric} from '../../../_shared/writers/report-writer'
 import {discoverArchitectureFiles, validateArchitectureDrift} from './validate-architecture-drift'
 
@@ -69,8 +69,13 @@ describe('architecture discovery', () => {
             await mkdir(churningRuntimeDir, {recursive: true})
             await writeFile(join(sandbox, 'storage', 'architecture.md'), '```mermaid\nflowchart TD\n  x[x]\n```\n')
 
-            execFileSync('git', ['init', '-q'], {cwd: sandbox})
-            execFileSync('git', ['add', 'architecture.md', '.gitignore'], {cwd: sandbox})
+            // Use the GIT_DIR-immune runner for setup too: a pre-push hook leaks
+            // GIT_DIR/GIT_WORK_TREE into the env, which would otherwise make these
+            // commands operate on the real repo instead of the sandbox — leaving
+            // sandbox/.git uncreated and the discovery below failing with
+            // "fatal: not a git repository".
+            runGitWorktreeCommand(['init', '-q'], sandbox)
+            runGitWorktreeCommand(['add', 'architecture.md', '.gitignore'], sandbox)
 
             const discovered = (await discoverArchitectureFiles(sandbox))
                 .map(file => relative(sandbox, file.absPath))

--- a/scripts/ensure-perf-stack.mjs
+++ b/scripts/ensure-perf-stack.mjs
@@ -28,10 +28,20 @@ const PERF_BIN_DIR = join(REPO_ROOT, 'infra/perf-stack/bin')
 const INSTALL_SCRIPT = join(REPO_ROOT, 'infra/perf-stack/scripts/install-binaries.mjs')
 const LIFECYCLE_SCRIPT = join(REPO_ROOT, 'infra/perf-stack/scripts/lifecycle.mjs')
 
-// Opt-out lever: PERF_STACK=0 makes the preflight a complete no-op so the
-// launched process runs exactly as it does today (NDJSON-only, no collector).
-// Default-on is what makes "just run the app" work; this is the escape hatch.
-export const PERF_STACK_DISABLED = '0'
+// Opt-in lever: the perf stack is OFF by default, so "just run the app" stays
+// NDJSON-only with no resident collector services and no first-run install.
+// Set PERF_STACK=1 (inline on the launch, or in your .env) to make the
+// preflight install the binaries, bring the stack up, and attach the OTLP
+// exporter. Anything else (absent, empty, `0`, `false`) is a complete no-op.
+export const PERF_STACK_ENABLED = '1'
+
+/**
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {boolean} true only when PERF_STACK is explicitly switched on
+ */
+export function perfStackEnabled(env) {
+  return env.PERF_STACK === PERF_STACK_ENABLED
+}
 
 // Interactive launches get the always-on-safe `lite` perf tier (wall sampling +
 // runtime metrics + log — see perf-probe.mjs). `deep` (heap snapshots) stays
@@ -62,7 +72,7 @@ export async function ensurePerfStack({
   log = (message) => process.stderr.write(`${message}\n`),
   newRunId = randomUUID,
 }) {
-  if (env.PERF_STACK === PERF_STACK_DISABLED) {
+  if (!perfStackEnabled(env)) {
     return { enabled: false }
   }
 
@@ -172,12 +182,12 @@ async function main(argv = process.argv.slice(2), baseEnv = process.env) {
       `Grafana: ${GRAFANA_BASE_URL}\nPerf run: ${result.instanceId}\nOTLP: ${result.endpoint}\nPerf tier: ${result.tier}\n`,
     )
   } else {
-    // Opt-out: guarantee the exporter AND the probe stay detached even if the
-    // endpoint/tier were already present in the inherited env — PERF_STACK=0
-    // means no collector and no profiling.
+    // Default (opt-out): guarantee the exporter AND the probe stay detached
+    // even if the endpoint/tier were already present in the inherited env —
+    // without PERF_STACK=1 there is no collector and no profiling.
     delete launchEnv.VOICETREE_OTLP_ENDPOINT
     delete launchEnv.VOICETREE_PERF_TIER
-    process.stdout.write('Perf stack disabled (PERF_STACK=0); OTLP export + profiling off, NDJSON unaffected\n')
+    process.stdout.write('Perf stack off (set PERF_STACK=1 to enable); OTLP export + profiling off, NDJSON unaffected\n')
   }
 
   const { code, signal } = await launch(command, commandArgs, launchEnv)

--- a/scripts/ensure-perf-stack.test.mjs
+++ b/scripts/ensure-perf-stack.test.mjs
@@ -54,11 +54,15 @@ function fakePerfStack({
 
 const silent = () => {}
 
+// The opt-in switch: the preflight only does work when PERF_STACK=1. Every
+// enabled-path test threads this in; absence of it is the default no-op.
+const ON = { PERF_STACK: '1' }
+
 test('cold start: installs binaries then brings the stack up', async () => {
   const stack = fakePerfStack({ present: [], running: false })
 
   const result = await ensurePerfStack({
-    env: {},
+    env: { ...ON },
     run: stack.run,
     installIsComplete: stack.installIsComplete,
     log: silent,
@@ -83,7 +87,7 @@ test('partial install converges: missing binaries trigger a reinstall, then up',
   const stack = fakePerfStack({ present: ['grafana'], running: false })
 
   const result = await ensurePerfStack({
-    env: {},
+    env: { ...ON },
     run: stack.run,
     installIsComplete: stack.installIsComplete,
     log: silent,
@@ -99,7 +103,7 @@ test('an enabled preflight selects the always-on lite perf tier', async () => {
   const stack = fakePerfStack({ present: ALL, running: true })
 
   const result = await ensurePerfStack({
-    env: {},
+    env: { ...ON },
     run: stack.run,
     installIsComplete: stack.installIsComplete,
     log: silent,
@@ -114,7 +118,7 @@ test('an incomplete install emits the one-time progress line', async () => {
   const lines = []
 
   await ensurePerfStack({
-    env: {},
+    env: { ...ON },
     run: stack.run,
     installIsComplete: stack.installIsComplete,
     log: (message) => lines.push(message),
@@ -130,7 +134,7 @@ test('warm stack: complete install → no reinstall, just an idempotent up', asy
   const lines = []
 
   const result = await ensurePerfStack({
-    env: {},
+    env: { ...ON },
     run: stack.run,
     installIsComplete: stack.installIsComplete,
     log: (message) => lines.push(message),
@@ -149,7 +153,7 @@ test('up failure surfaces a clear error and does not silently succeed', async ()
 
   await assert.rejects(
     ensurePerfStack({
-      env: {},
+      env: { ...ON },
       run: stack.run,
       installIsComplete: stack.installIsComplete,
       log: silent,
@@ -164,7 +168,7 @@ test('install failure aborts before attempting up', async () => {
 
   await assert.rejects(
     ensurePerfStack({
-      env: {},
+      env: { ...ON },
       run: stack.run,
       installIsComplete: stack.installIsComplete,
       log: silent,
@@ -174,35 +178,41 @@ test('install failure aborts before attempting up', async () => {
   assert.equal(stack.world.running, false, 'up was never attempted')
 })
 
-test('PERF_STACK=0 is a complete no-op: no install, no up, exporter left detached', async () => {
-  const stack = fakePerfStack({ present: [], running: false })
-  let installs = 0
-  let ups = 0
-  const countingRun = (action) => {
-    if (action === 'install') installs += 1
-    if (action === 'up') ups += 1
-    return stack.run(action)
-  }
+// The default is OFF: without PERF_STACK=1 the preflight must touch nothing.
+// Each falsy form (absent / empty / `0` / `false`) is a complete no-op.
+for (const env of [{}, { PERF_STACK: '' }, { PERF_STACK: '0' }, { PERF_STACK: 'false' }]) {
+  const label = 'PERF_STACK' in env ? JSON.stringify(env.PERF_STACK) : 'unset'
+  test(`perf stack off (${label}) is a complete no-op: no install, no up, exporter detached`, async () => {
+    const stack = fakePerfStack({ present: [], running: false })
+    let installs = 0
+    let ups = 0
+    const countingRun = (action) => {
+      if (action === 'install') installs += 1
+      if (action === 'up') ups += 1
+      return stack.run(action)
+    }
 
-  const result = await ensurePerfStack({
-    env: { PERF_STACK: '0' },
-    run: countingRun,
-    installIsComplete: stack.installIsComplete,
-    log: silent,
+    const result = await ensurePerfStack({
+      env,
+      run: countingRun,
+      installIsComplete: stack.installIsComplete,
+      log: silent,
+    })
+
+    assert.deepEqual(result, { enabled: false })
+    assert.equal(installs, 0, 'no install subprocess ran')
+    assert.equal(ups, 0, 'no up subprocess ran')
+    assert.equal(stack.world.present.size, 0)
+    assert.equal(stack.world.running, false)
   })
-
-  assert.deepEqual(result, { enabled: false })
-  assert.equal(installs, 0, 'no install subprocess ran')
-  assert.equal(ups, 0, 'no up subprocess ran')
-  assert.equal(stack.world.present.size, 0)
-  assert.equal(stack.world.running, false)
-})
+}
 
 test('honors a caller-provided endpoint and run instance id from env', async () => {
   const stack = fakePerfStack({ present: ALL, running: true })
 
   const result = await ensurePerfStack({
     env: {
+      ...ON,
       VOICETREE_OTLP_ENDPOINT: 'http://localhost:9999',
       VOICETREE_RUN_INSTANCE_ID: 'preset-run',
     },

--- a/webapp/src/shell/edge/main/runtime/electron/app/main.ts
+++ b/webapp/src/shell/edge/main/runtime/electron/app/main.ts
@@ -150,9 +150,10 @@ observabilityMetrics.init('vt-electron-main', {
 tracing.bridgeOwnerDiagnostics(subscribeOwnerDiagnostics, 'vt-electron-daemon');
 
 // Start the perf probe at the tier the launcher selected (ensure-perf-stack sets
-// VOICETREE_PERF_TIER=lite for interactive runs; storm runs set deep; PERF_STACK=0
-// leaves it unset → no-op). Lite emits wall/CPU profiles + runtime metrics — the
-// metrics are what populate the VT Runs dashboard. Electron keeps the event loop
+// VOICETREE_PERF_TIER=lite for interactive runs when PERF_STACK=1; storm runs set
+// deep; the default off-state leaves it unset → no-op). Lite emits wall/CPU
+// profiles + runtime metrics — the metrics are what populate the VT Runs
+// dashboard. Electron keeps the event loop
 // alive so the probe's beforeExit self-stop never fires; we stop it explicitly on
 // will-quit so Pyroscope flushes and the durable log closes.
 let stopPerfProbe: (() => Promise<void>) | undefined;


### PR DESCRIPTION
## Why

A plain `pnpm install && pnpm --filter voicetree-webapp run electron` was silently installing perf-stack binaries and bringing up six resident collector services on every machine. The `ensure-perf-stack` preflight was **default-ON** with an opt-out (`PERF_STACK=0`).

## What

**Flip to default-OFF / opt-in.** The preflight is now a complete no-op unless `PERF_STACK=1` is set — inline on the launch (`PERF_STACK=1 pnpm … run electron`) or as a standing default in `.env`. NDJSON-only is the default; OTLP export + profiling attach only when explicitly requested.

Reuses the existing `PERF_STACK` env var (read identically from `.env` or inline) rather than introducing a new name — smallest, clearest surface.

- `scripts/ensure-perf-stack.mjs` — `perfStackEnabled(env)` opt-in predicate; default path deletes `VOICETREE_OTLP_ENDPOINT`/`VOICETREE_PERF_TIER`.
- `scripts/ensure-perf-stack.test.mjs` — flipped to opt-in; added coverage that absent/empty/`0`/`false` all no-op (12 tests, all pass).
- `infra/perf-stack/README.md`, `main.ts` comment, `.env.example` — docs.

## Incidental fix (separate commit)

Opening this PR surfaced a pre-existing bug that fails the `architecture-drift` health check on **every local push from a worktree**: the pre-push hook leaks `GIT_DIR`, `GIT_WORK_TREE` **and** `GIT_COMMON_DIR`, but `runGitWorktreeCommand` only stripped the first two — so a sandbox `git init` wrote refs to the leaked common dir and died. Now strips the full set of git location-override vars, and the test's own sandbox setup routes through the hardened runner. Unaffected on server-side CI; removes a false local-push failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)