### PR TITLE
Fix packaged agent terminal spawn crashes

### DIFF
--- a/packages/systems/vt-daemon/src/agent-runtime/headless/tests/tmuxPromptFile.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/headless/tests/tmuxPromptFile.test.ts
@@ -10,12 +10,14 @@ import {join} from 'node:path'
 import {describe, expect, it, beforeEach, afterEach} from 'vitest'
 import type {TerminalId} from '@vt/vt-daemon/agent-runtime/terminals/terminal-registry/types.ts'
 import {
+    applyPromptFileToInteractiveSpawn,
     applyPromptFileToHeadlessSpawn,
     applyPromptFileToTmuxSpawn,
     deletePromptFile,
     deletePromptFileByPath,
     formatLaunchScript,
     promptFilePath,
+    rewriteInteractiveCommandForPromptFile,
     rewriteCommandForPromptFile,
     wrapForHeadlessTmux,
     writePromptFile,
@@ -136,6 +138,26 @@ describe('rewriteCommandForPromptFile (CLI-aware)', () => {
     })
 })
 
+describe('rewriteInteractiveCommandForPromptFile (TTY-preserving)', () => {
+    it('claude: strips $AGENT_PROMPT positional and uses cat substitution without redirecting stdin', () => {
+        const out: string = rewriteInteractiveCommandForPromptFile(
+            'claude --dangerously-skip-permissions "$AGENT_PROMPT" --disallowedTools AskUserQuestion',
+            '/v/.voicetree/terminals/Aki-prompt.txt',
+        )
+        expect(out).toBe(
+            `claude --dangerously-skip-permissions "$(cat '/v/.voicetree/terminals/Aki-prompt.txt')" --disallowedTools AskUserQuestion`,
+        )
+    })
+
+    it('gemini: uses cat substitution so the process keeps terminal stdin', () => {
+        const out: string = rewriteInteractiveCommandForPromptFile(
+            'gemini --yolo "$AGENT_PROMPT"',
+            '/v/x.txt',
+        )
+        expect(out).toBe(`gemini --yolo "$(cat '/v/x.txt')"`)
+    })
+})
+
 describe('wrapForHeadlessTmux', () => {
     it("wraps in bash -c '...' to unset AGENT_PROMPT and run the command", () => {
         const out: string = wrapForHeadlessTmux(`claude --print < '/v/p.txt'`)
@@ -209,6 +231,47 @@ describe('applyPromptFileToTmuxSpawn (mode-agnostic primitive)', () => {
         // to disk rather than staying in env.
         const envBytes: number = JSON.stringify(plan.env).length
         expect(envBytes).toBeLessThan(2_000)
+    })
+})
+
+describe('applyPromptFileToInteractiveSpawn', () => {
+    it('writes the prompt and rewrites Claude to read it through argv substitution while keeping stdin as the TTY', () => {
+        const plan = applyPromptFileToInteractiveSpawn({
+            projectRoot: project,
+            terminalId: tid('Aki'),
+            command: 'claude "$AGENT_PROMPT"',
+            env: {AGENT_PROMPT: 'task body', VOICETREE_TERMINAL_ID: 'Aki'},
+        })
+        expect(plan.promptFilePath).toBe(promptFilePath(project, tid('Aki')))
+        expect(readFileSync(plan.promptFilePath!, 'utf8')).toBe('task body')
+        expect(plan.command).toBe(`claude "$(cat '${plan.promptFilePath}')"`)
+        expect(plan.env.AGENT_PROMPT).toBe('')
+        expect(plan.env.AGENT_PROMPT_FILE).toBe(plan.promptFilePath)
+        expect(plan.env.VOICETREE_TERMINAL_ID).toBe('Aki')
+    })
+
+    it('preserves argument order around options that follow the prompt', () => {
+        const plan = applyPromptFileToInteractiveSpawn({
+            projectRoot: project,
+            terminalId: tid('Aki'),
+            command: 'claude --dangerously-skip-permissions "$AGENT_PROMPT" --disallowedTools AskUserQuestion',
+            env: {AGENT_PROMPT: 'task body', VOICETREE_TERMINAL_ID: 'Aki'},
+        })
+        expect(plan.command).toBe(
+            `claude --dangerously-skip-permissions "$(cat '${plan.promptFilePath}')" --disallowedTools AskUserQuestion`,
+        )
+    })
+
+    it('is a no-op when env has no AGENT_PROMPT', () => {
+        const plan = applyPromptFileToInteractiveSpawn({
+            projectRoot: project,
+            terminalId: tid('Aki'),
+            command: 'bash',
+            env: {VOICETREE_TERMINAL_ID: 'Aki'},
+        })
+        expect(plan.promptFilePath).toBeNull()
+        expect(plan.command).toBe('bash')
+        expect(plan.env).toEqual({VOICETREE_TERMINAL_ID: 'Aki'})
     })
 })
 

--- a/packages/systems/vt-daemon/src/agent-runtime/headless/tmuxPromptFile.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/headless/tmuxPromptFile.ts
@@ -7,7 +7,9 @@
  *   1. Writes the prompt to `{project}/.voicetree/terminals/{name}-prompt.txt`
  *      (mode 0600). The big string never crosses tmux's argv.
  *   2. Rewrites the agent invocation to consume the file:
- *        - claude / gemini → stdin redirection (`< {file}`)
+ *        - headless claude / gemini → stdin redirection (`< {file}`)
+ *        - interactive claude / gemini / codex → argv via `"$(cat {file})"`
+ *          so the agent keeps its TTY for further interaction
  *        - codex          → argv via `"$(cat {file})"` (positional)
  *        - other (fake)   → no argv rewrite; the agent reads
  *                           `AGENT_PROMPT_FILE` from env (see fake-agent).
@@ -88,6 +90,19 @@ function stripPositionalPromptArg(command: string): string {
     return stripped.replace(/\s+/g, ' ').trim()
 }
 
+function replacePositionalPromptArg(command: string, replacement: string): string {
+    let rewritten: string = command
+    let changed: boolean = false
+    for (const pattern of positionalPromptPatterns()) {
+        rewritten = rewritten.replace(pattern, (): string => {
+            changed = true
+            return ` ${replacement}`
+        })
+    }
+    if (!changed) return `${stripPositionalPromptArg(command)} ${replacement}`.replace(/\s+/g, ' ').trim()
+    return rewritten.replace(/\s+/g, ' ').trim()
+}
+
 /**
  * Rewrite the agent invocation to consume the prompt from `promptFile`.
  * CLI-aware: stdin for claude/gemini, `$(cat ...)` argv for codex, env-only for the rest.
@@ -105,6 +120,26 @@ export function rewriteCommandForPromptFile(command: string, promptFile: string)
     }
     // Unknown CLI (e.g. fake-agent): the agent must read AGENT_PROMPT_FILE
     // from env. Return the stripped command so argv stays short.
+    return stripped
+}
+
+function promptFileArg(promptFile: string): string {
+    return `"$(cat ${shellSingleQuote(promptFile)})"`
+}
+
+/**
+ * Rewrite a command for an interactive/headful terminal. Unlike the headless
+ * path, do not redirect stdin for Claude/Gemini: that makes the agent process
+ * consume a file instead of the terminal and can cause immediate exit. The
+ * shell reads the prompt file at launch time, while the CLI keeps its TTY.
+ */
+export function rewriteInteractiveCommandForPromptFile(command: string, promptFile: string): string {
+    const stripped: string = stripPositionalPromptArg(command)
+    const cli: SupportedHeadlessCli | null = detectCliType(stripped)
+
+    if (cli === 'claude' || cli === 'gemini' || cli === 'codex') {
+        return replacePositionalPromptArg(command, promptFileArg(promptFile))
+    }
     return stripped
 }
 
@@ -162,6 +197,26 @@ export function applyPromptFileToTmuxSpawn(args: {
     }
     const filePath: string = writePromptFile(args.projectRoot, args.terminalId, prompt)
     const rewritten: string = rewriteCommandForPromptFile(args.command, filePath)
+    const {AGENT_PROMPT: _drop, ...rest} = args.env
+    return {
+        command: rewritten,
+        env: {...rest, AGENT_PROMPT: '', AGENT_PROMPT_FILE: filePath},
+        promptFilePath: filePath,
+    }
+}
+
+export function applyPromptFileToInteractiveSpawn(args: {
+    readonly projectRoot: string
+    readonly terminalId: TerminalId
+    readonly command: string
+    readonly env: Record<string, string>
+}): PromptFileSpawnPlan {
+    const prompt: string | undefined = args.env.AGENT_PROMPT
+    if (!prompt) {
+        return {command: args.command, env: args.env, promptFilePath: null}
+    }
+    const filePath: string = writePromptFile(args.projectRoot, args.terminalId, prompt)
+    const rewritten: string = rewriteInteractiveCommandForPromptFile(args.command, filePath)
     const {AGENT_PROMPT: _drop, ...rest} = args.env
     return {
         command: rewritten,

--- a/packages/systems/vt-daemon/src/agent-runtime/spawn/buildTerminalEnvVars.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/spawn/buildTerminalEnvVars.ts
@@ -10,7 +10,12 @@ import {getRuntimeEnv, getGraphBridge} from '../runtime/runtime-config'
 import {getProjectDotVoicetreePath, resolveVoicetreeHomePath} from '@vt/paths'
 import {getRuntimeProjectRoot, getRuntimeProjectPaths} from '../runtime/graph-bridge'
 import {appendCliDiscoveryToAgentPrompt} from './injection/cliManualInjection'
-import {prependVtBinToPath, prependHomeBinToPath, readVtBinDirOrNull} from './injection/vtPathInjection'
+import {
+    inheritExecutablePathIfMissing,
+    prependVtBinToPath,
+    prependHomeBinToPath,
+    readVtBinDirOrNull,
+} from './injection/vtPathInjection'
 import {readDaemonPortFromProject} from './daemonUrlFile'
 import {promises as fs} from 'fs'
 import type {Dirent} from 'fs'
@@ -63,8 +68,8 @@ export async function buildTerminalEnvVars(params: {
     // AGENT_PROMPT_* templates are .md files in the single per-machine prompts
     // location ~/.voicetree/prompts (NO per-project prompts dir) — symlinks to the
     // canonical shipped source, kept in sync at daemon/Electron startup. A file is
-    // authoritative over any settings value of the same name; persisted settings
-    // prune these reserved keys so stale UI values cannot shadow the files.
+    // authoritative over any settings default of the same name; a settings value
+    // only applies when no file exists (e.g. a test that blanks the prompt).
     // --prompt-template selects which one becomes AGENT_PROMPT.
     const voicetreePromptsDir: string = path.join(voicetreeHomePath, 'prompts')
     const promptTemplates: Record<string, string> = await readPromptTemplates(voicetreePromptsDir)
@@ -99,9 +104,10 @@ export async function buildTerminalEnvVars(params: {
     const withCliDiscovery: Record<string, string> = appendCliDiscoveryToAgentPrompt(filtered)
     const withPersona: Record<string, string> = appendPersonaToAgentPrompt(withCliDiscovery, params.agentName, params.settings)
     const vtBinDir: string | null = await readVtBinDirOrNull()
+    const withInheritedPath: Record<string, string> = inheritExecutablePathIfMissing(withPersona, process.env.PATH)
     // $HOME/bin is prepended first so the daemon's vt-bin can sit in front of it.
     // Final order: vtBinDir : $HOME/bin : ...inherited PATH
-    const withHomeBin: Record<string, string> = prependHomeBinToPath(withPersona)
+    const withHomeBin: Record<string, string> = prependHomeBinToPath(withInheritedPath)
     return prependVtBinToPath(withHomeBin, vtBinDir)
 }
 

--- a/packages/systems/vt-daemon/src/agent-runtime/spawn/injection/vtPathInjection.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/spawn/injection/vtPathInjection.ts
@@ -36,6 +36,49 @@ import {delimiter, isAbsolute, join} from 'node:path'
 import os from 'node:os'
 import {getRuntimeEnv} from '@vt/vt-daemon/agent-runtime/runtime/runtime-config.ts'
 
+function uniquePathEntries(entries: readonly string[]): string {
+    const seen: Set<string> = new Set()
+    const result: string[] = []
+    for (const entry of entries) {
+        if (entry.length === 0 || seen.has(entry)) continue
+        seen.add(entry)
+        result.push(entry)
+    }
+    return result.join(delimiter)
+}
+
+export function defaultExecutablePath(platform: string = process.platform): string {
+    if (platform === 'win32') return ''
+    return [
+        '/opt/homebrew/bin',
+        '/usr/local/bin',
+        '/usr/bin',
+        '/bin',
+        '/usr/sbin',
+        '/sbin',
+    ].join(delimiter)
+}
+
+/**
+ * Preserve a usable executable PATH when the user settings do not explicitly
+ * inject one. Without this, the later ~/bin prepend creates PATH from scratch
+ * and generated launch scripts using `#!/usr/bin/env bash` cannot even resolve
+ * bash in packaged macOS app launches.
+ */
+export function inheritExecutablePathIfMissing(
+    envVars: Record<string, string>,
+    inheritedPath: string | undefined,
+    platform: string = process.platform,
+): Record<string, string> {
+    if (envVars.PATH !== undefined && envVars.PATH.length > 0) return envVars
+    const baseline: string = defaultExecutablePath(platform)
+    const pathValue: string = uniquePathEntries([
+        ...((inheritedPath ?? '').split(delimiter)),
+        ...(baseline ? baseline.split(delimiter) : []),
+    ])
+    return pathValue.length > 0 ? {...envVars, PATH: pathValue} : envVars
+}
+
 /**
  * Pure: returns a new env-var map with `vtBinDir` prepended to `PATH`.
  * - If `vtBinDir` is null or empty, returns `envVars` unchanged.

--- a/packages/systems/vt-daemon/src/agent-runtime/spawn/tests/vtPathInjection.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/spawn/tests/vtPathInjection.test.ts
@@ -19,7 +19,13 @@ import path from 'node:path'
 import {afterEach, beforeEach, describe, expect, it} from 'vitest'
 import {configureAgentRuntime} from '@vt/vt-daemon/agent-runtime/runtime/runtime-config.ts'
 import {buildTerminalEnvVars} from '../buildTerminalEnvVars'
-import {prependVtBinToPath, prependHomeBinToPath, resolveVtBinDir} from '../injection/vtPathInjection'
+import {
+    defaultExecutablePath,
+    inheritExecutablePathIfMissing,
+    prependVtBinToPath,
+    prependHomeBinToPath,
+    resolveVtBinDir,
+} from '../injection/vtPathInjection'
 
 describe('prependVtBinToPath (pure)', () => {
     it('passes through unchanged when vtBinDir is null', () => {
@@ -118,18 +124,45 @@ describe('resolveVtBinDir (pure)', () => {
     })
 })
 
+describe('inheritExecutablePathIfMissing (pure)', () => {
+    it('keeps an explicit PATH unchanged', () => {
+        expect(inheritExecutablePathIfMissing({PATH: '/custom/bin'}, '/usr/bin', 'darwin').PATH)
+            .toBe('/custom/bin')
+    })
+
+    it('inherits process PATH and appends the macOS baseline when PATH is absent', () => {
+        const result = inheritExecutablePathIfMissing({OTHER: 'x'}, '/custom/bin:/usr/bin', 'darwin')
+        expect(result.PATH).toContain('/custom/bin')
+        expect(result.PATH).toContain('/opt/homebrew/bin')
+        expect(result.PATH).toContain('/usr/local/bin')
+        expect(result.PATH).toContain('/bin')
+        expect(result.OTHER).toBe('x')
+    })
+
+    it('provides a Unix baseline even when inherited PATH is missing', () => {
+        const result = inheritExecutablePathIfMissing({}, undefined, 'linux')
+        expect(result.PATH).toBe(defaultExecutablePath('linux'))
+        expect(result.PATH).toContain('/usr/bin')
+        expect(result.PATH).toContain('/bin')
+    })
+})
+
 describe('buildTerminalEnvVars — vt-bin PATH injection end-to-end', () => {
     let tempDir: string
+    let originalPath: string | undefined
 
     beforeEach(async () => {
         tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vt-vtbin-spawn-'))
         process.env.VOICETREE_HOME_PATH = tempDir
+        originalPath = process.env.PATH
     })
 
     afterEach(async () => {
         await fs.rm(tempDir, {recursive: true, force: true})
         configureAgentRuntime({})
         delete process.env.VOICETREE_HOME_PATH
+        if (originalPath === undefined) delete process.env.PATH
+        else process.env.PATH = originalPath
     })
 
     it('prepends the configured vt-bin dir onto PATH', async () => {
@@ -192,9 +225,10 @@ describe('buildTerminalEnvVars — vt-bin PATH injection end-to-end', () => {
         expect(envVars.PATH).toContain('/usr/bin')
     })
 
-    it('sets PATH from scratch when no PATH is injected and vt-bin is configured', async () => {
+    it('inherits a usable PATH when no PATH is injected and vt-bin is configured', async () => {
         const vtBinDir: string = path.join(tempDir, 'vt-bin')
         await fs.mkdir(vtBinDir, {recursive: true})
+        process.env.PATH = '/custom/bin'
 
         configureAgentRuntime({
             env: {
@@ -215,10 +249,13 @@ describe('buildTerminalEnvVars — vt-bin PATH injection end-to-end', () => {
             } as never,
         })
 
-        // PATH = vtBinDir : $HOME/bin (or just vtBinDir on Windows)
+        // PATH = vtBinDir : $HOME/bin : inherited PATH : Unix baseline
         if (process.platform !== 'win32') {
             const homeBin: string = path.join(os.homedir(), 'bin')
-            expect(envVars.PATH).toBe(vtBinDir + path.delimiter + homeBin)
+            expect(envVars.PATH.startsWith(vtBinDir + path.delimiter + homeBin + path.delimiter)).toBe(true)
+            expect(envVars.PATH).toContain('/custom/bin')
+            expect(envVars.PATH).toContain('/usr/bin')
+            expect(envVars.PATH).toContain('/bin')
         } else {
             expect(envVars.PATH).toBe(vtBinDir)
         }

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/manager/terminal-manager.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/manager/terminal-manager.ts
@@ -10,7 +10,11 @@ import {
   type HeadlessAgentCleanupPolicy,
   spawnTmuxBackedTerminal,
 } from '@vt/vt-daemon/agent-runtime/headless/headlessAgentManager.ts';
-import {injectAgentCommandHeadful, writePromptFile} from '@vt/vt-daemon/agent-runtime/headless/tmuxPromptFile.ts';
+import {
+  applyPromptFileToInteractiveSpawn,
+  injectAgentCommandHeadful,
+  type PromptFileSpawnPlan,
+} from '@vt/vt-daemon/agent-runtime/headless/tmuxPromptFile.ts';
 import {
   getWindowsShell,
   resolveTerminalCwd,
@@ -18,13 +22,11 @@ import {
   type TerminalManagerDeps,
 } from './terminal-manager-spawn';
 import {
-  buildTmuxEnv,
   resolveHeadfulPromptInjection,
-  resolvePromptFileWrite,
   resolveTmuxProjectPath,
   withResolvedTmuxProjectPath,
+  withVoicetreeProjectPath,
   type HeadfulPromptInjectionRequest,
-  type PromptFileWriteRequest,
 } from '../tmux/tmuxSpawnPlanning';
 import {getRuntimeEnv} from '@vt/vt-daemon/agent-runtime/runtime/runtime-config.ts';
 import type {TerminalSpawnResult} from '@vt/vt-daemon-protocol'
@@ -46,11 +48,6 @@ export interface TerminalSpawnOpts {
 }
 
 export type TerminalCleanupPolicy = HeadlessAgentCleanupPolicy;
-
-function writeResolvedPromptFile(request: PromptFileWriteRequest | null): string | null {
-  if (!request) return null;
-  return writePromptFile(request.projectRoot, request.terminalId, request.prompt);
-}
 
 async function resolveRuntimeProjectRoot(): Promise<string | null> {
   try {
@@ -91,12 +88,9 @@ export class TerminalManager {
   // directly — no PTY is owned by this process.
   //
   // Phase 6 prompt delivery: the agent prompt is written to a disk file
-  // ({project}/.voicetree/terminals/{name}-prompt.txt, mode 0600) at spawn
-  // time as an auxiliary delivery path. After the shell is ready, the agent
-  // command is injected via `tmux send-keys` exactly as configured. The
-  // original AGENT_PROMPT env var is kept so existing
-  // agent commands like `claude "$AGENT_PROMPT"` and custom agents continue to
-  // receive the prompt through their configured interface.
+  // ({project}/.voicetree/terminals/{name}-prompt.txt, mode 0600) and the
+  // injected command is rewritten to consume that file. This keeps large
+  // prompts out of both the tmux command protocol and the shell argv plane.
   // tmux server inherits PATH/HOME/SHELL/USER from the Electron main spawn
   // context; panes inherit from the server.
   async spawnTmuxBacked(opts: TerminalSpawnOpts): Promise<TerminalSpawnResult> {
@@ -108,18 +102,25 @@ export class TerminalManager {
       const cwd: string = await resolveTerminalCwd(terminalData, getToolsDirectory, deps);
       const initial: Record<string, string> = terminalData.initialEnvVars ?? {};
       const projectRoot: string | undefined = resolveTmuxProjectPath(deps.env, initial, await resolveRuntimeProjectRoot());
-      const promptFile: string | null = writeResolvedPromptFile(
-        resolvePromptFileWrite(projectRoot, terminalId, initial.AGENT_PROMPT),
-      );
-      const tmuxEnv: Record<string, string> = buildTmuxEnv(initial, projectRoot, promptFile);
+      const command: string | undefined = terminalData.initialCommand;
+      const promptPlan: PromptFileSpawnPlan = projectRoot && command
+        ? applyPromptFileToInteractiveSpawn({
+            projectRoot,
+            terminalId,
+            command,
+            env: initial,
+          })
+        : {command: command ?? '', env: initial, promptFilePath: null};
+      const tmuxEnv: Record<string, string> = withVoicetreeProjectPath(promptPlan.env, projectRoot);
       const terminalDataWithProjectPath: TerminalData = {
         ...terminalData,
-        initialEnvVars: withResolvedTmuxProjectPath(initial, projectRoot),
+        initialEnvVars: withResolvedTmuxProjectPath(promptPlan.env, projectRoot),
+        initialCommand: command ? promptPlan.command : command,
       };
-      await spawnTmuxBackedTerminal(terminalId, terminalDataWithProjectPath, shell, cwd, tmuxEnv, undefined, promptFile);
+      await spawnTmuxBackedTerminal(terminalId, terminalDataWithProjectPath, shell, cwd, tmuxEnv, undefined, promptPlan.promptFilePath);
       const promptInjection: HeadfulPromptInjectionRequest | null = resolveHeadfulPromptInjection(
         terminalId,
-        terminalData.initialCommand,
+        command ? promptPlan.command : command,
         projectRoot,
       );
       if (promptInjection) {

--- a/packages/systems/vt-daemon/src/agent-runtime/terminals/tests/tmux/tmuxInteractiveSpawnPromptFile.test.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/terminals/tests/tmux/tmuxInteractiveSpawnPromptFile.test.ts
@@ -10,8 +10,8 @@
  *   - tmux session env carries AGENT_PROMPT_FILE pointing at the file
  *   - tmux session env's AGENT_PROMPT is empty (the primitive shadows it
  *     with '' to defeat OS env-inheritance)
- *   - the rewritten initialCommand consumes the file via stdin redirect
- *     (claude/gemini) or $(cat) (codex) rather than expanding $AGENT_PROMPT
+ *   - the rewritten initialCommand consumes the file via $(cat) rather than
+ *     expanding $AGENT_PROMPT or redirecting stdin away from the TTY
  *
  * No mocking. Real tmux underneath.
  */
@@ -23,7 +23,7 @@ import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {afterAll, afterEach, describe, expect, it} from 'vitest'
 import type {NodeIdAndFilePath} from '@vt/graph-model/graph'
-import {applyPromptFileToTmuxSpawn} from '@vt/vt-daemon/agent-runtime/headless/tmuxPromptFile.ts'
+import {applyPromptFileToInteractiveSpawn} from '@vt/vt-daemon/agent-runtime/headless/tmuxPromptFile.ts'
 import {spawnTmuxBackedTerminal} from '@vt/vt-daemon/agent-runtime/headless/headlessAgentManager.ts'
 import {clearTerminalRecords} from '../../terminal-registry'
 import {hasSession, killSession, resolveTmuxSessionName} from '../../tmux/tmux-session-manager'
@@ -122,11 +122,11 @@ describe('interactive tmux spawn with a giant AGENT_PROMPT (prompt-file primitiv
             AGENT_PROMPT_CORE: 'core template body',
             AGENT_PROMPT_LIGHTWEIGHT: 'lightweight template body',
         }
-        const initialCommand: string = 'claude --dangerously-skip-permissions "$AGENT_PROMPT"'
+        const initialCommand: string = 'claude --dangerously-skip-permissions "$AGENT_PROMPT" --disallowedTools AskUserQuestion'
 
         // Mirror what `TerminalManager.spawnTmuxBacked` does in
         // packages/systems/agent-runtime/src/application/terminals/terminal-manager.ts:
-        const plan = applyPromptFileToTmuxSpawn({
+        const plan = applyPromptFileToInteractiveSpawn({
             projectRoot: projectPath,
             terminalId,
             command: initialCommand,
@@ -137,7 +137,7 @@ describe('interactive tmux spawn with a giant AGENT_PROMPT (prompt-file primitiv
         // Sanity on the plan: prompt file path is set, command is CLI-rewritten,
         // big AGENT_PROMPT is gone from the env vector that tmux -e will receive.
         expect(plan.promptFilePath).toBe(join(projectPath, '.voicetree', 'terminals', `${terminalId}-prompt.txt`))
-        expect(plan.command).toBe(`claude --dangerously-skip-permissions < '${plan.promptFilePath}'`)
+        expect(plan.command).toBe(`claude --dangerously-skip-permissions "$(cat '${plan.promptFilePath}')" --disallowedTools AskUserQuestion`)
         expect(tmuxEnv.AGENT_PROMPT).toBe('')
         expect(tmuxEnv.AGENT_PROMPT_FILE).toBe(plan.promptFilePath)
         const envBytes: number = JSON.stringify(tmuxEnv).length

--- a/webapp/src/shell/UI/floating-windows/terminals/TerminalVanilla.ts
+++ b/webapp/src/shell/UI/floating-windows/terminals/TerminalVanilla.ts
@@ -425,16 +425,10 @@ export class TerminalVanilla {
         ? 'tmux reconnecting'
         : `tmux ${status}`;
 
-    // 'closed' is the relay's exit signal — the daemon side only sends
-    // {type:'exit'} when the tmux session is genuinely gone (agent process
-    // exited). Trigger the same close path the traffic-light close button
-    // uses so the floating window, WS subscriber, and tmux registry entry
-    // all tear down in one shot. Without this the renderer keeps the dead
-    // window onscreen and the WS reconnect loop pings forever.
-    if (status === 'closed') {
-      const windowElement: HTMLElement | null = this.container.closest('.cy-floating-window') as HTMLElement | null;
-      windowElement?.dispatchEvent(new CustomEvent('traffic-light-close', {bubbles: true}));
-    }
+    // A relay close means the tmux attach client ended, not necessarily that
+    // the tmux session or agent process exited. Do not route this through the
+    // traffic-light close path: that path kills the session, which can destroy
+    // a newly spawned agent before its launch script has run.
   }
 
 


### PR DESCRIPTION
## Summary
- preserve a usable executable `PATH` for packaged daemon agent spawns so generated launch scripts can resolve `/usr/bin/env bash`, shell-installed tools, and vt shims
- rewrite interactive agent commands to consume prompt files as positional CLI args instead of stdin redirection, preserving trailing flags like `--disallowedTools`
- stop treating terminal relay closure as a user close event; relay close only means the attach client ended, and killing the tmux session there races the launch script

## Verification
- `pnpm exec vitest run packages/systems/vt-daemon/src/agent-runtime/headless/tests/tmuxPromptFile.test.ts packages/systems/vt-daemon/src/agent-runtime/terminals/tests/tmux/tmuxInteractiveSpawnPromptFile.test.ts packages/systems/vt-daemon/src/agent-runtime/spawn/tests/vtPathInjection.test.ts` — 53 passed
- `pnpm exec tsc --noEmit --pretty false -p packages/systems/vt-daemon/tsconfig.json`
- `pnpm --filter voicetree-webapp exec tsc --noEmit --pretty false`
- commit hook tier-0 gates passed
- pre-push tier-1 gates passed: 18/18 checks, including `systems-health` 257/258 pass, 0 fail, 1 skip
- packaged app smoke test in `2026-06-06-argentina-protests`: real daemon RPC spawned a tmux-backed Claude terminal, metadata stayed `running`, tmux session and prompt file stayed present after 30s, Claude UI/output was visible, then explicit close succeeded
