### PR TITLE
fix(terminals): protect fresh status phrase from typed-input clobber

### DIFF
--- a/packages/libraries/vt-daemon-protocol/src/terminal-types.ts
+++ b/packages/libraries/vt-daemon-protocol/src/terminal-types.ts
@@ -109,6 +109,14 @@ export type TerminalData = {
      */
     readonly statusPhrase: string;
     /**
+     * Epoch-ms timestamp of the most recent `statusPhrase` write, or `0` while
+     * the phrase is still its initial empty string. Used to protect a freshly
+     * authored status from being clobbered by typed terminal input: input only
+     * overrides the phrase once the existing one is older than
+     * `STATUS_PHRASE_OVERRIDE_STALENESS_MS` (see `deriveTerminalInputStarted`).
+     */
+    readonly statusPhraseUpdatedAt: number;
+    /**
      * The last status preset the agent *itself* declared this turn (via
      * `create_graph`'s `agentStatus` or `vt agent status`), or `null` if it has
      * not declared one. Distinct from `lifecycle`, which is lossy: an

--- a/packages/systems/vt-daemon/src/agent-runtime/recovery/tests/classifier.test-fixtures.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/recovery/tests/classifier.test-fixtures.ts
@@ -28,6 +28,7 @@ export function makeTerminalData(overrides: Partial<TerminalData> = {}): Termina
         isDone: false,
         lifecycle: 'idle',
         statusPhrase: '',
+        statusPhraseUpdatedAt: 0,
         lastReportedStatus: null,
         lastOutputTime: 0,
         activityCount: 0,

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/core/handleTerminalInputStarted.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/core/handleTerminalInputStarted.test.ts
@@ -1,0 +1,143 @@
+import {describe, it, expect} from 'vitest'
+import {
+    advanceTerminalInputLine,
+    deriveTerminalInputStarted,
+    EMPTY_TERMINAL_INPUT_LINE_BUFFER,
+    statusPhraseFromTerminalInput,
+    STATUS_PHRASE_OVERRIDE_STALENESS_MS,
+    type TerminalInputLineBuffer,
+} from './handleTerminalInputStarted.ts'
+import {createTerminalData} from '../terminal-registry/types.ts'
+import type {TerminalId} from '../terminal-registry/types.ts'
+import type {TerminalRecord} from '../domain/session.ts'
+import type {NodeIdAndFilePath} from '@vt/graph-model/graph'
+
+function makeRecord(overrides: Partial<TerminalRecord['terminalData']> = {}): TerminalRecord {
+    const terminalData = {
+        ...createTerminalData({
+            terminalId: 't1' as TerminalId,
+            attachedToNodeId: '/tmp/ctx.md' as NodeIdAndFilePath,
+            terminalCount: 1,
+            title: 'test',
+            agentName: 'Agent',
+        }),
+        lifecycle: 'idle' as const,
+        ...overrides,
+    }
+    return {
+        terminalId: 't1',
+        terminalData,
+        status: 'running',
+        exitCode: null,
+        exitSignal: null,
+        killReason: null,
+        auditRetryCount: 0,
+        spawnedAt: 0,
+    }
+}
+
+// Feed each character as its own frame, mirroring how a relay forwards raw
+// per-keystroke input.
+function typeCharByChar(text: string): {buffer: TerminalInputLineBuffer; submissions: string[]} {
+    let buffer: TerminalInputLineBuffer = EMPTY_TERMINAL_INPUT_LINE_BUFFER
+    const submissions: string[] = []
+    for (const ch of text) {
+        const step = advanceTerminalInputLine(buffer, ch)
+        buffer = step.buffer
+        if (step.submitted !== null) submissions.push(step.submitted)
+    }
+    return {buffer, submissions}
+}
+
+describe('advanceTerminalInputLine', () => {
+    it('accumulates keystrokes and only submits on Enter (CR)', () => {
+        const {buffer, submissions} = typeCharByChar('review the PR\r')
+        expect(submissions).toEqual(['review the PR'])
+        expect(buffer.pending).toBe('')
+    })
+
+    it('treats LF as Enter too', () => {
+        expect(advanceTerminalInputLine(EMPTY_TERMINAL_INPUT_LINE_BUFFER, 'hi\n')).toEqual({
+            buffer: {pending: ''},
+            submitted: 'hi',
+        })
+    })
+
+    it('does not submit while a line is still being typed', () => {
+        const {buffer, submissions} = typeCharByChar('half typed')
+        expect(submissions).toEqual([])
+        expect(buffer.pending).toBe('half typed')
+    })
+
+    it('handles backspace (DEL/BS) as an edit of the pending line', () => {
+        const {submissions} = typeCharByChar('helxx\x7f\x7flo\r')
+        expect(submissions).toEqual(['hello'])
+    })
+
+    it('carries text typed after Enter into the next buffer', () => {
+        const step = advanceTerminalInputLine({pending: 'first'}, ' line\rnext')
+        expect(step.submitted).toBe('first line')
+        expect(step.buffer.pending).toBe('next')
+    })
+
+    it('joins multiple submitted lines in a single frame (paste)', () => {
+        const step = advanceTerminalInputLine(EMPTY_TERMINAL_INPUT_LINE_BUFFER, 'one\rtwo\r')
+        expect(step.submitted).toBe('one two')
+        expect(step.buffer.pending).toBe('')
+    })
+
+    it('a bare Enter is a submission of empty string, not null', () => {
+        expect(advanceTerminalInputLine(EMPTY_TERMINAL_INPUT_LINE_BUFFER, '\r').submitted).toBe('')
+    })
+})
+
+describe('statusPhraseFromTerminalInput', () => {
+    it('keeps only letters, collapsing the rest to single spaces', () => {
+        expect(statusPhraseFromTerminalInput('[From: Bob] ship fix/x? 123')).toBe('From Bob ship fix x')
+    })
+})
+
+describe('deriveTerminalInputStarted — phrase staleness', () => {
+    it('overrides an empty phrase immediately', () => {
+        const record = makeRecord({statusPhrase: '', statusPhraseUpdatedAt: 0})
+        const result = deriveTerminalInputStarted(record, 'fix the bug', 1_000)
+        expect(result.record.terminalData.statusPhrase).toBe('fix the bug')
+        expect(result.record.terminalData.statusPhraseUpdatedAt).toBe(1_000)
+    })
+
+    it('protects a phrase younger than the staleness window', () => {
+        const record = makeRecord({statusPhrase: 'opened PR', statusPhraseUpdatedAt: 1_000})
+        const result = deriveTerminalInputStarted(
+            record,
+            'something new',
+            1_000 + STATUS_PHRASE_OVERRIDE_STALENESS_MS - 1,
+        )
+        expect(result.record.terminalData.statusPhrase).toBe('opened PR')
+        // Turn state still resets even when the phrase is preserved.
+        expect(result.record.terminalData.lifecycle).toBe('active')
+        expect(result.record.terminalData.isDone).toBe(false)
+    })
+
+    it('overrides a phrase at/after the staleness window', () => {
+        const record = makeRecord({statusPhrase: 'opened PR', statusPhraseUpdatedAt: 1_000})
+        const result = deriveTerminalInputStarted(
+            record,
+            'review feedback',
+            1_000 + STATUS_PHRASE_OVERRIDE_STALENESS_MS,
+        )
+        expect(result.record.terminalData.statusPhrase).toBe('review feedback')
+    })
+
+    it('never overrides a phrase with letter-free input', () => {
+        const record = makeRecord({statusPhrase: 'opened PR', statusPhraseUpdatedAt: 0})
+        const result = deriveTerminalInputStarted(record, '123 !!!', 10 * 60_000)
+        expect(result.record.terminalData.statusPhrase).toBe('opened PR')
+    })
+
+    it('is a no-op for an exited terminal', () => {
+        const record = {...makeRecord(), status: 'exited' as const}
+        const result = deriveTerminalInputStarted(record, 'too late', 10 * 60_000)
+        expect(result.changed).toBe(false)
+        expect(result.record).toBe(record)
+    })
+})

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/core/handleTerminalInputStarted.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/core/handleTerminalInputStarted.ts
@@ -41,9 +41,13 @@ export function statusPhraseFromTerminalInput(inputText: string): string {
  * the submit bytes `send-text-to-terminal` writes (`\r`, and `\x1b\r` for
  * Alt+Enter — the `\x1b` is consumed as an ordinary, non-Enter character here).
  */
-const ENTER_CHARS: ReadonlySet<string> = new Set(['\r', '\n'])
+const ENTER_CHARS = ['\r', '\n'] as const
 /** DEL (`\x7f`) and BS (`\x08`) — so an in-line correction edits the buffer. */
-const BACKSPACE_CHARS: ReadonlySet<string> = new Set(['\x7f', '\x08'])
+const BACKSPACE_CHARS = ['\x7f', '\x08'] as const
+
+function includesChar(chars: readonly string[], ch: string): boolean {
+    return chars.includes(ch)
+}
 
 export type TerminalInputLineBuffer = {readonly pending: string}
 
@@ -67,10 +71,10 @@ export function advanceTerminalInputLine(
     let pending: string = buffer.pending
     const completed: string[] = []
     for (const ch of payload) {
-        if (ENTER_CHARS.has(ch)) {
+        if (includesChar(ENTER_CHARS, ch)) {
             completed.push(pending)
             pending = ''
-        } else if (BACKSPACE_CHARS.has(ch)) {
+        } else if (includesChar(BACKSPACE_CHARS, ch)) {
             pending = pending.slice(0, -1)
         } else {
             pending += ch

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/core/handleTerminalInputStarted.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/core/handleTerminalInputStarted.ts
@@ -1,6 +1,15 @@
 import {MAX_STATUS_PHRASE_LENGTH, type TerminalRecordPatch} from '@vt/vt-daemon-protocol'
 import type {TerminalRecord} from '../domain/session.ts'
 
+/**
+ * How long an agent-authored status phrase is protected from being overwritten
+ * by text typed into (or injected into) the terminal. Within this window the
+ * carefully-written phrase wins; only once it is older than this does typed
+ * input replace it. Keeps a human glancing at the tree from seeing a status the
+ * agent just wrote get clobbered the instant someone resumes the terminal.
+ */
+export const STATUS_PHRASE_OVERRIDE_STALENESS_MS = 5 * 60_000
+
 export type TerminalInputStartedResult = {
     readonly changed: boolean
     readonly patches: readonly TerminalRecordPatch[]
@@ -15,15 +24,90 @@ export function statusPhraseFromTerminalInput(inputText: string): string {
         .slice(0, MAX_STATUS_PHRASE_LENGTH)
 }
 
+// ---------------------------------------------------------------------------
+// Typed-line accumulation
+//
+// A terminal relay forwards raw keystrokes one frame at a time, so a human
+// typing "review the PR" then Enter arrives as the frames 'r','e','v',… ,'\r'.
+// Updating the status on every frame would leave it showing a single trailing
+// character. `advanceTerminalInputLine` buffers those keystrokes and only emits
+// a completed line once an Enter (CR/LF) is seen, so the status reflects the
+// whole submitted message rather than a mid-typing fragment.
+// ---------------------------------------------------------------------------
+
+/**
+ * Enter symbols. A human Enter in the renderer's xterm arrives as CR (`\r`);
+ * LF (`\n`) covers pasted newlines and alternative line endings. This matches
+ * the submit bytes `send-text-to-terminal` writes (`\r`, and `\x1b\r` for
+ * Alt+Enter — the `\x1b` is consumed as an ordinary, non-Enter character here).
+ */
+const ENTER_CHARS: ReadonlySet<string> = new Set(['\r', '\n'])
+/** DEL (`\x7f`) and BS (`\x08`) — so an in-line correction edits the buffer. */
+const BACKSPACE_CHARS: ReadonlySet<string> = new Set(['\x7f', '\x08'])
+
+export type TerminalInputLineBuffer = {readonly pending: string}
+
+export const EMPTY_TERMINAL_INPUT_LINE_BUFFER: TerminalInputLineBuffer = {pending: ''}
+
+export type TerminalInputLineStep = {
+    /** Buffer carried to the next frame (text typed after the last Enter). */
+    readonly buffer: TerminalInputLineBuffer
+    /**
+     * The completed line to treat as a submission, or `null` if this frame
+     * contained no Enter and we are still accumulating. Empty string is a valid
+     * submission (a bare Enter) — distinct from `null`.
+     */
+    readonly submitted: string | null
+}
+
+export function advanceTerminalInputLine(
+    buffer: TerminalInputLineBuffer,
+    payload: string,
+): TerminalInputLineStep {
+    let pending: string = buffer.pending
+    const completed: string[] = []
+    for (const ch of payload) {
+        if (ENTER_CHARS.has(ch)) {
+            completed.push(pending)
+            pending = ''
+        } else if (BACKSPACE_CHARS.has(ch)) {
+            pending = pending.slice(0, -1)
+        } else {
+            pending += ch
+        }
+    }
+    if (completed.length === 0) {
+        return {buffer: {pending}, submitted: null}
+    }
+    return {buffer: {pending}, submitted: completed.join(' ')}
+}
+
 export function deriveTerminalInputStarted(
     record: TerminalRecord,
     inputText: string,
+    nowMs: number,
 ): TerminalInputStartedResult {
     if (record.status === 'exited') {
         return {changed: false, patches: [], record}
     }
 
-    const nextPhrase: string = statusPhraseFromTerminalInput(inputText)
+    // Typed input always reactivates the turn — the agent is being resumed, so
+    // it is no longer done and re-enters `active`, clearing any preset it
+    // declared on the previous turn. This is independent of whether we also
+    // adopt the input as the new status phrase.
+    //
+    // The phrase, by contrast, is only overwritten when the existing one is
+    // "spent": empty (never set), or older than the staleness window. A phrase
+    // the agent wrote moments ago is left untouched so a resume does not erase
+    // it. A blank derived phrase (input with no letters) never overwrites.
+    const existingPhrase: string = record.terminalData.statusPhrase
+    const phraseIsStale: boolean =
+        existingPhrase === '' ||
+        nowMs - record.terminalData.statusPhraseUpdatedAt >= STATUS_PHRASE_OVERRIDE_STALENESS_MS
+    const candidatePhrase: string = statusPhraseFromTerminalInput(inputText)
+    const overridePhrase: boolean = phraseIsStale && candidatePhrase.length > 0
+    const nextPhrase: string = overridePhrase ? candidatePhrase : existingPhrase
+
     const nextRecord: TerminalRecord = {
         ...record,
         terminalData: {
@@ -32,6 +116,7 @@ export function deriveTerminalInputStarted(
             isDone: false,
             lastReportedStatus: null,
             statusPhrase: nextPhrase,
+            statusPhraseUpdatedAt: overridePhrase ? nowMs : record.terminalData.statusPhraseUpdatedAt,
         },
     }
 
@@ -42,7 +127,7 @@ export function deriveTerminalInputStarted(
     if (record.terminalData.lifecycle !== 'active') {
         patches.push({kind: 'lifecycle', value: 'active'})
     }
-    if (record.terminalData.statusPhrase !== nextPhrase) {
+    if (overridePhrase && nextPhrase !== existingPhrase) {
         patches.push({kind: 'statusPhrase', value: nextPhrase})
     }
 

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/relay/tests/tmux-attach-relay.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/relay/tests/tmux-attach-relay.test.ts
@@ -285,9 +285,11 @@ describe('tmux attach relay', () => {
             ws.send(JSON.stringify({type: 'input', payload: 'BF312_INPUT_STARTED\r'}))
             await waitForOutput(output, 'ECHO:BF312_INPUT_STARTED')
 
+            // The relay accumulates keystrokes and emits the completed line on
+            // Enter, so the mark carries the submitted text without the CR.
             expect(marks).toEqual([{
                 terminalId: sessionName,
-                inputText: 'BF312_INPUT_STARTED\r',
+                inputText: 'BF312_INPUT_STARTED',
             }])
         } finally {
             ws.close()

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/relay/tmux-attach-relay.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/relay/tmux-attach-relay.ts
@@ -4,7 +4,12 @@ import type {IPty} from 'node-pty'
 import {WebSocket} from 'ws'
 import {getTmuxBinaryPath, getTmuxCommandArgs} from '../tmux/tmux-server'
 import {hasSession, resolveTmuxSessionName} from '../tmux/tmux-session-manager'
-import {markTerminalInputStarted} from '../terminal-registry/lifecycle.ts'
+import {
+    advanceTerminalInputLine,
+    EMPTY_TERMINAL_INPUT_LINE_BUFFER,
+    markTerminalInputStarted,
+    type TerminalInputLineBuffer,
+} from '../terminal-registry/lifecycle.ts'
 
 const DEFAULT_COLS: 120 = 120
 const DEFAULT_ROWS: 40 = 40
@@ -260,6 +265,10 @@ export async function attachTmuxSessionToWebSocket(
 
     const pendingWrites: string[] = []
     const writeState: {flushing: boolean} = {flushing: false}
+    // Accumulates the user's keystrokes for this attachment so the terminal's
+    // live status is only updated once a full line is submitted (Enter), not on
+    // every partial keystroke frame.
+    let inputLineBuffer: TerminalInputLineBuffer = EMPTY_TERMINAL_INPUT_LINE_BUFFER
 
     term.onData((payload: string): void => sendData(ws, payload))
     term.onExit(({exitCode}: {readonly exitCode: number}): void => {
@@ -278,8 +287,15 @@ export async function attachTmuxSessionToWebSocket(
 
         if ((record.type === 'input' || record.type === 'data') && typeof record.payload === 'string') {
             const payload: string = record.payload
-            const markInputStarted = options.markInputStarted ?? markTerminalInputStarted
-            markInputStarted(parsed.sessionName, payload)
+            // Every keystroke is forwarded to the pty so typing/echo is
+            // unaffected; the status, though, is only refreshed once Enter
+            // completes a line (see `advanceTerminalInputLine`).
+            const step = advanceTerminalInputLine(inputLineBuffer, payload)
+            inputLineBuffer = step.buffer
+            if (step.submitted !== null) {
+                const markInputStarted = options.markInputStarted ?? markTerminalInputStarted
+                markInputStarted(parsed.sessionName, step.submitted)
+            }
             enqueuePacedInput(term, pendingWrites, writeState, payload)
             return
         }

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/terminal-registry/lifecycle.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/terminal-registry/lifecycle.ts
@@ -2,6 +2,15 @@ import {classifyExit} from '@vt/vt-daemon/agent-runtime/lifecycle'
 import {recordTierEvent} from '@vt/vt-daemon/agent-runtime/lifecycle'
 import type {TerminalLifecycle, TerminalKillReason} from '@vt/vt-daemon/agent-runtime/lifecycle'
 import {deriveTerminalInputStarted} from '../core/handleTerminalInputStarted.ts'
+// Re-exported as part of the terminal-registry input surface: the tmux relay
+// accumulates raw keystrokes with these before handing a completed line to
+// `markTerminalInputStarted`, so it depends on this surface rather than reaching
+// into the core handler module directly.
+export {
+    advanceTerminalInputLine,
+    EMPTY_TERMINAL_INPUT_LINE_BUFFER,
+    type TerminalInputLineBuffer,
+} from '../core/handleTerminalInputStarted.ts'
 import {updateTerminalIsDoneWorkflow} from '../workflows/terminalIsDone.ts'
 import {
     hasActiveChildren,
@@ -46,11 +55,15 @@ export function updateTerminalIsDone(
     updateTerminalIsDoneWorkflow(terminalId, isDone, runtime)
 }
 
-export function markTerminalInputStarted(terminalId: string, inputText: string): void {
+export function markTerminalInputStarted(
+    terminalId: string,
+    inputText: string,
+    nowMs: number = Date.now(),
+): void {
     const record: TerminalRecord | undefined = terminalRecords.get(terminalId)
     if (!record) return
 
-    const result = deriveTerminalInputStarted(record, inputText)
+    const result = deriveTerminalInputStarted(record, inputText, nowMs)
     if (!result.changed) return
 
     terminalRecords.set(terminalId, result.record)
@@ -181,7 +194,7 @@ export function applyAgentStatus(terminalId: string, update: AgentStatusUpdate):
         terminalData: {
             ...record.terminalData,
             ...(lifecycleChanged ? {lifecycle: nextLifecycle} : {}),
-            ...(phraseChanged ? {statusPhrase: nextPhrase} : {}),
+            ...(phraseChanged ? {statusPhrase: nextPhrase, statusPhraseUpdatedAt: Date.now()} : {}),
             ...(reportedStatusChanged ? {lastReportedStatus: nextReportedStatus} : {}),
         },
     })

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/terminal-registry/types.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/terminal-registry/types.ts
@@ -53,6 +53,7 @@ export function createTerminalData(
         isDone: false,
         lifecycle: 'spawning',
         statusPhrase: '',
+        statusPhraseUpdatedAt: 0,
         lastReportedStatus: null,
         lastOutputTime: now(),
         activityCount: 0,

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/tests/terminal-registry.lifecycle.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/tests/terminal-registry.lifecycle.test.ts
@@ -268,7 +268,7 @@ describe('terminal-registry lifecycle wiring', () => {
     });
 
     describe('markTerminalInputStarted - new user/agent turn reset', () => {
-        it('reactivates a running terminal that previously reported done', () => {
+        it('reactivates a running terminal but preserves a freshly-authored phrase', () => {
             spawn('t1');
             updateTerminalIsDone('t1', true);
             applyAgentStatus('t1', {preset: 'done', phrase: 'opened PR #273'});
@@ -278,15 +278,58 @@ describe('terminal-registry lifecycle wiring', () => {
             expect(lifecycleOf('t1')).toBe('active');
             expect(isDoneOf('t1')).toBe(false);
             expect(lastReportedStatusOf('t1')).toBeNull();
-            expect(statusPhraseOf('t1')).toBe('please review PR');
+            // The agent wrote 'opened PR #273' moments ago, so the resume must
+            // NOT clobber it — only the turn state resets.
+            expect(statusPhraseOf('t1')).toBe('opened PR #273');
         });
 
-        it('uses a readable letter-only phrase from the input text', () => {
+        it('overrides a phrase older than the staleness window', () => {
+            vi.useFakeTimers();
+            try {
+                vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+                spawn('t1');
+                applyAgentStatus('t1', {preset: 'working', phrase: 'opened PR #273'});
+
+                vi.advanceTimersByTime(5 * 60_000 + 1);
+                markTerminalInputStarted('t1', 'please review PR #273!');
+
+                expect(statusPhraseOf('t1')).toBe('please review PR');
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('protects a phrase that is still within the staleness window', () => {
+            vi.useFakeTimers();
+            try {
+                vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+                spawn('t1');
+                applyAgentStatus('t1', {preset: 'working', phrase: 'opened PR #273'});
+
+                vi.advanceTimersByTime(5 * 60_000 - 1);
+                markTerminalInputStarted('t1', 'please review PR #273!');
+
+                expect(statusPhraseOf('t1')).toBe('opened PR #273');
+                expect(lifecycleOf('t1')).toBe('active');
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('uses a readable letter-only phrase when there is no phrase to protect', () => {
             spawn('t1');
 
             markTerminalInputStarted('t1', '[From: Bob] ship fix/status-reset-on-input? 123');
 
             expect(statusPhraseOf('t1')).toBe('From Bob ship fix status reset on input');
+        });
+
+        it('never overrides a phrase with empty input (no letters)', () => {
+            spawn('t1');
+
+            markTerminalInputStarted('t1', '12345 !@#$', 10 * 60_000);
+
+            expect(statusPhraseOf('t1')).toBe('');
         });
 
         it('does not reactivate a process that has actually exited', () => {


### PR DESCRIPTION
Typed terminal input previously overwrote a terminal's live status phrase on
every keystroke frame, instantly erasing a status the agent had just authored
and leaving a one-character fragment behind.

Two fixes:
- deriveTerminalInputStarted now only adopts typed input as the status phrase
  when the existing phrase is empty or older than STATUS_PHRASE_OVERRIDE_
  STALENESS_MS (5 min); a fresh agent-authored phrase is preserved. The turn
  still reactivates (active / not-done / cleared preset) regardless. Records
  carry a statusPhraseUpdatedAt timestamp (set by applyAgentStatus and on
  override) to drive the staleness check.
- The tmux relay accumulates raw keystrokes per attachment and only marks input
  started once Enter (CR/LF) completes a line, so the status reflects the whole
  submitted message instead of a partial keystroke. The relay depends on the
  terminal-registry input surface (lifecycle.ts re-exports advanceTerminalInputLine)
  rather than reaching into the core handler module directly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
