### PR TITLE
Strengthen agent wait stop guidance

### DIFF
--- a/packages/libraries/vt-daemon-protocol/src/tool-specs.ts
+++ b/packages/libraries/vt-daemon-protocol/src/tool-specs.ts
@@ -127,7 +127,7 @@ export const AGENT_WAIT_SPEC: ToolSpec = {
     description: [
         'Wait for specified agent terminals to complete. Returns immediately with a `monitorId`. The monitor polls in the background and sends a completion message to your terminal when all agents are done.',
         '',
-        '**IMPORTANT:** This tool is non-blocking. After calling it, continue with other work or inform the user you are waiting. Do NOT manually poll agent status — a `[WaitForAgents] Agent(s) completed.` message will be automatically injected into your terminal when all agents finish. You will see this message appear as if the user sent it.',
+        '**IMPORTANT:** This tool is non-blocking. After calling it, do not poll, inspect output, or take further action on these agents; end your turn and wait for the automatic completion notification. A `[WaitForAgents] Agent(s) completed.` message will be automatically injected into your terminal when all agents finish. You will see this message appear as if the user sent it.',
         '',
         '**NOTE:** `vt agent spawn` now auto-starts a monitor, so you only need `vt agent wait` for explicit multi-agent waits or custom polling intervals.',
     ].join('\n'),

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/tools/waitForAgentsTool.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/tools/waitForAgentsTool.test.ts
@@ -11,19 +11,46 @@
 // is touched, so we pass an unused bridge stub. Per CLAUDE.md we assert on the
 // observable result, not on whether any internal function was called.
 
-import {describe, expect, it} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
 
 import type {GraphBridge} from '@vt/vt-daemon/config/toolBridges.ts'
+import {cancelMonitor} from '../agent-completion-monitor.ts'
+import {
+    clearTerminalRecords,
+    recordTerminalSpawn,
+} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry'
+import {createTerminalData} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/types.ts'
 import {waitForAgentsTool} from './waitForAgentsTool.ts'
 
 // The bridge is never reached on the unknown-caller path; a stub documents that.
 const unusedBridge: GraphBridge = {} as unknown as GraphBridge
+const STOP_INSTRUCTION =
+    'Do not poll, inspect output, or take further action on these agents; end your turn now and wait for the automatic completion notification that will be sent back to you.'
 
 function parsePayload(response: {content: Array<{text: string}>}): unknown {
     return JSON.parse(response.content[0]?.text ?? 'null')
 }
 
-describe('waitForAgentsTool — caller validation', () => {
+function spawnTerminal(terminalId: string): void {
+    recordTerminalSpawn(terminalId, createTerminalData({
+        terminalId,
+        attachedToNodeId: `/tmp/${terminalId}.md`,
+        terminalCount: 1,
+        title: terminalId,
+        agentName: terminalId,
+        parentTerminalId: null,
+    }))
+}
+
+describe('waitForAgentsTool', () => {
+    beforeEach(() => {
+        clearTerminalRecords()
+    })
+
+    afterEach(() => {
+        clearTerminalRecords()
+    })
+
     it('unknown caller terminal: returns an error payload with the family-standard wording', () => {
         const response = waitForAgentsTool(
             {terminalIds: ['target-1'], callerTerminalId: 'caller-does-not-exist'},
@@ -34,5 +61,43 @@ describe('waitForAgentsTool — caller validation', () => {
         const payload = parsePayload(response) as {success: boolean; error: string}
         expect(payload.success).toBe(false)
         expect(payload.error).toBe('Unknown caller terminal: caller-does-not-exist')
+    })
+
+    it('monitoring response instructs the caller to end the turn and wait for notification', () => {
+        spawnTerminal('caller')
+        spawnTerminal('target')
+
+        const response = waitForAgentsTool(
+            {terminalIds: ['target'], callerTerminalId: 'caller', pollIntervalMs: 1_000_000},
+            unusedBridge,
+        )
+
+        const payload = parsePayload(response) as {status: string; message: string; monitorId: string}
+        cancelMonitor(payload.monitorId)
+        expect(payload.status).toBe('monitoring')
+        expect(payload.message).toContain(STOP_INSTRUCTION)
+        expect(payload.message).not.toContain('You are free to continue other work now')
+        expect(payload.message.endsWith(STOP_INSTRUCTION)).toBe(true)
+    })
+
+    it('already-waiting response repeats the same stop-and-wait instruction', () => {
+        spawnTerminal('caller')
+        spawnTerminal('target')
+
+        const firstResponse = waitForAgentsTool(
+            {terminalIds: ['target'], callerTerminalId: 'caller', pollIntervalMs: 1_000_000},
+            unusedBridge,
+        )
+        const firstPayload = parsePayload(firstResponse) as {monitorId: string}
+
+        const secondResponse = waitForAgentsTool(
+            {terminalIds: ['target'], callerTerminalId: 'caller', pollIntervalMs: 1_000_000},
+            unusedBridge,
+        )
+
+        cancelMonitor(firstPayload.monitorId)
+        const secondPayload = parsePayload(secondResponse) as {status: string; message: string}
+        expect(secondPayload.status).toBe('already_waiting')
+        expect(secondPayload.message).toContain(STOP_INSTRUCTION)
     })
 })

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/tools/waitForAgentsTool.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/tools/waitForAgentsTool.ts
@@ -12,6 +12,9 @@ import {
 import type {GraphBridge} from '@vt/vt-daemon/config/toolBridges.ts'
 import {listTerminalRecords, type TerminalRecord} from '../agentControlRuntime'
 
+const WAIT_FOR_AGENTS_STOP_INSTRUCTION =
+    'Do not poll, inspect output, or take further action on these agents; end your turn now and wait for the automatic completion notification that will be sent back to you.'
+
 export interface WaitForAgentsParams {
     terminalIds: string[]
     callerTerminalId: string
@@ -51,7 +54,7 @@ export function waitForAgentsTool(
         return buildJsonResponse({
             status: 'already_waiting',
             terminalIds,
-            message: `Already waiting on ${alreadyWaitingOn.length} terminal(s): ${alreadyWaitingOn.join(', ')}. No new monitor started.`,
+            message: `Already waiting on ${alreadyWaitingOn.length} terminal(s): ${alreadyWaitingOn.join(', ')}. No new monitor started. ${WAIT_FOR_AGENTS_STOP_INSTRUCTION}`,
         })
     }
 
@@ -67,6 +70,6 @@ export function waitForAgentsTool(
         monitorId,
         status: 'monitoring',
         terminalIds: targetTerminalIds,
-        message: `Background monitor started (${monitorId}). You do NOT need to poll or check on these agents — a completion message will be automatically injected into your terminal when all ${targetTerminalIds.length} agent(s) finish. You are free to continue other work now. When agents complete, you will receive a "[WaitForAgents] Agent(s) completed." message with details about each agent's status and the nodes they created. ${messageSuffix}`,
+        message: `Background monitor started (${monitorId}). ${messageSuffix ? `${messageSuffix} ` : ''}${WAIT_FOR_AGENTS_STOP_INSTRUCTION}`,
     })
 }


### PR DESCRIPTION
## Summary
- make vt agent wait monitoring responses explicitly tell agents to stop and wait for the automatic completion notification
- apply the same instruction when a monitor is already active
- update tool-spec guidance and add regression coverage

## Verification
- pnpm --filter @vt/vt-daemon exec vitest run src/agent-runtime/agent-control/tools/waitForAgentsTool.test.ts
- pnpm --filter @vt/vt-daemon run typecheck
- git push pre-push tier-1 checks passed

Note: full @vt/vt-daemon test run had unrelated stale remote-worktree fixture failures under /root/vt-wts/wt-* before push; focused coverage, typecheck, and pre-push passed.