### PR TITLE
Gate task folder nodes behind env flag

### DIFF
--- a/packages/libraries/graph-model/src/pure/graph/graph-operations/tasks/createTaskNode.test.ts
+++ b/packages/libraries/graph-model/src/pure/graph/graph-operations/tasks/createTaskNode.test.ts
@@ -272,7 +272,7 @@ describe('createTaskNode', () => {
   })
 
   describe('node ID generation', () => {
-    it('should create the task node as a folder identity note (<dir>/task_x/task_x.md)', () => {
+    it('should generate a flat task node by default', () => {
       const nodes: Record<NodeIdAndFilePath, GraphNode> = {
         '/project/a.md': createTestNode('/project/a.md', [])
       }
@@ -286,12 +286,10 @@ describe('createTaskNode', () => {
       })
 
       const id: string = (result[0] as UpsertNodeDelta).nodeToUpsert.absoluteFilePathIsID
-      // A folder identity note: the file basename equals its containing folder name.
-      expect(id).toMatch(/^\/project\/(task_[a-z0-9]+)\/\1\.md$/)
+      expect(id).toMatch(/^\/project\/task_[a-z0-9]+\.md$/)
     })
 
-    it('keeps the folder-identity invariant when the folder name collides (varies the folder, not the note)', () => {
-      // Pre-seed the exact folder note id this task would produce, forcing a collision.
+    it('keeps default duplicate task nodes flat when the candidate id collides', () => {
       const graph0: Graph = createGraphFromNodes({'/project/a.md': createTestNode('/project/a.md', [])})
       const firstId: string = (createTaskNode({
         taskDescription: 'Dup task', selectedNodeIds: ['/project/a.md'] as readonly NodeIdAndFilePath[], graph: graph0, writeFolderPath: '/project',
@@ -303,6 +301,44 @@ describe('createTaskNode', () => {
       })
       const secondId: string = (createTaskNode({
         taskDescription: 'Dup task', selectedNodeIds: ['/project/a.md'] as readonly NodeIdAndFilePath[], graph: graph1, writeFolderPath: '/project',
+      })[0] as UpsertNodeDelta).nodeToUpsert.absoluteFilePathIsID
+
+      expect(secondId).not.toBe(firstId)
+      expect(secondId).toMatch(/^\/project\/task_[a-z0-9]+_2\.md$/)
+    })
+
+    it('can create the task node as a folder identity note (<dir>/task_x/task_x.md)', () => {
+      const nodes: Record<NodeIdAndFilePath, GraphNode> = {
+        '/project/a.md': createTestNode('/project/a.md', [])
+      }
+      const graph: Graph = createGraphFromNodes(nodes)
+
+      const result: GraphDelta = createTaskNode({
+        taskDescription: 'Folder task',
+        selectedNodeIds: ['/project/a.md'] as readonly NodeIdAndFilePath[],
+        graph,
+        writeFolderPath: '/project',
+        useTaskFolderNode: true,
+      })
+
+      const id: string = (result[0] as UpsertNodeDelta).nodeToUpsert.absoluteFilePathIsID
+      // A folder identity note: the file basename equals its containing folder name.
+      expect(id).toMatch(/^\/project\/(task_[a-z0-9]+)\/\1\.md$/)
+    })
+
+    it('keeps the folder-identity invariant when the folder name collides (varies the folder, not the note)', () => {
+      // Pre-seed the exact folder note id this task would produce, forcing a collision.
+      const graph0: Graph = createGraphFromNodes({'/project/a.md': createTestNode('/project/a.md', [])})
+      const firstId: string = (createTaskNode({
+        taskDescription: 'Dup task', selectedNodeIds: ['/project/a.md'] as readonly NodeIdAndFilePath[], graph: graph0, writeFolderPath: '/project', useTaskFolderNode: true,
+      })[0] as UpsertNodeDelta).nodeToUpsert.absoluteFilePathIsID
+
+      const graph1: Graph = createGraphFromNodes({
+        '/project/a.md': createTestNode('/project/a.md', []),
+        [firstId]: createTestNode(firstId, []),
+      })
+      const secondId: string = (createTaskNode({
+        taskDescription: 'Dup task', selectedNodeIds: ['/project/a.md'] as readonly NodeIdAndFilePath[], graph: graph1, writeFolderPath: '/project', useTaskFolderNode: true,
       })[0] as UpsertNodeDelta).nodeToUpsert.absoluteFilePathIsID
 
       expect(secondId).not.toBe(firstId)

--- a/packages/libraries/graph-model/src/pure/graph/graph-operations/tasks/createTaskNode.ts
+++ b/packages/libraries/graph-model/src/pure/graph/graph-operations/tasks/createTaskNode.ts
@@ -1,5 +1,5 @@
 import type { Graph, GraphDelta, GraphNode, NodeIdAndFilePath } from '../..'
-import { nodeBasename, parseMarkdownToGraphNode, stableIdSuffix } from '../graphOperationPrimitives'
+import { ensureUniqueNodeId, nodeBasename, parseMarkdownToGraphNode, stableIdSuffix } from '../graphOperationPrimitives'
 import { findMostConnectedNode } from '../indexes/findMostConnectedNode'
 import * as O from 'fp-ts/lib/Option.js'
 
@@ -9,18 +9,17 @@ export interface TaskNodeCreationParams {
   readonly graph: Graph
   readonly writeFolderPath: string
   readonly initialStatus?: string
+  readonly useTaskFolderNode?: boolean
 }
 
 /**
- * A task node is created as a FOLDER identity note (`<dir>/task_<suffix>/task_<suffix>.md`)
- * rather than a flat file, so that the moment an agent is spawned on it the node IS a
- * folder — the agent's progress nodes then nest INSIDE the task folder (via create_graph
- * task-folder routing) instead of cluttering the parent graph. Live-gardening prevention,
- * resolving progress-node co-location by construction.
+ * Optional task-folder node creation (`<dir>/task_<suffix>/task_<suffix>.md`).
+ * When enabled, the task node is already a folder identity note, so an agent's
+ * progress nodes can nest inside the task folder via create_graph task-folder
+ * routing instead of cluttering the parent graph.
  *
- * Uniqueness is enforced on the FOLDER name (not the note basename) to preserve the
- * `<folder>/<folder>.md` identity-note invariant on the rare suffix collision (same task
- * spawned twice into the same folder).
+ * Uniqueness is enforced on the FOLDER name (not the note basename) to preserve
+ * the `<folder>/<folder>.md` identity-note invariant on rare suffix collisions.
  */
 function createTaskFolderNoteId(
   writeFolderPath: string,
@@ -40,6 +39,16 @@ function createTaskFolderNoteId(
   return noteId(`${base}_${n}`)
 }
 
+function createFlatTaskNodeCandidateId(
+  writeFolderPath: string,
+  taskDescription: string,
+  selectedNodeIds: readonly NodeIdAndFilePath[]
+): NodeIdAndFilePath {
+  const separator: string = writeFolderPath.endsWith('/') ? '' : '/'
+  const suffix: string = stableIdSuffix([writeFolderPath, taskDescription, ...selectedNodeIds])
+  return `${writeFolderPath}${separator}task_${suffix}.md`
+}
+
 /**
  * Creates a task node with the user's description and a parent edge to the most-connected
  * node from the selection. Context node references are handled separately.
@@ -48,10 +57,12 @@ function createTaskFolderNoteId(
  * @returns GraphDelta containing the new task node
  */
 export function createTaskNode(params: TaskNodeCreationParams): GraphDelta {
-  const { taskDescription, selectedNodeIds, graph, writeFolderPath, initialStatus } = params
+  const { taskDescription, selectedNodeIds, graph, writeFolderPath, initialStatus, useTaskFolderNode } = params
 
   const existingIds: ReadonlySet<string> = new Set(Object.keys(graph.nodes))
-  const nodeId: NodeIdAndFilePath = createTaskFolderNoteId(writeFolderPath, taskDescription, selectedNodeIds, existingIds)
+  const nodeId: NodeIdAndFilePath = useTaskFolderNode === true
+    ? createTaskFolderNoteId(writeFolderPath, taskDescription, selectedNodeIds, existingIds)
+    : ensureUniqueNodeId(createFlatTaskNodeCandidateId(writeFolderPath, taskDescription, selectedNodeIds), existingIds)
 
   const mostConnectedNodeId: NodeIdAndFilePath = findMostConnectedNode(selectedNodeIds, graph)
   // Use basename-form wikilinks, matching human-authored convention.

--- a/packages/systems/vt-daemon/src/_shared/taskFolderFeatureFlag.ts
+++ b/packages/systems/vt-daemon/src/_shared/taskFolderFeatureFlag.ts
@@ -1,0 +1,6 @@
+export const TASK_FOLDER_NODES_FLAG: 'VT_ENABLE_TASK_FOLDER_NODES' = 'VT_ENABLE_TASK_FOLDER_NODES'
+
+export function taskFolderNodesEnabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+    const raw: string | undefined = env[TASK_FOLDER_NODES_FLAG]
+    return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on'
+}

--- a/packages/systems/vt-daemon/src/agent-runtime/agent-control/tools/spawnAgentTool.ts
+++ b/packages/systems/vt-daemon/src/agent-runtime/agent-control/tools/spawnAgentTool.ts
@@ -11,6 +11,7 @@ import {loadSettings} from '@vt/app-config/settings'
 import type {VTSettings, AgentConfig, ResolvedAgent} from '@vt/graph-model/settings'
 import {flattenAgentTree} from '@vt/graph-model/settings'
 import {type ToolResponse, buildJsonResponse} from '@vt/vt-daemon/_shared/toolResponse.ts'
+import {taskFolderNodesEnabledFromEnv} from '@vt/vt-daemon/_shared/taskFolderFeatureFlag.ts'
 import {startMonitor} from '../agent-completion-monitor.ts'
 import {applyToolGraphDelta, getToolGraph, getToolWriteFolderPath} from '@vt/vt-daemon/config/graphBridge.ts'
 import type {GraphBridge} from '@vt/vt-daemon/config/toolBridges.ts'
@@ -314,7 +315,8 @@ async function spawnAgentForTask(
             selectedNodeIds: [resolvedParentId],
             graph: graphContext.graph,
             writeFolderPath: graphContext.writeFolderPath,
-            initialStatus: 'claimed'
+            initialStatus: 'claimed',
+            useTaskFolderNode: taskFolderNodesEnabledFromEnv(),
         })
         const taskNodeId: NodeIdAndFilePath | undefined = taskNodeIdFromDelta(taskNodeDelta)
         if (!taskNodeId) return errorResponse('Failed to create task node')

--- a/packages/systems/vt-daemon/src/create-graph/createGraphTool.ts
+++ b/packages/systems/vt-daemon/src/create-graph/createGraphTool.ts
@@ -18,6 +18,7 @@ import {getFolderIdentityNoteId, getFolderChildNodeIds, getSubFolderPaths, getFo
 import {findBestMatchingNode} from '@vt/graph-model/markdown'
 import {slugify} from '../_shared/slugify.ts'
 import {type ToolResponse, buildJsonResponse} from '@vt/vt-daemon/_shared/toolResponse.ts'
+import {taskFolderNodesEnabledFromEnv} from '@vt/vt-daemon/_shared/taskFolderFeatureFlag.ts'
 import {loadSettings} from '@vt/app-config/settings'
 import type {VTSettings} from '@vt/graph-model/settings'
 import {DEFAULT_SUBGRAPH_LIMITS} from '@vt/graph-model/settings'
@@ -174,12 +175,12 @@ export function worktreeFolderNoteInput(
 }
 
 /**
- * Live-gardening task-folder routing. An agent anchored to a task node that is a
- * folder identity note (every task node is created as one — see createTaskNode)
- * files its progress nodes INTO that folder by default, so they nest under the task
- * instead of cluttering the parent graph, and the folder is then subject to the
- * `folder_child_count_limit` cap. Returns the absolute task folder to use as the
- * effective outputPath, or null when task routing does not apply.
+ * Live-gardening task-folder routing. When the task-folder feature flag is enabled,
+ * an agent anchored to a task node that is a folder identity note files its progress
+ * nodes INTO that folder by default, so they nest under the task instead of cluttering
+ * the parent graph, and the folder is then subject to the `folder_child_count_limit`
+ * cap. Returns the absolute task folder to use as the effective outputPath, or null
+ * when task routing does not apply.
  *
  * Precedence: an explicit outputPath (deliberate placement) and worktree routing
  * both win. A plain (non-folder) anchored node is left untouched — converting an
@@ -190,7 +191,9 @@ export function resolveTaskFolderOutputPath(
     explicitOutputPath: string | undefined,
     worktreeRouting: WorktreeRouting,
     anchoredToNodeId: NodeIdAndFilePath | null,
+    enabled: boolean = taskFolderNodesEnabledFromEnv(),
 ): string | null {
+    if (!enabled) return null
     const hasExplicit: boolean = !!explicitOutputPath && explicitOutputPath.trim() !== ''
     if (hasExplicit || worktreeRouting.active || anchoredToNodeId === null) return null
     if (!isFolderIdentityNote(anchoredToNodeId)) return null
@@ -400,8 +403,8 @@ export async function createGraphTool(
     const worktreeRouting: WorktreeRouting = resolveWorktreeRouting(outputPath, callerRecord.terminalData.worktreeName)
     const anchoredToNodeId: NodeIdAndFilePath | null =
         O.isSome(callerRecord.terminalData.anchoredToNodeId) ? callerRecord.terminalData.anchoredToNodeId.value : null
-    // Task-folder routing wins over worktree routing: an agent's progress nests inside
-    // its own task folder; both yield to an explicit outputPath.
+    // Worktree routing and explicit outputPath keep deliberate placement ahead of
+    // optional task-folder nesting.
     const taskFolderOutputPath: string | null = resolveTaskFolderOutputPath(outputPath, worktreeRouting, anchoredToNodeId)
     const effectiveOutputPath: string | undefined = taskFolderOutputPath ?? worktreeRouting.outputPath
     const outputDirectoryResult: Result<string> = await resolveConfiguredOutputDirectory(effectiveOutputPath, bridge)

--- a/packages/systems/vt-daemon/src/create-graph/worktreeAutoFolder.test.ts
+++ b/packages/systems/vt-daemon/src/create-graph/worktreeAutoFolder.test.ts
@@ -78,26 +78,31 @@ describe('worktreeFolderNoteInput', () => {
 describe('resolveTaskFolderOutputPath (live-gardening task-folder routing)', () => {
     const inactiveWorktree: WorktreeRouting = {outputPath: undefined, active: false, worktreeName: null}
 
-    it('routes into the task folder when anchored to a folder task node (no outputPath / worktree)', () => {
+    it('does not route into the task folder when task folder nodes are disabled', () => {
         const taskNote: NodeIdAndFilePath = '/proj/sub/task_abc/task_abc.md'
-        expect(resolveTaskFolderOutputPath(undefined, inactiveWorktree, taskNote)).toBe('/proj/sub/task_abc/')
+        expect(resolveTaskFolderOutputPath(undefined, inactiveWorktree, taskNote, false)).toBeNull()
+    })
+
+    it('routes into the task folder when enabled and anchored to a folder task node (no outputPath / worktree)', () => {
+        const taskNote: NodeIdAndFilePath = '/proj/sub/task_abc/task_abc.md'
+        expect(resolveTaskFolderOutputPath(undefined, inactiveWorktree, taskNote, true)).toBe('/proj/sub/task_abc/')
     })
 
     it('does not route when anchored to a plain (non-folder) node', () => {
-        expect(resolveTaskFolderOutputPath(undefined, inactiveWorktree, '/proj/sub/plain.md')).toBeNull()
+        expect(resolveTaskFolderOutputPath(undefined, inactiveWorktree, '/proj/sub/plain.md', true)).toBeNull()
     })
 
     it('does not route when there is no anchored node', () => {
-        expect(resolveTaskFolderOutputPath(undefined, inactiveWorktree, null)).toBeNull()
+        expect(resolveTaskFolderOutputPath(undefined, inactiveWorktree, null, true)).toBeNull()
     })
 
     it('yields to an explicit outputPath (deliberate placement wins)', () => {
-        expect(resolveTaskFolderOutputPath('some/dir', inactiveWorktree, '/proj/task_x/task_x.md')).toBeNull()
+        expect(resolveTaskFolderOutputPath('some/dir', inactiveWorktree, '/proj/task_x/task_x.md', true)).toBeNull()
     })
 
     it('yields to active worktree routing', () => {
         const activeWorktree: WorktreeRouting = {outputPath: 'wt-x', active: true, worktreeName: 'wt-x'}
-        expect(resolveTaskFolderOutputPath(undefined, activeWorktree, '/proj/task_x/task_x.md')).toBeNull()
+        expect(resolveTaskFolderOutputPath(undefined, activeWorktree, '/proj/task_x/task_x.md', true)).toBeNull()
     })
 })
 

--- a/webapp/src/shell/agent/orchestrateRunAgent.test.ts
+++ b/webapp/src/shell/agent/orchestrateRunAgent.test.ts
@@ -56,6 +56,21 @@ describe('runAgentOnSelectedNodes (shared orchestrator)', () => {
         expect(result.contextNodeId).toBe('ctx.md')
     })
 
+    it('uses a task folder node when the injected feature flag is enabled', async () => {
+        const rec: Recorder = {appliedDeltas: [], spawnRequests: []}
+        const selectedNodeIds = ['/proj/a.md'] as NodeIdAndFilePath[]
+
+        await orchestrateRunAgentOnSelectedNodes(
+            {selectedNodeIds, taskDescription: 'folder task'},
+            {...recordingEffects(rec, O.some('/proj')), isTaskFolderNodeEnabled: () => true},
+        )
+
+        const head = rec.appliedDeltas[0][0]
+        expect(head.type).toBe('UpsertNode')
+        const taskNodeId = head.type === 'UpsertNode' ? head.nodeToUpsert.absoluteFilePathIsID : ''
+        expect(taskNodeId).toMatch(/^\/proj\/(task_[a-z0-9]+)\/\1\.md$/)
+    })
+
     it('spawns only AFTER the delta is applied (task node must exist first)', async () => {
         const order: string[] = []
         const selectedNodeIds = ['/proj/a.md'] as NodeIdAndFilePath[]

--- a/webapp/src/shell/agent/orchestrateRunAgent.ts
+++ b/webapp/src/shell/agent/orchestrateRunAgent.ts
@@ -48,6 +48,7 @@ export interface RunAgentEffects {
     readonly getWriteFolderPath: () => Promise<O.Option<string>>
     readonly applyTaskNodeDelta: (delta: GraphDelta) => Promise<unknown>
     readonly spawnAgentTerminal: (req: SpawnAgentTerminalRequest) => Promise<SpawnAgentTerminalResult>
+    readonly isTaskFolderNodeEnabled?: () => boolean
 }
 
 export async function orchestrateRunAgentOnSelectedNodes(
@@ -65,7 +66,13 @@ export async function orchestrateRunAgentOnSelectedNodes(
 
     // createTaskNode places the node via layout (position: O.none); the click
     // position is intentionally not threaded here.
-    const taskNodeDelta: GraphDelta = createTaskNode({taskDescription, selectedNodeIds, graph, writeFolderPath})
+    const taskNodeDelta: GraphDelta = createTaskNode({
+        taskDescription,
+        selectedNodeIds,
+        graph,
+        writeFolderPath,
+        useTaskFolderNode: effects.isTaskFolderNodeEnabled?.() === true,
+    })
 
     const head = taskNodeDelta[0]
     const taskNodeId: NodeIdAndFilePath =

--- a/webapp/src/shell/edge/main/agent/runAgentOnSelectedNodes.ts
+++ b/webapp/src/shell/edge/main/agent/runAgentOnSelectedNodes.ts
@@ -16,6 +16,13 @@ import {spawnTerminalWithContextNode} from '@vt/vt-daemon-client'
 import {getVtDaemonClient} from '@/shell/edge/main/runtime/electron/daemon/daemon-url-binding'
 import {getGraphFromDaemon, postDeltaThroughDaemonWithEditors} from '@/shell/edge/main/runtime/electron/daemon/ipc/daemon-ipc-proxy'
 
+const TASK_FOLDER_NODES_FLAG: 'VT_ENABLE_TASK_FOLDER_NODES' = 'VT_ENABLE_TASK_FOLDER_NODES'
+
+function isTaskFolderNodeEnabled(): boolean {
+    const raw: string | undefined = process.env[TASK_FOLDER_NODES_FLAG]
+    return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on'
+}
+
 export function runAgentOnSelectedNodes(
     params: RunAgentOnSelectedParams,
 ): Promise<RunAgentOnSelectedResult> {
@@ -24,5 +31,6 @@ export function runAgentOnSelectedNodes(
         getWriteFolderPath,
         applyTaskNodeDelta: postDeltaThroughDaemonWithEditors,
         spawnAgentTerminal: (req) => spawnTerminalWithContextNode(getVtDaemonClient(), req),
+        isTaskFolderNodeEnabled,
     })
 }


### PR DESCRIPTION
## Summary
- restores flat task_<id>.md task nodes by default
- keeps folder-identity task nodes and task-folder progress routing available behind VT_ENABLE_TASK_FOLDER_NODES
- wires the flag through daemon spawn, create_graph routing, and Electron run-agent orchestration

## Verification
- VT_REMOTE_EXEC=1 pnpm exec vitest run packages/libraries/graph-model/src/pure/graph/graph-operations/tasks/createTaskNode.test.ts
- VT_REMOTE_EXEC=1 pnpm exec vitest run packages/systems/vt-daemon/src/create-graph/worktreeAutoFolder.test.ts
- VT_REMOTE_EXEC=1 pnpm exec vitest run webapp/src/shell/agent/orchestrateRunAgent.test.ts
- pnpm --filter @vt/vt-daemon run typecheck
- pnpm --filter voicetree-webapp run check
- git diff --check
- gitleaks git --staged --redact --no-banner -l error --config .gitleaks.toml
- VT_REMOTE_EXEC=1 npm run test:t0:local
- VT_REMOTE_EXEC=1 node scripts/run-remote.mjs pnpm --filter @vt/measures run health:subgraph-gate

## Known local check note
- VT_REMOTE_EXEC=1 npm run test:local passed all non-E2E tier-1 checks but failed local e2e-tier1: Electron stayed on project selection and did not auto-load --open-folder before Cytoscape initialization timeout. This appears before the task-node/spawn code path changed here; CI should provide a cleaner signal.
